### PR TITLE
Add warden-skill for local CLI usage guidance

### DIFF
--- a/warden-skill/SKILL.md
+++ b/warden-skill/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: warden-skill
+description: Guide for using Warden CLI locally to analyze code changes. Use when running warden commands, configuring warden.toml, creating custom skills, understanding triggers, or troubleshooting analysis issues. Triggers on "run warden", "warden config", "warden.toml", "create warden skill", "add trigger", or any Warden-related local development task.
+---
+
+# Warden Usage
+
+Warden is an event-driven AI agent that analyzes code changes and executes configurable skills to produce structured reports with findings.
+
+## Quick Start
+
+```bash
+# Set API key
+export WARDEN_ANTHROPIC_API_KEY=sk-ant-...
+
+# Analyze uncommitted changes (uses warden.toml triggers)
+warden
+
+# Run specific skill on uncommitted changes
+warden --skill find-bugs
+
+# Analyze specific files
+warden src/auth.ts src/database.ts
+
+# Analyze changes from git ref
+warden main..HEAD
+warden HEAD~3
+```
+
+## CLI Reference
+
+```
+warden [command] [targets...] [options]
+```
+
+**Commands:**
+- `(default)` - Run analysis
+- `init` - Initialize warden.toml and GitHub workflow
+- `add <skill>` - Add skill trigger to warden.toml
+- `setup-app` - Create GitHub App via manifest flow
+
+**Targets:**
+- `<files>` - Specific files (e.g., `src/auth.ts`)
+- `<glob>` - Pattern match (e.g., `src/**/*.ts`)
+- `<git-ref>` - Git range (e.g., `main..HEAD`, `HEAD~3`)
+- `(none)` - Uncommitted changes
+
+**Key Options:**
+| Option | Description |
+|--------|-------------|
+| `--skill <name>` | Run only this skill |
+| `--config <path>` | Path to warden.toml (default: ./warden.toml) |
+| `-m, --model <model>` | Model to use |
+| `--json` | Output as JSON |
+| `-o, --output <path>` | Write output to JSONL file |
+| `--fail-on <severity>` | Exit 1 if findings >= severity |
+| `--comment-on <severity>` | Show findings >= severity |
+| `--fix` | Auto-apply suggested fixes |
+| `--parallel <n>` | Concurrent executions (default: 4) |
+| `-q, --quiet` | Errors and summary only |
+| `-v, --verbose` | Show real-time findings |
+| `-vv` | Debug info (tokens, latency) |
+
+**Severity levels:** `critical`, `high`, `medium`, `low`, `info`, `off`
+
+## Configuration (warden.toml)
+
+See [references/config-schema.md](references/config-schema.md) for complete schema.
+
+**Minimal example:**
+
+```toml
+version = 1
+
+[defaults]
+model = "claude-sonnet-4-20250514"
+
+[[triggers]]
+name = "find-bugs"
+event = "pull_request"
+actions = ["opened", "synchronize"]
+skill = "find-bugs"
+
+[triggers.filters]
+paths = ["src/**/*.ts"]
+```
+
+**With custom output thresholds:**
+
+```toml
+[[triggers]]
+name = "security-strict"
+event = "pull_request"
+actions = ["opened", "synchronize"]
+skill = "security-review"
+
+[triggers.filters]
+paths = ["src/auth/**", "src/payments/**"]
+
+[triggers.output]
+failOn = "critical"
+commentOn = "high"
+maxFindings = 20
+```
+
+## Creating Custom Skills
+
+Skills live in `.warden/skills/`, `.agents/skills/`, or `.claude/skills/`.
+
+**Structure:**
+```
+.warden/skills/my-skill/
+└── SKILL.md
+```
+
+**SKILL.md format:**
+
+```markdown
+---
+name: my-skill
+description: What this skill analyzes
+allowed-tools: Read Grep Glob
+---
+
+[Analysis instructions for the agent]
+
+## What to Look For
+- Specific issue type 1
+- Specific issue type 2
+
+## Output Format
+Report findings with severity, location, and suggested fix.
+```
+
+**Available tools:** `Read`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Bash`, `Write`, `Edit`
+
+**Inline skill in warden.toml:**
+
+```toml
+[[skills]]
+name = "custom-check"
+description = "Check for TODO comments"
+prompt = """
+Find TODO comments that have been in the code for too long.
+Report as low severity findings.
+"""
+
+[skills.tools]
+allowed = ["Read", "Grep", "Glob"]
+```
+
+## Built-in Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `find-bugs` | Logical/functional bugs, null handling, async issues |
+| `security-review` | Injection, auth, CSRF, crypto, race conditions |
+| `code-simplifier` | Readability, consistency, redundancy removal |
+| `performance-review` | N+1 queries, blocking I/O, memory leaks |
+
+## Common Patterns
+
+**Strict security on critical files:**
+```toml
+[[triggers]]
+name = "auth-security"
+event = "pull_request"
+actions = ["opened", "synchronize"]
+skill = "security-review"
+model = "claude-opus-4-20250514"
+maxTurns = 100
+
+[triggers.filters]
+paths = ["src/auth/**", "src/payments/**"]
+
+[triggers.output]
+failOn = "critical"
+```
+
+**Skip test files:**
+```toml
+[triggers.filters]
+paths = ["src/**/*.ts"]
+ignorePaths = ["**/*.test.ts", "**/*.spec.ts"]
+```
+
+**Whole-file analysis for configs:**
+```toml
+[defaults.chunking.filePatterns]
+pattern = "*.config.*"
+mode = "whole-file"
+```
+
+## Troubleshooting
+
+**No findings reported:**
+- Check `--comment-on` threshold (default shows all)
+- Verify skill matches file types in `filters.paths`
+- Use `-v` to see which files are being analyzed
+
+**Files being skipped:**
+- Built-in skip patterns: lock files, minified, `node_modules/`, `dist/`
+- Check `ignorePaths` in config
+- Use `-vv` to see skip reasons
+
+**Token/cost issues:**
+- Reduce `maxTurns` (default: 50)
+- Use chunking settings to control chunk size
+- Filter to relevant files with `paths`

--- a/warden-skill/references/config-schema.md
+++ b/warden-skill/references/config-schema.md
@@ -1,0 +1,130 @@
+# warden.toml Configuration Schema
+
+## Top-Level Structure
+
+```toml
+version = 1                    # Required, must be 1
+
+[defaults]                     # Optional, inherited by all triggers
+[[triggers]]                   # Required, array of trigger configs
+[[skills]]                     # Optional, inline skill definitions
+```
+
+## Defaults Section
+
+```toml
+[defaults]
+model = "claude-sonnet-4-20250514"    # Default model
+maxTurns = 50                         # Max agentic turns per hunk
+defaultBranch = "main"                # Base branch for comparisons
+
+[defaults.output]
+failOn = "high"                # Exit 1 if findings >= this severity
+commentOn = "medium"           # Show findings >= this severity
+maxFindings = 50               # Max findings to report (0 = unlimited)
+commentOnSuccess = false       # Post comment even with no findings
+
+[defaults.filters]
+paths = ["src/**/*.ts"]        # Include only matching files
+ignorePaths = ["*.test.ts"]    # Exclude matching files
+
+[defaults.chunking]
+enabled = true                 # Enable hunk-based chunking
+
+[defaults.chunking.coalesce]
+enabled = true                 # Merge nearby hunks
+maxGapLines = 30               # Lines between hunks to merge
+maxChunkSize = 8000            # Max chars per chunk
+
+[[defaults.chunking.filePatterns]]
+pattern = "*.config.*"         # Glob pattern
+mode = "whole-file"            # per-hunk | whole-file | skip
+```
+
+## Triggers Section
+
+```toml
+[[triggers]]
+name = "trigger-name"          # Required, unique identifier
+event = "pull_request"         # Required: pull_request | issues | issue_comment | schedule
+actions = ["opened", "synchronize"]  # Required for non-schedule events
+skill = "find-bugs"            # Required, skill name or path
+
+# Optional overrides (inherit from defaults if not set)
+model = "claude-opus-4-20250514"
+maxTurns = 100
+
+[triggers.filters]
+paths = ["src/**"]
+ignorePaths = ["**/*.test.ts"]
+
+[triggers.output]
+failOn = "critical"
+commentOn = "high"
+maxFindings = 20
+commentOnSuccess = true
+
+# Schedule-specific (only for event = "schedule")
+[triggers.schedule]
+issueTitle = "Daily Security Review"   # GitHub issue title for tracking
+createFixPR = true                     # Create PR with fixes
+fixBranchPrefix = "security-fix"       # Branch name prefix
+```
+
+**Event types:**
+- `pull_request` - Triggers on PR events
+- `issues` - Triggers on issue events
+- `issue_comment` - Triggers on issue/PR comments
+- `schedule` - Triggers on cron schedule (GitHub Action)
+
+**Actions (for non-schedule):**
+- `opened`, `synchronize`, `reopened`, `closed`
+
+## Skills Section (Inline Skills)
+
+```toml
+[[skills]]
+name = "custom-skill"
+description = "What this skill checks"
+prompt = """
+Analysis instructions here.
+Look for specific issues.
+"""
+
+[skills.tools]
+allowed = ["Read", "Grep", "Glob"]     # Whitelist tools
+denied = ["Write", "Edit", "Bash"]     # Blacklist tools (optional)
+```
+
+## Severity Values
+
+Used in `failOn` and `commentOn`:
+- `critical` - Most severe
+- `high`
+- `medium`
+- `low`
+- `info` - Least severe
+- `off` - Disable threshold
+
+## Built-in Skip Patterns
+
+Always skipped (cannot be overridden):
+- Package locks: `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, etc.
+- Minified files: `**/*.min.js`, `**/*.min.css`
+- Build artifacts: `dist/`, `build/`, `node_modules/`, `.next/`, `__pycache__/`
+- Generated code: `*.generated.*`, `*.g.ts`, `__generated__/`
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `WARDEN_ANTHROPIC_API_KEY` | Claude API key (required) |
+| `WARDEN_MODEL` | Default model (lowest priority) |
+
+## Model Precedence (highest to lowest)
+
+1. Trigger-level `model`
+2. `[defaults]` `model`
+3. CLI `--model` flag
+4. `WARDEN_MODEL` env var
+5. SDK default


### PR DESCRIPTION
## Summary
- Add `warden-skill/` with SKILL.md and config schema reference
- Provides agents with knowledge of CLI commands, warden.toml configuration, custom skill creation, and troubleshooting

## Test plan
- [ ] Install skill and verify it triggers on warden-related queries
- [ ] Confirm config examples are accurate