### PR TITLE
fix(release): Add tagPrefix for v-prefixed tags

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,5 @@
 changelogPolicy: none
+tagPrefix: v
 preReleaseCommand: bash bin/bump-version.sh
 targets:
   - name: github


### PR DESCRIPTION
Craft was failing during `craft prepare` with:

```
fatal: No tags can describe '<commit>'.
Try --always, or create some tags.
```

This happened because Craft uses `git describe` to find previous tags, but by
default looks for tags without a prefix. Our tags use the `v` prefix (e.g.,
`v0.1.0`, `v0.1.1`), so Craft couldn't find them.

Adding `tagPrefix: v` to `.craft.yml` tells Craft to look for `v`-prefixed tags.