### PR TITLE
ref(cli): Extract diff application logic to dedicated module

### DIFF
--- a/src/cli/diff-apply.test.ts
+++ b/src/cli/diff-apply.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { applyUnifiedDiff, applyHunk } from './diff-apply.js';
+import type { DiffHunk } from '../diff/index.js';
+
+describe('applyHunk', () => {
+  it('replaces a single line', () => {
+    const lines = ['line1', 'line2', 'line3'];
+    const hunk: DiffHunk = {
+      oldStart: 2,
+      oldCount: 1,
+      newStart: 2,
+      newCount: 1,
+      content: '@@ -2,1 +2,1 @@\n-line2\n+LINE2',
+      lines: ['-line2', '+LINE2'],
+    };
+
+    const result = applyHunk(lines, hunk);
+    expect(result).toEqual(['line1', 'LINE2', 'line3']);
+  });
+
+  it('adds lines', () => {
+    const lines = ['a', 'b'];
+    const hunk: DiffHunk = {
+      oldStart: 1,
+      oldCount: 2,
+      newStart: 1,
+      newCount: 4,
+      content: '@@ -1,2 +1,4 @@\n a\n+new1\n+new2\n b',
+      lines: [' a', '+new1', '+new2', ' b'],
+    };
+
+    const result = applyHunk(lines, hunk);
+    expect(result).toEqual(['a', 'new1', 'new2', 'b']);
+  });
+
+  it('removes lines', () => {
+    const lines = ['a', 'b', 'c', 'd'];
+    const hunk: DiffHunk = {
+      oldStart: 2,
+      oldCount: 2,
+      newStart: 2,
+      newCount: 0,
+      content: '@@ -2,2 +2,0 @@\n-b\n-c',
+      lines: ['-b', '-c'],
+    };
+
+    const result = applyHunk(lines, hunk);
+    expect(result).toEqual(['a', 'd']);
+  });
+
+  it('handles context lines', () => {
+    const lines = ['first', 'middle', 'last'];
+    const hunk: DiffHunk = {
+      oldStart: 1,
+      oldCount: 3,
+      newStart: 1,
+      newCount: 3,
+      content: '@@ -1,3 +1,3 @@\n first\n-middle\n+MIDDLE\n last',
+      lines: [' first', '-middle', '+MIDDLE', ' last'],
+    };
+
+    const result = applyHunk(lines, hunk);
+    expect(result).toEqual(['first', 'MIDDLE', 'last']);
+  });
+
+  it('throws on context mismatch', () => {
+    const lines = ['actual'];
+    const hunk: DiffHunk = {
+      oldStart: 1,
+      oldCount: 1,
+      newStart: 1,
+      newCount: 1,
+      content: '@@ -1,1 +1,1 @@\n-expected\n+new',
+      lines: ['-expected', '+new'],
+    };
+
+    expect(() => applyHunk(lines, hunk)).toThrow('context mismatch');
+  });
+
+  it('throws when line does not exist', () => {
+    const lines = ['only'];
+    const hunk: DiffHunk = {
+      oldStart: 5,
+      oldCount: 1,
+      newStart: 5,
+      newCount: 1,
+      content: '@@ -5,1 +5,1 @@\n-missing\n+new',
+      lines: ['-missing', '+new'],
+    };
+
+    expect(() => applyHunk(lines, hunk)).toThrow("line 5 doesn't exist");
+  });
+
+  it('handles new file diffs with oldStart of 0', () => {
+    const lines: string[] = [];
+    const hunk: DiffHunk = {
+      oldStart: 0,
+      oldCount: 0,
+      newStart: 1,
+      newCount: 3,
+      content: '@@ -0,0 +1,3 @@\n+line1\n+line2\n+line3',
+      lines: ['+line1', '+line2', '+line3'],
+    };
+
+    const result = applyHunk(lines, hunk);
+    expect(result).toEqual(['line1', 'line2', 'line3']);
+  });
+});
+
+describe('applyUnifiedDiff', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `warden-diff-apply-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('applies a single-line replacement', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'const x = "hello";\nconst y = "world";\n');
+
+    const diff = `@@ -1,2 +1,2 @@
+-const x = "hello";
++const x = "goodbye";
+ const y = "world";`;
+
+    applyUnifiedDiff(filePath, diff);
+
+    const result = readFileSync(filePath, 'utf-8');
+    expect(result).toBe('const x = "goodbye";\nconst y = "world";\n');
+  });
+
+  it('applies a multi-line addition', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'function foo() {\n  return 1;\n}\n');
+
+    const diff = `@@ -1,3 +1,5 @@
+ function foo() {
++  // Added comment
++  const x = 1;
+   return 1;
+ }`;
+
+    applyUnifiedDiff(filePath, diff);
+
+    const result = readFileSync(filePath, 'utf-8');
+    expect(result).toBe(
+      'function foo() {\n  // Added comment\n  const x = 1;\n  return 1;\n}\n'
+    );
+  });
+
+  it('applies a multi-line deletion', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'line1\nline2\nline3\nline4\n');
+
+    const diff = `@@ -1,4 +1,2 @@
+ line1
+-line2
+-line3
+ line4`;
+
+    applyUnifiedDiff(filePath, diff);
+
+    const result = readFileSync(filePath, 'utf-8');
+    expect(result).toBe('line1\nline4\n');
+  });
+
+  it('applies multiple hunks in reverse order', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'a\nb\nc\nd\ne\nf\ng\n');
+
+    // Two hunks: one at line 2, one at line 6
+    const diff = `@@ -2,1 +2,1 @@
+-b
++B
+@@ -6,1 +6,1 @@
+-f
++F`;
+
+    applyUnifiedDiff(filePath, diff);
+
+    const result = readFileSync(filePath, 'utf-8');
+    expect(result).toBe('a\nB\nc\nd\ne\nF\ng\n');
+  });
+
+  it('throws error for non-existent file', () => {
+    const filePath = join(testDir, 'nonexistent.ts');
+    const diff = `@@ -1,1 +1,1 @@
+-old
++new`;
+
+    expect(() => applyUnifiedDiff(filePath, diff)).toThrow('File not found');
+  });
+
+  it('throws error for context mismatch', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'actual content\n');
+
+    const diff = `@@ -1,1 +1,1 @@
+-expected content
++new content`;
+
+    expect(() => applyUnifiedDiff(filePath, diff)).toThrow('context mismatch');
+  });
+
+  it('throws error for empty diff', () => {
+    const filePath = join(testDir, 'test.ts');
+    writeFileSync(filePath, 'content\n');
+
+    expect(() => applyUnifiedDiff(filePath, '')).toThrow('No valid hunks');
+  });
+});

--- a/src/cli/diff-apply.ts
+++ b/src/cli/diff-apply.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure diff application functions.
+ * Apply unified diffs to file content without side effects beyond file I/O.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { parsePatch, type DiffHunk } from '../diff/index.js';
+
+/**
+ * Apply a single hunk to the file content lines.
+ */
+export function applyHunk(lines: string[], hunk: DiffHunk): string[] {
+  const result = [...lines];
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+
+  for (const line of hunk.lines) {
+    const prefix = line[0] ?? '';
+    const content = line.slice(1);
+
+    switch (prefix) {
+      case '-':
+        oldLines.push(content);
+        break;
+      case '+':
+        newLines.push(content);
+        break;
+      case ' ':
+      case '':
+        // Context line appears in both old and new
+        oldLines.push(content);
+        newLines.push(content);
+        break;
+    }
+  }
+
+  // Convert 1-based line number to 0-based index.
+  // New file diffs use @@ -0,0 +1,N @@, so clamp to 0.
+  const startIndex = Math.max(0, hunk.oldStart - 1);
+
+  for (let i = 0; i < oldLines.length; i++) {
+    const lineIndex = startIndex + i;
+    if (lineIndex >= result.length) {
+      throw new Error(`Hunk context mismatch: line ${lineIndex + 1} doesn't exist`);
+    }
+    if (result[lineIndex] !== oldLines[i]) {
+      throw new Error(
+        `Hunk context mismatch at line ${lineIndex + 1}: ` +
+          `expected "${oldLines[i]}", got "${result[lineIndex]}"`
+      );
+    }
+  }
+
+  result.splice(startIndex, oldLines.length, ...newLines);
+  return result;
+}
+
+/**
+ * Apply a unified diff to a file.
+ * Hunks are applied in reverse order by line number to prevent line shift issues.
+ */
+export function applyUnifiedDiff(filePath: string, diff: string): void {
+  if (!existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const hunks = parsePatch(diff);
+  if (hunks.length === 0) {
+    throw new Error('No valid hunks found in diff');
+  }
+
+  const content = readFileSync(filePath, 'utf-8');
+  let lines = content.split('\n');
+
+  // Sort hunks by oldStart in descending order to apply from bottom to top
+  const sortedHunks = [...hunks].sort((a, b) => b.oldStart - a.oldStart);
+
+  for (const hunk of sortedHunks) {
+    lines = applyHunk(lines, hunk);
+  }
+
+  writeFileSync(filePath, lines.join('\n'));
+}

--- a/src/cli/fix.test.ts
+++ b/src/cli/fix.test.ts
@@ -2,11 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import {
-  applyUnifiedDiff,
-  collectFixableFindings,
-  applyAllFixes,
-} from './fix.js';
+import { collectFixableFindings, applyAllFixes } from './fix.js';
+import { applyUnifiedDiff } from './diff-apply.js';
 import type { Finding, SkillReport } from '../types/index.js';
 
 describe('applyUnifiedDiff', () => {

--- a/src/cli/fix.ts
+++ b/src/cli/fix.ts
@@ -2,14 +2,16 @@
  * Fix application functionality for the warden CLI.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import chalk from 'chalk';
 import figures from 'figures';
 import type { Finding, SkillReport } from '../types/index.js';
-import { parsePatch, type DiffHunk } from '../diff/index.js';
 import { pluralize, type Reporter } from './output/index.js';
 import { ICON_CHECK } from './output/icons.js';
 import { Verbosity } from './output/verbosity.js';
+import { applyUnifiedDiff } from './diff-apply.js';
+
+// Re-export for backward compatibility
+export { applyUnifiedDiff } from './diff-apply.js';
 
 export interface FixResult {
   success: boolean;
@@ -22,79 +24,6 @@ export interface FixSummary {
   skipped: number;
   failed: number;
   results: FixResult[];
-}
-
-/**
- * Apply a unified diff to a file.
- * Hunks are applied in reverse order by line number to prevent line shift issues.
- */
-export function applyUnifiedDiff(filePath: string, diff: string): void {
-  if (!existsSync(filePath)) {
-    throw new Error(`File not found: ${filePath}`);
-  }
-
-  const hunks = parsePatch(diff);
-  if (hunks.length === 0) {
-    throw new Error('No valid hunks found in diff');
-  }
-
-  const content = readFileSync(filePath, 'utf-8');
-  let lines = content.split('\n');
-
-  // Sort hunks by oldStart in descending order to apply from bottom to top
-  const sortedHunks = [...hunks].sort((a, b) => b.oldStart - a.oldStart);
-
-  for (const hunk of sortedHunks) {
-    lines = applyHunk(lines, hunk);
-  }
-
-  writeFileSync(filePath, lines.join('\n'));
-}
-
-/**
- * Apply a single hunk to the file content lines.
- */
-function applyHunk(lines: string[], hunk: DiffHunk): string[] {
-  const result = [...lines];
-
-  // Parse hunk lines into operations
-  const oldLines: string[] = [];
-  const newLines: string[] = [];
-
-  for (const line of hunk.lines) {
-    if (line.startsWith('-')) {
-      oldLines.push(line.slice(1));
-    } else if (line.startsWith('+')) {
-      newLines.push(line.slice(1));
-    } else if (line.startsWith(' ') || line === '') {
-      // Context line - should match in both
-      const contextLine = line.startsWith(' ') ? line.slice(1) : line;
-      oldLines.push(contextLine);
-      newLines.push(contextLine);
-    }
-  }
-
-  // The start index is 0-based (hunk.oldStart is 1-based)
-  const startIndex = hunk.oldStart - 1;
-
-  // Verify the old lines match (context check)
-  for (let i = 0; i < oldLines.length; i++) {
-    const lineIndex = startIndex + i;
-    if (lineIndex >= result.length) {
-      throw new Error(`Hunk context mismatch: line ${lineIndex + 1} doesn't exist`);
-    }
-    if (result[lineIndex] !== oldLines[i]) {
-      throw new Error(
-        `Hunk context mismatch at line ${lineIndex + 1}: ` +
-        `expected "${oldLines[i]}", got "${result[lineIndex]}"`
-      );
-    }
-  }
-
-  // Replace the old lines with new lines
-  result.splice(startIndex, oldLines.length, ...newLines);
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
Extract pure diff application functions (`applyHunk`, `applyUnifiedDiff`) from `fix.ts` into a new `diff-apply.ts` module.

This creates a clear separation between the pure diff logic ("how to apply diffs") and the interactive fix workflow ("what to apply and when"). The pure functions are now independently testable with simple input/output tests.

Also fixes a pre-existing bug where new file diffs using `@@ -0,0 +1,N @@` format would cause `splice()` to operate from the array end instead of the start, due to `oldStart - 1` producing `-1`.

Changes:
- `src/cli/diff-apply.ts` - New module with pure diff application logic
- `src/cli/diff-apply.test.ts` - Dedicated tests including regression test for the bug fix
- `src/cli/fix.ts` - Imports from new module, re-exports for backward compatibility
- `src/cli/fix.test.ts` - Updated imports