### PR TITLE
feat(cli): Auto-save run logs to ~/.local/warden/runs

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,6 +20,7 @@ import {
   runSkillTasks,
   pluralize,
   writeJsonlReport,
+  getRunLogPath,
   type SkillTaskOptions,
 } from './output/index.js';
 import {
@@ -166,6 +167,11 @@ async function runSkills(
     writeJsonlReport(options.output, reports, totalDuration);
     reporter.success(`Wrote JSONL output to ${options.output}`);
   }
+
+  // Always write automatic run log for debugging
+  const runLogPath = getRunLogPath(cwd);
+  writeJsonlReport(runLogPath, reports, totalDuration);
+  reporter.debug(`Run log: ${runLogPath}`);
 
   // Output results
   reporter.blank();
@@ -465,6 +471,11 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
     writeJsonlReport(options.output, reports, totalDuration);
     reporter.success(`Wrote JSONL output to ${options.output}`);
   }
+
+  // Always write automatic run log for debugging
+  const runLogPath = getRunLogPath(repoPath);
+  writeJsonlReport(runLogPath, reports, totalDuration);
+  reporter.debug(`Run log: ${runLogPath}`);
 
   // Output results
   reporter.blank();

--- a/src/cli/output/index.ts
+++ b/src/cli/output/index.ts
@@ -29,4 +29,10 @@ export {
   type RunTasksOptions,
 } from './tasks.js';
 export { BoxRenderer, type BoxOptions } from './box.js';
-export { writeJsonlReport, type JsonlRecord, type JsonlRunMetadata } from './jsonl.js';
+export {
+  writeJsonlReport,
+  getRunLogsDir,
+  getRunLogPath,
+  type JsonlRecord,
+  type JsonlRunMetadata,
+} from './jsonl.js';

--- a/src/cli/output/jsonl.ts
+++ b/src/cli/output/jsonl.ts
@@ -1,7 +1,38 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
 import type { SkillReport, UsageStats } from '../../types/index.js';
 import { countBySeverity } from './formatters.js';
+
+/**
+ * Get the default run logs directory.
+ * Uses WARDEN_STATE_DIR env var if set, otherwise ~/.local/warden/runs
+ */
+export function getRunLogsDir(): string {
+  const stateDir = process.env['WARDEN_STATE_DIR'];
+  if (stateDir) {
+    return join(stateDir, 'runs');
+  }
+  return join(homedir(), '.local', 'warden', 'runs');
+}
+
+/**
+ * Generate a run log filename from directory name and timestamp.
+ * Format: {dirname}_{timestamp}.jsonl
+ * Timestamp has colons replaced with hyphens for filesystem compatibility.
+ */
+export function generateRunLogFilename(cwd: string, timestamp: Date = new Date()): string {
+  const dirName = basename(cwd) || 'unknown';
+  const ts = timestamp.toISOString().replace(/:/g, '-');
+  return `${dirName}_${ts}.jsonl`;
+}
+
+/**
+ * Get the full path for an automatic run log.
+ */
+export function getRunLogPath(cwd: string, timestamp: Date = new Date()): string {
+  return join(getRunLogsDir(), generateRunLogFilename(cwd, timestamp));
+}
 
 /**
  * Metadata for a JSONL run record.


### PR DESCRIPTION
Every warden run now automatically saves a JSONL log to a central location for debugging and auditing purposes. Files are named {dirname}_{timestamp}.jsonl for easy identification.

The default location is ~/.local/warden/runs/, which can be overridden via WARDEN_STATE_DIR environment variable. The run log path is shown in verbose mode (-v).