### PR TITLE
fix(release): Run CI on release branches for Craft artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/*"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Craft publish fails when it can't find npm artifacts for the release commit. The root cause is that CI only ran on `main`, but `craft prepare` creates release commits on `release/*` branches, so no artifacts were uploaded for those commit SHAs.

This matches the approach used by sentry-mcp: run CI on both `main` and `release/*` branches so artifacts are uploaded when release commits are pushed.

The previous fix (#91) added artifact upload to CI, which was correct. This ensures CI actually runs on release commits.

Fixes the "Can't find any artifacts" error during craft publish.