### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,5 +1,8 @@
 name: Warden
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/getsentry/warden/security/code-scanning/3](https://github.com/getsentry/warden/security/code-scanning/3)

In general, the fix is to explicitly declare least‑privilege `permissions` for the workflow or job so that `GITHUB_TOKEN` is restricted instead of inheriting broad defaults. For this workflow, we only need read access to repository contents (for checkout and reading metadata), because any write operations (comments, status updates, labels, etc.) should use the GitHub App token already being created.

The best minimal fix is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) with `contents: read`. This applies to all jobs, including `review`, and does not change functional behavior other than limiting the inherited `GITHUB_TOKEN` capabilities. No additional imports or methods are needed, only a YAML edit in `.github/workflows/warden.yml` near the top of the file. If later you discover that some step truly requires more scopes on `GITHUB_TOKEN`, you can selectively add them, but the safe default is `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
