### PR TITLE
fix(cli): Resolve remote config for --skill flag

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -235,8 +235,11 @@ async function runSkills(
   interface SkillToRun { skill: string; remote?: string; filters: { paths?: string[]; ignorePaths?: string[] } }
   let skillsToRun: SkillToRun[];
   if (options.skill) {
-    // Explicit skill specified via CLI (no remote support or filters in this mode)
-    skillsToRun = [{ skill: options.skill, filters: {} }];
+    // Explicit skill specified via CLI — check config for remote/filters if available
+    const match = config
+      ? resolveSkillConfigs(config, options.model).find((t) => t.skill === options.skill)
+      : undefined;
+    skillsToRun = [{ skill: options.skill, remote: match?.remote, filters: match?.filters ?? {} }];
   } else if (config) {
     // Get skills from matched triggers, preserving remote property and filters
     const resolvedTriggers = resolveSkillConfigs(config, options.model);


### PR DESCRIPTION
When `--skill` is passed via CLI with a target (e.g., `warden origin/main..HEAD --skill code-simplifier`), the `remote` property from `warden.toml` was ignored. This caused "Skill not found" errors for remote skills even after running `warden sync`.

The `runSkills()` path for explicit `--skill` was constructing the skill entry without consulting the config, so remote and filter metadata was always lost. Now it looks up the matching skill config entry to inherit `remote` and `filters`.