### PR TITLE
fix(release): Move tagPrefix under github target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,7 +1,7 @@
 changelogPolicy: none
-tagPrefix: v
 preReleaseCommand: bash bin/bump-version.sh
 targets:
   - name: github
+    tagPrefix: v
   - name: npm
     id: "@sentry/warden"


### PR DESCRIPTION
Craft's `getGitTagPrefix()` only reads `tagPrefix` from the github target
configuration, not the root level. The root-level placement was being
ignored, causing the 0.2.0 release to be tagged as `0.2.0` instead of
`v0.2.0`.

Verified against other Sentry JS projects using Craft (sentry-cordova,
sentry-rrweb, sentry-fullstory, spotlight) which all place `tagPrefix`
under the github target.