### PR TITLE
feat(utils): Add non-interactive exec utilities to prevent SSH prompts

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -1,8 +1,8 @@
 import { readFileSync, appendFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { execSync } from 'node:child_process';
 import { Octokit } from '@octokit/rest';
+import { execNonInteractive } from '../utils/exec.js';
 import { loadWardenConfig, resolveTrigger, type ResolvedTrigger } from '../config/loader.js';
 import type { ScheduleConfig } from '../config/schema.js';
 import { buildEventContext } from '../event/context.js';
@@ -158,7 +158,7 @@ function findClaudeCodeExecutable(): string {
   const envPath = process.env['CLAUDE_CODE_PATH'];
   if (envPath) {
     try {
-      execSync(`test -x "${envPath}"`, { encoding: 'utf-8' });
+      execNonInteractive(`test -x "${envPath}"`);
       return envPath;
     } catch {
       // Path from env doesn't exist, continue to fallbacks
@@ -168,7 +168,7 @@ function findClaudeCodeExecutable(): string {
   // Standard install location from claude.ai/install.sh
   const homeLocalBin = `${process.env['HOME']}/.local/bin/claude`;
   try {
-    execSync(`test -x "${homeLocalBin}"`, { encoding: 'utf-8' });
+    execNonInteractive(`test -x "${homeLocalBin}"`);
     return homeLocalBin;
   } catch {
     // Not found in standard location
@@ -176,7 +176,7 @@ function findClaudeCodeExecutable(): string {
 
   // Try which command
   try {
-    const path = execSync('which claude', { encoding: 'utf-8' }).trim();
+    const path = execNonInteractive('which claude');
     if (path) {
       return path;
     }
@@ -189,7 +189,7 @@ function findClaudeCodeExecutable(): string {
 
   for (const p of commonPaths) {
     try {
-      execSync(`test -x "${p}"`, { encoding: 'utf-8' });
+      execNonInteractive(`test -x "${p}"`);
       return p;
     } catch {
       // Path doesn't exist or isn't executable

--- a/src/cli/git.test.ts
+++ b/src/cli/git.test.ts
@@ -1,32 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
 import { getDefaultBranch, getCurrentBranch, getCommitMessage } from './git.js';
 
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+vi.mock('../utils/exec.js', () => ({
+  execNonInteractive: vi.fn(),
 }));
 
-const mockExecSync = vi.mocked(execSync);
+import { execNonInteractive } from '../utils/exec.js';
+
+const mockExecNonInteractive = vi.mocked(execNonInteractive);
 
 beforeEach(() => {
-  mockExecSync.mockReset();
+  mockExecNonInteractive.mockReset();
 });
 
 describe('git error handling', () => {
-  it('includes stderr in error message when git command fails', () => {
-    const error = new Error('Command failed') as Error & { stderr: string };
-    error.stderr = 'fatal: not a git repository';
-    mockExecSync.mockImplementation(() => {
-      throw error;
+  it('includes error message when git command fails', () => {
+    mockExecNonInteractive.mockImplementation(() => {
+      throw new Error('Command failed: git rev-parse --abbrev-ref HEAD\nfatal: not a git repository');
     });
 
     expect(() => getCurrentBranch()).toThrow(
-      'Git command failed: git rev-parse --abbrev-ref HEAD\nfatal: not a git repository'
+      'Git command failed: git rev-parse --abbrev-ref HEAD\nCommand failed: git rev-parse --abbrev-ref HEAD\nfatal: not a git repository'
     );
   });
 
-  it('includes command in error message when stderr is empty', () => {
-    mockExecSync.mockImplementation(() => {
+  it('includes command in error message when error is simple', () => {
+    mockExecNonInteractive.mockImplementation(() => {
       throw new Error('Command failed');
     });
 
@@ -39,6 +38,7 @@ describe('git error handling', () => {
 /**
  * Creates a mock that simulates git branch detection.
  * Returns success for branches in existingBranches, and optionally a config value.
+ * Note: execNonInteractive returns trimmed output, so no trailing newlines.
  */
 function mockBranchDetection(
   existingBranches: string[],
@@ -47,11 +47,11 @@ function mockBranchDetection(
   return (cmd: string) => {
     for (const branch of existingBranches) {
       if (cmd === `git rev-parse --verify ${branch}`) {
-        return 'abc123\n';
+        return 'abc123';
       }
     }
     if (cmd === 'git config init.defaultBranch' && configDefault) {
-      return `${configDefault}\n`;
+      return configDefault;
     }
     throw new Error('Not found');
   };
@@ -59,39 +59,39 @@ function mockBranchDetection(
 
 describe('getDefaultBranch', () => {
   it('returns main when main branch exists locally', () => {
-    mockExecSync.mockImplementation(mockBranchDetection(['main']));
+    mockExecNonInteractive.mockImplementation(mockBranchDetection(['main']));
     expect(getDefaultBranch()).toBe('main');
   });
 
   it('returns master when main does not exist but master does', () => {
-    mockExecSync.mockImplementation(mockBranchDetection(['master']));
+    mockExecNonInteractive.mockImplementation(mockBranchDetection(['master']));
     expect(getDefaultBranch()).toBe('master');
   });
 
   it('returns develop when main and master do not exist but develop does', () => {
-    mockExecSync.mockImplementation(mockBranchDetection(['develop']));
+    mockExecNonInteractive.mockImplementation(mockBranchDetection(['develop']));
     expect(getDefaultBranch()).toBe('develop');
   });
 
   it('returns git config init.defaultBranch when no common branches exist', () => {
-    mockExecSync.mockImplementation(mockBranchDetection([], 'trunk'));
+    mockExecNonInteractive.mockImplementation(mockBranchDetection([], 'trunk'));
     expect(getDefaultBranch()).toBe('trunk');
   });
 
   it('returns hardcoded main when no branches exist and no config is set', () => {
-    mockExecSync.mockImplementation(mockBranchDetection([]));
+    mockExecNonInteractive.mockImplementation(mockBranchDetection([]));
     expect(getDefaultBranch()).toBe('main');
   });
 });
 
 describe('getCommitMessage', () => {
   it('returns subject and body from commit', () => {
-    mockExecSync.mockImplementation((cmd: string) => {
+    mockExecNonInteractive.mockImplementation((cmd: string) => {
       if (cmd === 'git log -1 --format=%s HEAD') {
-        return 'feat: Add new feature\n';
+        return 'feat: Add new feature';
       }
       if (cmd === 'git log -1 --format=%b HEAD') {
-        return 'This is the commit body.\n\nWith multiple paragraphs.\n';
+        return 'This is the commit body.\n\nWith multiple paragraphs.';
       }
       throw new Error('Unexpected command');
     });
@@ -102,12 +102,12 @@ describe('getCommitMessage', () => {
   });
 
   it('returns empty body when commit has no body', () => {
-    mockExecSync.mockImplementation((cmd: string) => {
+    mockExecNonInteractive.mockImplementation((cmd: string) => {
       if (cmd === 'git log -1 --format=%s abc123') {
-        return 'fix: Quick fix\n';
+        return 'fix: Quick fix';
       }
       if (cmd === 'git log -1 --format=%b abc123') {
-        return '\n';
+        return '';
       }
       throw new Error('Unexpected command');
     });

--- a/src/cli/git.ts
+++ b/src/cli/git.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
 import { countPatchChunks } from '../types/index.js';
+import { execNonInteractive } from '../utils/exec.js';
 
 export interface GitFileChange {
   filename: string;
@@ -12,18 +12,14 @@ export interface GitFileChange {
 
 /**
  * Execute a git command and return stdout.
+ * Uses non-interactive mode to prevent SSH passphrase prompts.
  */
 function git(args: string, cwd: string = process.cwd()): string {
   try {
-    return execSync(`git ${args}`, {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    return execNonInteractive(`git ${args}`, { cwd });
   } catch (error) {
-    const execError = error as { stderr?: Buffer | string; message: string };
-    const stderr = execError.stderr?.toString() ?? '';
-    throw new Error(`Git command failed: git ${args}\n${stderr || execError.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Git command failed: git ${args}\n${message}`);
   }
 }
 

--- a/src/skills/remote.ts
+++ b/src/skills/remote.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, renameSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { execFileSync } from 'node:child_process';
 import { z } from 'zod';
+import { execGitNonInteractive } from '../utils/exec.js';
 import { loadSkillFromMarkdown, SkillLoaderError } from './loader.js';
 import type { SkillDefinition } from '../config/schema.js';
 
@@ -283,16 +283,12 @@ export interface FetchRemoteOptions {
 
 /**
  * Execute a git command and return stdout.
- * Uses execFileSync to avoid shell injection vulnerabilities.
+ * Uses non-interactive mode to prevent SSH passphrase prompts.
  * Throws SkillLoaderError on failure.
  */
 function execGit(args: string[], options?: { cwd?: string }): string {
   try {
-    return execFileSync('git', args, {
-      encoding: 'utf-8',
-      cwd: options?.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    return execGitNonInteractive(args, { cwd: options?.cwd });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new SkillLoaderError(`Git command failed: git ${args.join(' ')}: ${message}`);

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ExecError,
+  execNonInteractive,
+  execFileNonInteractive,
+  execGitNonInteractive,
+  GIT_NON_INTERACTIVE_ENV,
+} from './exec.js';
+
+describe('ExecError', () => {
+  it('formats error message with stderr', () => {
+    const error = new ExecError('git status', 1, 'not a git repository', null);
+    expect(error.message).toBe('Command failed: git status\nnot a git repository');
+    expect(error.name).toBe('ExecError');
+    expect(error.command).toBe('git status');
+    expect(error.exitCode).toBe(1);
+    expect(error.stderr).toBe('not a git repository');
+    expect(error.signal).toBeNull();
+  });
+
+  it('formats error message with signal when no stderr', () => {
+    const error = new ExecError('long-process', null, '', 'SIGTERM');
+    expect(error.message).toBe('Command failed: long-process\nKilled by signal SIGTERM');
+  });
+
+  it('shows unknown error when no stderr or signal', () => {
+    const error = new ExecError('mystery', null, '', null);
+    expect(error.message).toBe('Command failed: mystery\nUnknown error');
+  });
+});
+
+describe('GIT_NON_INTERACTIVE_ENV', () => {
+  it('contains expected environment variables', () => {
+    expect(GIT_NON_INTERACTIVE_ENV.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(GIT_NON_INTERACTIVE_ENV.GIT_SSH_COMMAND).toBe('ssh -o BatchMode=yes');
+  });
+});
+
+describe('execNonInteractive', () => {
+  it('executes a simple command and returns stdout', () => {
+    const result = execNonInteractive('echo hello');
+    expect(result).toBe('hello');
+  });
+
+  it('trims whitespace from output', () => {
+    const result = execNonInteractive('echo "  padded  "');
+    expect(result).toBe('padded');
+  });
+
+  it('throws ExecError when command fails', () => {
+    expect(() => execNonInteractive('exit 1')).toThrow(ExecError);
+    try {
+      execNonInteractive('exit 1');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ExecError);
+      const error = e as ExecError;
+      expect(error.exitCode).toBe(1);
+    }
+  });
+
+  it('throws ExecError with stderr when command fails with output', () => {
+    expect(() => execNonInteractive('echo "error message" >&2 && exit 1')).toThrow(ExecError);
+    try {
+      execNonInteractive('echo "error message" >&2 && exit 1');
+    } catch (e) {
+      const error = e as ExecError;
+      expect(error.stderr).toBe('error message');
+    }
+  });
+
+  it('throws ExecError for non-existent command', () => {
+    expect(() => execNonInteractive('nonexistent-command-xyz')).toThrow(ExecError);
+  });
+
+  describe('with cwd option', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `warden-exec-test-${Date.now()}`);
+      mkdirSync(tempDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('executes command in specified directory', () => {
+      writeFileSync(join(tempDir, 'test.txt'), 'content');
+      const result = execNonInteractive('ls', { cwd: tempDir });
+      expect(result).toBe('test.txt');
+    });
+  });
+
+  describe('with env option', () => {
+    it('passes environment variables to command', () => {
+      const result = execNonInteractive('echo $TEST_VAR', {
+        env: { TEST_VAR: 'test-value' },
+      });
+      expect(result).toBe('test-value');
+    });
+
+    it('merges with existing process.env', () => {
+      // PATH should still be available
+      const result = execNonInteractive('which echo', {
+        env: { CUSTOM_VAR: 'custom' },
+      });
+      expect(result).toContain('echo');
+    });
+  });
+});
+
+describe('execFileNonInteractive', () => {
+  it('executes file with arguments', () => {
+    const result = execFileNonInteractive('echo', ['hello', 'world']);
+    expect(result).toBe('hello world');
+  });
+
+  it('avoids shell interpretation of special characters', () => {
+    // Without shell, $ should not be interpreted
+    const result = execFileNonInteractive('echo', ['$HOME']);
+    expect(result).toBe('$HOME');
+  });
+
+  it('throws ExecError when file fails', () => {
+    expect(() => execFileNonInteractive('false', [])).toThrow(ExecError);
+    try {
+      execFileNonInteractive('false', []);
+    } catch (e) {
+      const error = e as ExecError;
+      expect(error.exitCode).toBe(1);
+      expect(error.command).toBe('false ');
+    }
+  });
+
+  it('throws ExecError for non-existent file', () => {
+    expect(() => execFileNonInteractive('nonexistent-binary-xyz', [])).toThrow(ExecError);
+  });
+
+  describe('with options', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `warden-exec-file-test-${Date.now()}`);
+      mkdirSync(tempDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('executes in specified directory', () => {
+      writeFileSync(join(tempDir, 'file.txt'), 'content');
+      const result = execFileNonInteractive('ls', [], { cwd: tempDir });
+      expect(result).toBe('file.txt');
+    });
+
+    it('passes environment variables', () => {
+      // Create a simple script that echoes an env var
+      const scriptPath = join(tempDir, 'echo-var.sh');
+      writeFileSync(scriptPath, '#!/bin/sh\necho "$MY_VAR"');
+      chmodSync(scriptPath, 0o755);
+
+      const result = execFileNonInteractive(scriptPath, [], {
+        env: { MY_VAR: 'from-env' },
+      });
+      expect(result).toBe('from-env');
+    });
+  });
+});
+
+describe('execGitNonInteractive', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `warden-git-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    // Initialize a git repo for testing
+    execFileNonInteractive('git', ['init'], { cwd: tempDir });
+    execFileNonInteractive('git', ['config', 'user.email', 'test@example.com'], { cwd: tempDir });
+    execFileNonInteractive('git', ['config', 'user.name', 'Test User'], { cwd: tempDir });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('executes git commands', () => {
+    const result = execGitNonInteractive(['status', '--short'], { cwd: tempDir });
+    // Empty repo should have empty status
+    expect(result).toBe('');
+  });
+
+  it('returns git output', () => {
+    const result = execGitNonInteractive(['rev-parse', '--is-inside-work-tree'], { cwd: tempDir });
+    expect(result).toBe('true');
+  });
+
+  it('throws ExecError when git command fails', () => {
+    expect(() =>
+      execGitNonInteractive(['rev-parse', 'nonexistent-ref'], { cwd: tempDir })
+    ).toThrow(ExecError);
+  });
+
+  it('includes GIT_NON_INTERACTIVE_ENV in environment', () => {
+    // We can verify this indirectly by checking that git doesn't try to prompt
+    // A more direct test would require mocking, but this validates the integration
+    const result = execGitNonInteractive(['config', '--get', 'user.email'], { cwd: tempDir });
+    expect(result).toBe('test@example.com');
+  });
+
+  it('merges custom env vars with non-interactive settings', () => {
+    // Custom env vars are accepted, but GIT_NON_INTERACTIVE_ENV always takes precedence
+    const result = execGitNonInteractive(['config', '--get', 'user.name'], {
+      cwd: tempDir,
+      env: { CUSTOM_VAR: 'value' },
+    });
+    expect(result).toBe('Test User');
+  });
+});

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,135 @@
+import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
+
+/**
+ * Error thrown when a command fails.
+ */
+export class ExecError extends Error {
+  constructor(
+    public readonly command: string,
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
+    public readonly signal: string | null
+  ) {
+    const details = stderr || (signal ? `Killed by signal ${signal}` : 'Unknown error');
+    super(`Command failed: ${command}\n${details}`);
+    this.name = 'ExecError';
+  }
+}
+
+/**
+ * Options for exec functions.
+ */
+export interface ExecOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeout?: number;
+}
+
+/**
+ * Git environment variables that disable interactive prompts.
+ * - GIT_TERMINAL_PROMPT=0: Disables git's internal prompts
+ * - GIT_SSH_COMMAND with BatchMode=yes: Makes SSH fail instead of prompting for passphrase
+ */
+export const GIT_NON_INTERACTIVE_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+};
+
+/**
+ * Build spawn options for non-interactive execution.
+ * - stdin: 'ignore' maps to /dev/null, ensuring immediate EOF on read (no hangs)
+ * - stdout/stderr: 'pipe' to capture output
+ */
+function buildSpawnOptions(options?: ExecOptions): SpawnSyncOptions {
+  return {
+    encoding: 'utf-8',
+    cwd: options?.cwd,
+    env: options?.env ? { ...process.env, ...options.env } : process.env,
+    timeout: options?.timeout,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+}
+
+/**
+ * Execute a shell command in non-interactive mode.
+ * Uses piped stdio to avoid passing terminal to child process.
+ *
+ * @param command - The shell command to execute
+ * @param options - Execution options (cwd, env, timeout)
+ * @returns The trimmed stdout output
+ * @throws ExecError if the command fails
+ */
+export function execNonInteractive(command: string, options?: ExecOptions): string {
+  const spawnOptions = buildSpawnOptions(options);
+
+  // Use shell to execute the command string
+  const result = spawnSync(command, {
+    ...spawnOptions,
+    shell: true,
+  });
+
+  if (result.error) {
+    throw new ExecError(command, null, result.error.message, null);
+  }
+
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    throw new ExecError(command, result.status, stderr, result.signal?.toString() ?? null);
+  }
+
+  const stdout = typeof result.stdout === 'string' ? result.stdout : '';
+  return stdout.trim();
+}
+
+/**
+ * Execute a file with arguments in non-interactive mode.
+ * Uses execFile semantics (no shell), avoiding shell injection vulnerabilities.
+ * Uses piped stdio to avoid passing terminal to child process.
+ *
+ * @param file - The executable to run
+ * @param args - Arguments to pass to the executable
+ * @param options - Execution options (cwd, env, timeout)
+ * @returns The trimmed stdout output
+ * @throws ExecError if the command fails
+ */
+export function execFileNonInteractive(
+  file: string,
+  args: string[],
+  options?: ExecOptions
+): string {
+  const spawnOptions = buildSpawnOptions(options);
+  const command = `${file} ${args.join(' ')}`;
+
+  const result = spawnSync(file, args, spawnOptions);
+
+  if (result.error) {
+    throw new ExecError(command, null, result.error.message, null);
+  }
+
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    throw new ExecError(command, result.status, stderr, result.signal?.toString() ?? null);
+  }
+
+  const stdout = typeof result.stdout === 'string' ? result.stdout : '';
+  return stdout.trim();
+}
+
+/**
+ * Execute a git command in non-interactive mode.
+ * Combines execFileNonInteractive with GIT_NON_INTERACTIVE_ENV for
+ * defense-in-depth against SSH prompts.
+ *
+ * @param args - Arguments to pass to git
+ * @param options - Execution options (cwd, env, timeout)
+ * @returns The trimmed stdout output
+ * @throws ExecError if the command fails
+ */
+export function execGitNonInteractive(args: string[], options?: ExecOptions): string {
+  const env = {
+    ...options?.env,
+    ...GIT_NON_INTERACTIVE_ENV, // Always override to ensure non-interactive
+  };
+
+  return execFileNonInteractive('git', args, { ...options, env });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,13 @@
 export { processInBatches } from './async.js';
 export { getVersion, getMajorVersion } from './version.js';
+export {
+  ExecError,
+  execNonInteractive,
+  execFileNonInteractive,
+  execGitNonInteractive,
+  GIT_NON_INTERACTIVE_ENV,
+} from './exec.js';
+export type { ExecOptions } from './exec.js';
 
 /** Default concurrency for parallel trigger/skill execution */
 export const DEFAULT_CONCURRENCY = 4;


### PR DESCRIPTION
Add exec utility functions that prevent interactive prompts during child process execution.

When loading remote skills, git operations (clone/fetch) can trigger SSH passphrase prompts
if the user's SSH key requires a passphrase and ssh-agent isn't running. SSH opens `/dev/tty`
directly, bypassing stdio configuration, which causes the CLI to hang waiting for input that
will never come in non-interactive contexts.

This PR adds a new `src/utils/exec.ts` module with utilities that prevent this:

- **`execNonInteractive`**: Shell command execution with stdin mapped to `/dev/null`
- **`execFileNonInteractive`**: Direct file execution (no shell) for injection safety
- **`execGitNonInteractive`**: Git-specific wrapper that also sets `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND='ssh -o BatchMode=yes'`
- **`ExecError`**: Structured error class with exit code, stderr, and signal information

The combination of `/dev/null` stdin and SSH's `BatchMode=yes` ensures that SSH fails fast
with a clear error message instead of hanging indefinitely waiting for a passphrase.

Migrated all child process calls in `src/cli/git.ts`, `src/skills/remote.ts`, and
`src/action/main.ts` to use the new utilities.