### PR TITLE
feat(action): Add sane defaults for failOn and commentOn

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
   fail-on:
     description: 'Minimum severity level to fail the action (critical, high, medium, low, info)'
     required: false
+    default: 'high'
+  comment-on:
+    description: 'Minimum severity level to show annotations in code review (critical, high, medium, low, info)'
+    required: false
+    default: 'medium'
   max-findings:
     description: 'Maximum number of findings to report (0 for unlimited)'
     required: false
@@ -75,6 +80,7 @@ runs:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_CONFIG_PATH: ${{ inputs.config-path }}
         INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_COMMENT_ON: ${{ inputs.comment-on }}
         INPUT_MAX_FINDINGS: ${{ inputs.max-findings }}
         INPUT_PARALLEL: ${{ inputs.parallel }}
         CLAUDE_CODE_PATH: ${{ env.HOME }}/.local/bin/claude

--- a/warden.toml
+++ b/warden.toml
@@ -1,5 +1,11 @@
 version = 1
 
+[defaults.output]
+# Fail check on high+ severity findings (critical, high)
+failOn = "high"
+# Show annotations for medium+ severity findings
+commentOn = "medium"
+
 [[triggers]]
 name = "security-review"
 event = "pull_request"


### PR DESCRIPTION
## Summary

- Add default `fail-on: 'high'` so checks fail on critical/high severity findings out of the box
- Add new `comment-on` input with default `'medium'` to control annotation visibility
- Wire up `commentOn` input in action code with proper fallback from trigger config → action input
- Update repo's `warden.toml` with explicit defaults section for documentation

## Test plan

- [ ] Verify action builds successfully
- [ ] Test with a PR that has high severity findings → check should fail
- [ ] Test with a PR that has only medium/low findings → check should pass (neutral)
- [ ] Verify annotations appear for medium+ severity findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)