### PR TITLE
fix(release): Upload npm tarball artifact during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,10 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: pnpm build:action
+
+      - run: pnpm pack
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}
+          path: "*.tgz"


### PR DESCRIPTION
Craft's npm target expects build artifacts to be available. This adds `pnpm pack` and GitHub artifact upload steps to the CI workflow so Craft can find and publish the package during release.

Previously, the publish step would fail with "Can't find any artifacts" because no artifacts were being uploaded. The tarball is now packed after the build and uploaded with the commit SHA as the artifact name, which Craft uses to locate it.

Refs getsentry/craft#123