### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/getsentry/warden/security/code-scanning/2](https://github.com/getsentry/warden/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required for this workflow. For a CI job that only checks out code, installs dependencies, and runs build/test steps, `contents: read` is typically sufficient. This can be specified either at the top level of the workflow (applied to all jobs) or within the specific job. Since there is only one job (`build`), either approach works; adding it at the root is simplest and clear.

The best minimal fix without changing existing behavior is to add a workflow-level `permissions` block just below the workflow `name:` (or anywhere at the root level), setting `contents: read`. None of the steps need write access: `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` all function with read-only repository contents. No additional imports or dependencies are needed; this is purely a YAML configuration change within `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: CI`) and before the `on:` block (line 3).  
This will constrain the `GITHUB_TOKEN` for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
