### PR TITLE
feat(config): Add configurable maxTurns with default of 50

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -318,6 +318,7 @@ async function runScheduledAnalysis(
       const report = await runSkill(skill, context, {
         apiKey: inputs.anthropicApiKey,
         model: resolved.model,
+        maxTurns: trigger.maxTurns ?? config.defaults?.maxTurns,
         pathToClaudeCodeExecutable: claudePath,
       });
       console.log(`Found ${report.findings.length} findings`);
@@ -518,6 +519,7 @@ async function run(): Promise<void> {
       const report = await runSkill(skill, context, {
         apiKey: inputs.anthropicApiKey,
         model: trigger.model,
+        maxTurns: trigger.maxTurns ?? config.defaults?.maxTurns,
         pathToClaudeCodeExecutable: claudePath,
       });
       console.log(`Found ${report.findings.length} findings`);

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { resolveTrigger } from './loader.js';
-import type { Trigger, WardenConfig } from './schema.js';
+import { WardenConfigSchema, type Trigger, type WardenConfig } from './schema.js';
 
 describe('resolveTrigger', () => {
   const baseTrigger: Trigger = {
@@ -192,5 +192,66 @@ describe('resolveTrigger', () => {
 
       expect(resolved.model).toBe('claude-haiku-3-5-20241022');
     });
+  });
+});
+
+describe('maxTurns config', () => {
+  it('accepts maxTurns in defaults', () => {
+    const config = {
+      version: 1,
+      defaults: {
+        maxTurns: 25,
+      },
+      triggers: [],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.defaults?.maxTurns).toBe(25);
+  });
+
+  it('accepts maxTurns in trigger', () => {
+    const config = {
+      version: 1,
+      triggers: [
+        {
+          name: 'test',
+          event: 'pull_request',
+          actions: ['opened'],
+          skill: 'security-review',
+          maxTurns: 30,
+        },
+      ],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.triggers[0]?.maxTurns).toBe(30);
+  });
+
+  it('rejects non-positive maxTurns', () => {
+    const config = {
+      version: 1,
+      defaults: {
+        maxTurns: 0,
+      },
+      triggers: [],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer maxTurns', () => {
+    const config = {
+      version: 1,
+      defaults: {
+        maxTurns: 10.5,
+      },
+      triggers: [],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -72,6 +72,8 @@ export const TriggerSchema = z.object({
   output: OutputConfigSchema.optional(),
   /** Model to use for this trigger (e.g., 'claude-sonnet-4-20250514'). Uses SDK default if not specified. */
   model: z.string().optional(),
+  /** Maximum agentic turns (API round-trips) per hunk analysis. Overrides defaults.maxTurns. */
+  maxTurns: z.number().int().positive().optional(),
   /** Schedule-specific configuration. Only used when event is 'schedule'. */
   schedule: ScheduleConfigSchema.optional(),
 }).refine(
@@ -114,6 +116,8 @@ export const DefaultsSchema = z.object({
   output: OutputConfigSchema.optional(),
   /** Default model for all triggers (e.g., 'claude-sonnet-4-20250514') */
   model: z.string().optional(),
+  /** Maximum agentic turns (API round-trips) per hunk analysis. Default: 50 */
+  maxTurns: z.number().int().positive().optional(),
 });
 export type Defaults = z.infer<typeof DefaultsSchema>;
 

--- a/src/sdk/runner.ts
+++ b/src/sdk/runner.ts
@@ -236,7 +236,7 @@ async function analyzeHunk(
   repoPath: string,
   options: SkillRunnerOptions
 ): Promise<HunkAnalysisResult> {
-  const { maxTurns = 5, model, abortController, pathToClaudeCodeExecutable } = options;
+  const { maxTurns = 50, model, abortController, pathToClaudeCodeExecutable } = options;
 
   const systemPrompt = buildHunkSystemPrompt(skill);
   const userPrompt = buildHunkUserPrompt(hunkCtx);


### PR DESCRIPTION
## Summary
- Add `maxTurns` config option to `warden.toml` at both defaults and per-trigger levels
- Increase default from 5 to 50 to prevent `error_max_turns` during thorough analysis
- Precedence: `trigger.maxTurns` > `defaults.maxTurns` > hardcoded default (50)

## Example

```toml
version = 1

[defaults]
maxTurns = 30

[[triggers]]
name = "thorough-review"
event = "pull_request"
actions = ["opened"]
skill = "security-review"
maxTurns = 100  # override for this trigger
```

## Test plan
- [x] Added schema validation tests for maxTurns
- [x] All existing tests pass