### PR TITLE
ref(skill): Remove outdated built-in and inline skills docs

### DIFF
--- a/.claude/skills/warden-skill/SKILL.md
+++ b/.claude/skills/warden-skill/SKILL.md
@@ -175,30 +175,6 @@ remote = "getsentry/skills@abc123"
 
 **Cache TTL:** 24 hours for unpinned refs (override with `WARDEN_SKILL_CACHE_TTL` in seconds)
 
-**Inline skill in warden.toml:**
-
-```toml
-[[skills]]
-name = "custom-check"
-description = "Check for TODO comments"
-prompt = """
-Find TODO comments that have been in the code for too long.
-Report as low severity findings.
-"""
-
-[skills.tools]
-allowed = ["Read", "Grep", "Glob"]
-```
-
-## Built-in Skills
-
-| Skill | Purpose |
-|-------|---------|
-| `find-bugs` | Logical/functional bugs, null handling, async issues |
-| `security-review` | Injection, auth, CSRF, crypto, race conditions |
-| `code-simplifier` | Readability, consistency, redundancy removal |
-| `performance-review` | N+1 queries, blocking I/O, memory leaks |
-
 ## Common Patterns
 
 **Strict security on critical files:**

--- a/.claude/skills/warden-skill/references/config-schema.md
+++ b/.claude/skills/warden-skill/references/config-schema.md
@@ -7,7 +7,6 @@ version = 1                    # Required, must be 1
 
 [defaults]                     # Optional, inherited by all triggers
 [[triggers]]                   # Required, array of trigger configs
-[[skills]]                     # Optional, inline skill definitions
 ```
 
 ## Defaults Section
@@ -80,22 +79,6 @@ fixBranchPrefix = "security-fix"       # Branch name prefix
 
 **Actions (for non-schedule):**
 - `opened`, `synchronize`, `reopened`, `closed`
-
-## Skills Section (Inline Skills)
-
-```toml
-[[skills]]
-name = "custom-skill"
-description = "What this skill checks"
-prompt = """
-Analysis instructions here.
-Look for specific issues.
-"""
-
-[skills.tools]
-allowed = ["Read", "Grep", "Glob"]     # Whitelist tools
-denied = ["Write", "Edit", "Bash"]     # Blacklist tools (optional)
-```
 
 ## Severity Values
 


### PR DESCRIPTION
Remove the built-in skills section and inline skills documentation from warden-skill since Warden no longer supports these.

Skills are now sourced exclusively from:
- Local custom skills in `.warden/skills/`, `.agents/skills/`, or `.claude/skills/`
- Remote skills fetched from GitHub repositories

Removed references:
- Built-in skills table (`find-bugs`, `security-review`, `code-simplifier`, `performance-review`)
- `[[skills]]` section in config schema
- Inline skill example in warden.toml documentation