### PR TITLE
feat(cli): Show severity label next to dot in TUI

### DIFF
--- a/src/cli/output/formatters.test.ts
+++ b/src/cli/output/formatters.test.ts
@@ -7,6 +7,7 @@ import {
   truncate,
   padRight,
   formatStatsCompact,
+  formatSeverityBadge,
 } from './formatters.js';
 import type { Severity, UsageStats } from '../../types/index.js';
 
@@ -77,6 +78,16 @@ describe('formatFindingCountsPlain', () => {
       info: 1,
     };
     expect(formatFindingCountsPlain(counts)).toBe('7 findings (1 critical, 2 high, 3 medium, 1 info)');
+  });
+});
+
+describe('formatSeverityBadge', () => {
+  it('includes severity text for each level', () => {
+    expect(formatSeverityBadge('critical')).toContain('critical');
+    expect(formatSeverityBadge('high')).toContain('high');
+    expect(formatSeverityBadge('medium')).toContain('medium');
+    expect(formatSeverityBadge('low')).toContain('low');
+    expect(formatSeverityBadge('info')).toContain('info');
   });
 });
 

--- a/src/cli/output/formatters.ts
+++ b/src/cli/output/formatters.ts
@@ -54,10 +54,11 @@ export function formatSeverityDot(severity: Severity): string {
 }
 
 /**
- * Format a severity badge for terminal output (colored dot).
+ * Format a severity badge for terminal output (colored dot + severity text).
  */
 export function formatSeverityBadge(severity: Severity): string {
-  return formatSeverityDot(severity);
+  const config = SEVERITY_CONFIG[severity];
+  return `${config.color(config.symbol)} ${config.color(`(${severity})`)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Display severity level (critical, high, medium, low, info) in parentheses next to the colored dot for each finding in the interactive TUI
- Makes it easier to identify issue severity at a glance without relying only on color

## Test plan
- [x] Added test for `formatSeverityBadge` covering all severity levels
- [x] All existing tests pass