### PR TITLE
feat(output): Add link to full report when findings are filtered

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -489,6 +489,7 @@ async function run(): Promise<void> {
 
     // Create skill check (only for PRs)
     let skillCheckId: number | undefined;
+    let skillCheckUrl: string | undefined;
     if (context.pullRequest) {
       try {
         const skillCheck = await createSkillCheck(octokit, trigger.skill, {
@@ -497,6 +498,7 @@ async function run(): Promise<void> {
           headSha: context.pullRequest.headSha,
         });
         skillCheckId = skillCheck.checkRunId;
+        skillCheckUrl = skillCheck.url;
       } catch (error) {
         console.error(`::warning::Failed to create skill check for ${trigger.skill}: ${error}`);
       }
@@ -536,6 +538,8 @@ async function run(): Promise<void> {
           ? renderSkillReport(report, {
               maxFindings: trigger.output.maxFindings ?? inputs.maxFindings,
               commentOn,
+              checkRunUrl: skillCheckUrl,
+              totalFindings: report.findings.length,
             })
           : undefined;
 

--- a/src/output/renderer.test.ts
+++ b/src/output/renderer.test.ts
@@ -553,4 +553,145 @@ describe('renderSkillReport', () => {
       expect(result.summaryComment).not.toContain('<sub>');
     });
   });
+
+  describe('check run link', () => {
+    it('shows link to full report when findings are filtered out', () => {
+      const report: SkillReport = {
+        ...baseReport,
+        findings: [
+          {
+            id: 'f1',
+            severity: 'high',
+            title: 'High Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 10 },
+          },
+          {
+            id: 'f2',
+            severity: 'low',
+            title: 'Low Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 20 },
+          },
+          {
+            id: 'f3',
+            severity: 'info',
+            title: 'Info Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 30 },
+          },
+        ],
+      };
+
+      const result = renderSkillReport(report, {
+        commentOn: 'high',
+        checkRunUrl: 'https://github.com/owner/repo/runs/123',
+        totalFindings: 3,
+      });
+
+      expect(result.summaryComment).toContain('View 2 additional findings in Checks');
+      expect(result.summaryComment).toContain('https://github.com/owner/repo/runs/123');
+    });
+
+    it('shows singular "finding" when only one is hidden', () => {
+      const report: SkillReport = {
+        ...baseReport,
+        findings: [
+          {
+            id: 'f1',
+            severity: 'high',
+            title: 'High Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 10 },
+          },
+          {
+            id: 'f2',
+            severity: 'low',
+            title: 'Low Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 20 },
+          },
+        ],
+      };
+
+      const result = renderSkillReport(report, {
+        commentOn: 'high',
+        checkRunUrl: 'https://github.com/owner/repo/runs/123',
+        totalFindings: 2,
+      });
+
+      expect(result.summaryComment).toContain('View 1 additional finding in Checks');
+    });
+
+    it('shows link when all findings filtered out', () => {
+      const report: SkillReport = {
+        ...baseReport,
+        findings: [
+          {
+            id: 'f1',
+            severity: 'low',
+            title: 'Low Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 10 },
+          },
+        ],
+      };
+
+      const result = renderSkillReport(report, {
+        commentOn: 'high',
+        checkRunUrl: 'https://github.com/owner/repo/runs/123',
+        totalFindings: 1,
+      });
+
+      expect(result.summaryComment).toContain('No findings to report');
+      expect(result.summaryComment).toContain('View 1 additional finding in Checks');
+    });
+
+    it('does not show link when no checkRunUrl provided', () => {
+      const report: SkillReport = {
+        ...baseReport,
+        findings: [
+          {
+            id: 'f1',
+            severity: 'high',
+            title: 'High Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 10 },
+          },
+        ],
+      };
+
+      const result = renderSkillReport(report, {
+        commentOn: 'high',
+        totalFindings: 3,
+      });
+
+      expect(result.summaryComment).not.toContain('View');
+      expect(result.summaryComment).not.toContain('additional finding');
+    });
+
+    it('does not show link when no findings are hidden', () => {
+      const report: SkillReport = {
+        ...baseReport,
+        findings: [
+          {
+            id: 'f1',
+            severity: 'high',
+            title: 'High Issue',
+            description: 'Details',
+            location: { path: 'src/a.ts', startLine: 10 },
+          },
+        ],
+      };
+
+      const result = renderSkillReport(report, {
+        commentOn: 'high',
+        checkRunUrl: 'https://github.com/owner/repo/runs/123',
+        totalFindings: 1,
+      });
+
+      expect(result.summaryComment).not.toContain('View');
+      expect(result.summaryComment).not.toContain('additional finding');
+    });
+  });
 });

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -27,4 +27,8 @@ export interface RenderOptions {
   extraLabels?: string[];
   /** Only include findings at or above this severity level in rendered output. Use 'off' to disable comments. */
   commentOn?: SeverityThreshold;
+  /** URL to the GitHub Check run containing the full report (used when findings are filtered) */
+  checkRunUrl?: string;
+  /** Total number of findings before filtering (used to show "X more findings" link) */
+  totalFindings?: number;
 }


### PR DESCRIPTION
When the `commentOn` threshold filters findings from PR comments (e.g., showing only high+ severity), users had no way to see the full list of findings including medium, low, and info severity issues. The full report was available in the GitHub Check run but there was no link to access it.

This adds a "View X additional findings in Checks" link to the PR comment summary when findings are hidden by the commentOn filter. The link takes users directly to the Check run where they can see all findings.

Implementation:
- Added `checkRunUrl` and `totalFindings` options to `RenderOptions` 
- Captures the skill check URL when creating the check run
- Displays the link in the summary comment when `hiddenCount > 0`
- Uses existing `pluralize` helper for proper grammar

Fixes #21