### PR TITLE
feat(cli): Graceful CLI interrupt handling on Ctrl+C

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
-import { main, abortController } from './main.js';
+import { main, abortController, interrupted } from './main.js';
+
+let interruptCount = 0;
 
 process.on('SIGINT', () => {
-  // Abort any running SDK queries
+  interruptCount++;
   abortController.abort();
-  process.stderr.write('\n');
-  process.exit(130);
+  interrupted.value = true;
+
+  if (interruptCount > 1) {
+    // Second Ctrl+C: force exit immediately
+    process.exit(130);
+  }
+
+  // First Ctrl+C: let the main flow collect partial results.
+  // The interrupt message is rendered by Ink (TTY) or logPlain (non-TTY)
+  // via the abort signal listener -- no direct stderr writes needed here.
 });
 
 main().catch((error) => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -41,6 +41,12 @@ import { runSync } from './commands/sync.js';
 export const abortController = new AbortController();
 
 /**
+ * Track whether SIGINT was received so the main flow can
+ * render partial results and exit with code 130.
+ */
+export const interrupted = { value: false };
+
+/**
  * Load environment variables from .env files in the given directory.
  * Loads .env first, then .env.local for local overrides.
  */
@@ -143,20 +149,31 @@ async function outputResultsAndHandleFixes(
     console.log(renderTerminalReport(filteredReports, reporter.mode));
   }
 
+  // Show interrupted banner before summary (read live to catch SIGINT during rendering)
+  if (interrupted.value) {
+    reporter.blank();
+    reporter.warning('Interrupted — showing partial results');
+  }
+
   // Show summary (uses filtered reports for display)
   reporter.blank();
   reporter.renderSummary(filteredReports, totalDuration);
 
-  // Handle fixes (uses filtered reports - only show fixes for visible findings)
+  // Handle fixes: --fix (automatic) always runs, interactive prompt is skipped on interrupt
   const fixableFindings = collectFixableFindings(filteredReports);
   if (fixableFindings.length > 0) {
     if (options.fix) {
       const fixSummary = applyAllFixes(fixableFindings);
       renderFixSummary(fixSummary, reporter);
-    } else if (!options.json && reporter.verbosity !== Verbosity.Quiet && reporter.mode.isTTY) {
+    } else if (!interrupted.value && !options.json && reporter.verbosity !== Verbosity.Quiet && reporter.mode.isTTY) {
       const fixSummary = await runInteractiveFixFlow(fixableFindings, reporter);
       renderFixSummary(fixSummary, reporter);
     }
+  }
+
+  // Interrupted takes precedence for exit code
+  if (interrupted.value) {
+    return 130;
   }
 
   // Determine exit code (based on original reports, not filtered)

--- a/src/cli/output/ink-runner.tsx
+++ b/src/cli/output/ink-runner.tsx
@@ -41,6 +41,7 @@ import figures from 'figures';
 interface SkillRunnerProps {
   skills: SkillState[];
   completedItems: SkillState[];
+  interrupted: boolean;
 }
 
 function Spinner(): React.ReactElement {
@@ -156,7 +157,7 @@ function RunningSkill({ skill }: { skill: SkillState }): React.ReactElement {
  * We use a SINGLE Static component to avoid layout conflicts from multiple
  * absolutely-positioned Static containers.
  */
-function SkillRunner({ skills, completedItems }: SkillRunnerProps): React.ReactElement {
+function SkillRunner({ skills, completedItems, interrupted }: SkillRunnerProps): React.ReactElement {
   const running = skills.filter((s) => s.status === 'running');
   const pending = skills.filter((s) => s.status === 'pending');
 
@@ -180,6 +181,11 @@ function SkillRunner({ skills, completedItems }: SkillRunnerProps): React.ReactE
           {ICON_PENDING} {skill.displayName}
         </Text>
       ))}
+      {interrupted && (
+        <Text color="yellow" dimColor>
+          {figures.warning} Interrupted, finishing up... (press Ctrl+C again to force exit)
+        </Text>
+      )}
     </Box>
   );
 }
