### PR TITLE
fix(cli): Load .env files from repo root in file mode

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -235,8 +235,16 @@ async function runSkills(
 async function runFileMode(filePatterns: string[], options: CLIOptions, reporter: Reporter): Promise<number> {
   const cwd = process.cwd();
 
+  // Try to find repo root for env loading, fall back to cwd
+  let envDir = cwd;
+  try {
+    envDir = getRepoRoot(cwd);
+  } catch {
+    // Not in a git repo - use cwd
+  }
+
   // Load environment variables from .env files if they exist
-  loadEnvFiles(cwd);
+  loadEnvFiles(envDir);
 
   // Build context from files
   reporter.step('Building context from files...');


### PR DESCRIPTION
## Summary
- File mode was loading `.env`/`.env.local` from cwd instead of repo root
- This caused env vars (like `WARDEN_ANTHROPIC_API_KEY`) to not be found when running warden from a subdirectory
- Now consistent with git ref mode, config mode, and direct skill mode

## Test plan
- [ ] Run `warden src/**/*.ts --skill <name>` from a subdirectory with `.env.local` at repo root
- [ ] Verify API key is loaded correctly