### PR TITLE
fix(release): Fetch tags in checkout step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The release workflow was failing with:

```
fatal: No tags can describe '8b648b808a770138808f5954fda6ca0ccf13451f'.
Try --always, or create some tags.
```

`actions/checkout@v4` doesn't fetch tags by default, even with `fetch-depth: 0`. Craft's `git describe --tags --abbrev=0` needs tags to be present locally to determine the previous version.

Adding `fetch-tags: true` ensures tags are fetched alongside the full commit history.