@@ -209,6 +215,7 @@ export async function runSkillTasksWithInk(
     // No tasks or quiet mode - run without UI
     const results: SkillTaskResult[] = [];
     for (const task of tasks) {
+      if (task.runnerOptions?.abortController?.signal.aborted) break;
       const result = await runSkillTask(task, 5, noopCallbacks);
       results.push(result);
     }
@@ -224,9 +231,12 @@ export async function runSkillTasksWithInk(
   // which can cause layout conflicts due to absolute positioning
   process.stderr.write('\x1b[1mSKILLS\x1b[0m\n');
 
+  // Track interrupt state for rendering in the Ink component
+  let interrupted = false;
+
   // Create Ink instance
   const { rerender, unmount } = render(
-    <SkillRunner skills={skillStates} completedItems={completedItems} />,
+    <SkillRunner skills={skillStates} completedItems={completedItems} interrupted={false} />,
     { stdout: process.stderr }
   );
 
@@ -235,14 +245,25 @@ export async function runSkillTasksWithInk(
   // starting simultaneously) trigger 5 immediate rerenders, which Ink cannot
   // process correctly, resulting in the same line appearing multiple times.
   let updatePending = false;
+  let unmounted = false;
   const updateUI = () => {
-    if (updatePending) return;
+    if (updatePending || unmounted) return;
     updatePending = true;
     setImmediate(() => {
       updatePending = false;
-      rerender(<SkillRunner skills={[...skillStates]} completedItems={[...completedItems]} />);
+      if (unmounted) return;
+      rerender(<SkillRunner skills={[...skillStates]} completedItems={[...completedItems]} interrupted={interrupted} />);
     });
   };
+
+  // Listen for abort signal to show interrupt message in the Ink UI
+  const abortSignal = tasks[0]?.runnerOptions?.abortController?.signal;
+  if (abortSignal && !abortSignal.aborted) {
+    abortSignal.addEventListener('abort', () => {
+      interrupted = true;
+      updateUI();
+    }, { once: true });
+  }
 
   // Callbacks to update state
   const callbacks: SkillProgressCallbacks = {
@@ -346,11 +367,13 @@ export async function runSkillTasksWithInk(
 
   if (concurrency <= 1) {
     for (const task of tasks) {
+      if (task.runnerOptions?.abortController?.signal.aborted) break;
       const result = await runSkillTask(task, fileConcurrency, callbacks);
       results.push(result);
     }
   } else {
     for (let i = 0; i < tasks.length; i += concurrency) {
+      if (tasks[i]?.runnerOptions?.abortController?.signal.aborted) break;
       const batch = tasks.slice(i, i + concurrency);
       const batchResults = await Promise.all(
         batch.map((task) => runSkillTask(task, fileConcurrency, callbacks))
@@ -359,7 +382,9 @@ export async function runSkillTasksWithInk(
     }
   }
 
-  // Cleanup
+  // Cleanup - set unmounted flag before unmount to prevent pending setImmediate
+  // callbacks from calling rerender on the unmounted Ink instance
+  unmounted = true;
   unmount();
 
   return results;

--- a/src/cli/output/tasks.test.ts
+++ b/src/cli/output/tasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createDefaultCallbacks } from './tasks.js';
+import { createDefaultCallbacks, runSkillTasks } from './tasks.js';
 import { Verbosity } from './verbosity.js';
 import type { OutputMode } from './tty.js';
 import type { SkillReport, Finding } from '../../types/index.js';
@@ -304,5 +304,55 @@ describe('createDefaultCallbacks', () => {
       const cb = createDefaultCallbacks(tasks, logMode(), Verbosity.Normal);
       expect(cb.onExtractionResult).toBeUndefined();
     });
+  });
+});
+
+describe('runSkillTasks', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  function makeAbortedTasks(): { tasks: SkillTaskOptions[]; resolveSkill: ReturnType<typeof vi.fn> } {
+    const controller = new AbortController();
+    controller.abort();
+    const resolveSkill = vi.fn();
+    const context = { eventType: 'pull_request', repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' }, repoPath: '/tmp' } as SkillTaskOptions['context'];
+    const tasks: SkillTaskOptions[] = [
+      { name: 'task-a', resolveSkill, context, runnerOptions: { abortController: controller } },
+      { name: 'task-b', resolveSkill, context, runnerOptions: { abortController: controller } },
+    ];
+    return { tasks, resolveSkill };
+  }
+
+  it('skips all tasks when abort signal is already set', async () => {
+    const { tasks, resolveSkill } = makeAbortedTasks();
+
+    const results = await runSkillTasks(tasks, {
+      mode: logMode(),
+      verbosity: Verbosity.Quiet,
+      concurrency: 1,
+    });
+
+    expect(results).toHaveLength(0);
+    expect(resolveSkill).not.toHaveBeenCalled();
+  });
+
+  it('skips remaining batches when abort signal is already set (parallel)', async () => {
+    const { tasks, resolveSkill } = makeAbortedTasks();
+
+    const results = await runSkillTasks(tasks, {
+      mode: logMode(),
+      verbosity: Verbosity.Quiet,
+      concurrency: 4,
+    });
+
+    expect(results).toHaveLength(0);
+    expect(resolveSkill).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -435,17 +435,29 @@ export async function runSkillTasks(
     console.error(chalk.bold('SKILLS'));
   }
 
+  // Listen for abort signal to show interrupt message (non-TTY only; Ink handles TTY)
+  const abortSignal = tasks[0]?.runnerOptions?.abortController?.signal;
+  if (abortSignal && !abortSignal.aborted && !mode.isTTY && verbosity !== Verbosity.Quiet) {
+    abortSignal.addEventListener('abort', () => {
+      logPlain('Interrupted, finishing up... (press Ctrl+C again to force exit)');
+    }, { once: true });
+  }
+
   const results: SkillTaskResult[] = [];
 
   if (concurrency <= 1) {
     // Sequential execution
     for (const task of tasks) {
+      // Skip remaining tasks if abort was signaled (graceful interrupt)
+      if (task.runnerOptions?.abortController?.signal.aborted) break;
       const result = await runSkillTask(task, fileConcurrency, effectiveCallbacks);
       results.push(result);
     }
   } else {
     // Parallel execution with concurrency limit
     for (let i = 0; i < tasks.length; i += concurrency) {
+      // Skip remaining batches if abort was signaled (graceful interrupt)
+      if (tasks[i]?.runnerOptions?.abortController?.signal.aborted) break;
       const batch = tasks.slice(i, i + concurrency);
       const batchResults = await Promise.all(
         batch.map((task) => runSkillTask(task, fileConcurrency, effectiveCallbacks))


### PR DESCRIPTION
When the user presses Ctrl+C during a scan, the process now collects partial
results from completed skills and renders them instead of hard-exiting with
no output.

**Behavior:**
- First Ctrl+C: abort in-progress SDK queries, skip remaining task batches,
  render partial results with "Interrupted" banner, exit 130
- Second Ctrl+C: force immediate exit
- Interactive fix flow is skipped when interrupted (user clearly wants out)

The abort controller was already wired through the SDK and checked at the
hunk level, so running tasks finish quickly after signal. The main change is
removing the immediate `process.exit(130)` and letting the normal output
path run with an interrupted flag.

Closes #109