### PR TITLE
feat(release): Switch to Craft release tool

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,6 @@
+changelogPolicy: none
+preReleaseCommand: bash bin/bump-version.sh
+targets:
+  - name: github
+  - name: npm
+    id: "@sentry/warden"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,59 +1,56 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-permissions:
-  contents: write
-  id-token: write
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        type: choice
+        default: minor
+        options:
+          - minor
+          - patch
+          - major
+      force:
+        description: Force release (bypass blockers)
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: pnpm build:action
-
-      - name: Publish to npm
-        run: npm publish --provenance --access public
-
-      - name: Get version info
+      - name: Calculate version
         id: version
         run: |
-          echo "tag=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
-          echo "major=${GITHUB_REF_NAME%%.*}" >> $GITHUB_OUTPUT
+          CURRENT=$(node -p "require('./package.json').version")
+          NEW=$(npx semver -i ${{ inputs.bump }} $CURRENT)
+          echo "new=$NEW" >> $GITHUB_OUTPUT
 
-      - name: Commit dist/action to tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f dist/action/
-          git commit -m "Build action for ${{ steps.version.outputs.tag }}"
-          git tag -f ${{ steps.version.outputs.tag }}
-          git push -f origin ${{ steps.version.outputs.tag }}
-
-      - name: Update major version tag
-        run: |
-          git tag -f ${{ steps.version.outputs.major }}
-          git push -f origin ${{ steps.version.outputs.major }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          generate_release_notes: true
+          version: ${{ steps.version.outputs.new }}
+          force: ${{ inputs.force }}

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,25 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="v${VERSION%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$MAJOR" -m "Update $MAJOR to $GITHUB_REF_NAME"
+          git push -f origin "$MAJOR"

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+export npm_config_git_tag_version=false
+npm version "${NEW_VERSION}"
+
+# Build for npm and GitHub Action (dist/action must be committed with release)
+pnpm install --frozen-lockfile
+pnpm build
+pnpm build:action
+git add -f dist/action/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "bin": {
     "warden": "dist/cli/index.js"
   },
+  "packageManager": "pnpm@10.28.0",
   "scripts": {
     "cli": "tsx src/cli/index.ts",
     "build": "tsc",
@@ -19,8 +20,7 @@
     "test:watch": "vitest",
     "test:examples": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
-    "prepare": "simple-git-hooks",
-    "release": "pnpm lint && pnpm build && pnpm test && npm version"
+    "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged && pnpm typecheck"


### PR DESCRIPTION
Replace tag-triggered releases with manual workflow_dispatch using Sentry's Craft tool. Releases now use a bump type selector (major/minor/patch) and authenticate via Sentry Release Bot GitHub App.