### PR TITLE
feat(dedup): Add intra-batch finding consolidation

### DIFF
--- a/src/action/review/poster.test.ts
+++ b/src/action/review/poster.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../output/dedup.js', () => ({
   deduplicateFindings: vi.fn(),
   processDuplicateActions: vi.fn(),
   findingToExistingComment: vi.fn(),
+  consolidateBatchFindings: vi.fn(),
 }));
 
 vi.mock('../../output/renderer.js', () => ({
@@ -18,8 +19,7 @@ vi.mock('../../output/renderer.js', () => ({
   renderFindingsBody: vi.fn().mockReturnValue('rendered findings body'),
 }));
 
-
-import { deduplicateFindings, processDuplicateActions, findingToExistingComment } from '../../output/dedup.js';
+import { deduplicateFindings, processDuplicateActions, findingToExistingComment, consolidateBatchFindings } from '../../output/dedup.js';
 import { renderSkillReport } from '../../output/renderer.js';
 
 describe('postTriggerReview', () => {
@@ -28,6 +28,12 @@ describe('postTriggerReview', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    // Default: consolidation passes findings through unchanged
+    vi.mocked(consolidateBatchFindings).mockImplementation(async (findings) => ({
+      findings,
+      removedCount: 0,
+    }));
   });
 
   const mockOctokit = {
@@ -377,5 +383,101 @@ describe('postTriggerReview', () => {
 
     expect(postResult.posted).toBe(false);
     expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('consolidates batch findings before dedup when multiple findings exist', async () => {
+    const finding1 = createFinding({ id: 'f1', severity: 'high', title: 'Root cause' });
+    const finding2 = createFinding({ id: 'f2', severity: 'medium', title: 'Same root cause, different framing' });
+
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 2 issues',
+        findings: [finding1, finding2],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult({
+        review: {
+          event: 'COMMENT',
+          body: 'Test review',
+          comments: [
+            { path: 'test.ts', line: 10, body: 'Comment 1' },
+            { path: 'test.ts', line: 10, body: 'Comment 2' },
+          ],
+        },
+      }),
+      reportOn: 'info',
+    };
+
+    // Mock consolidation removing the duplicate
+    vi.mocked(consolidateBatchFindings).mockResolvedValue({
+      findings: [finding1],
+      removedCount: 1,
+    });
+
+    vi.mocked(findingToExistingComment).mockReturnValue(createExistingComment());
+
+    // Re-render mock for the consolidated findings
+    vi.mocked(renderSkillReport).mockReturnValue(createRenderResult({
+      review: {
+        event: 'COMMENT',
+        body: 'Re-rendered review',
+        comments: [{ path: 'test.ts', line: 10, body: 'Comment 1' }],
+      },
+    }));
+
+    const ctx: ReviewPostingContext = {
+      result,
+      existingComments: [],
+      apiKey: 'test-key',
+    };
+
+    const postResult = await postTriggerReview(ctx, mockDeps);
+
+    // Consolidation should have been called with both findings
+    expect(consolidateBatchFindings).toHaveBeenCalledWith(
+      [finding1, finding2],
+      { apiKey: 'test-key', hashOnly: false }
+    );
+
+    expect(postResult.posted).toBe(true);
+    // Only the consolidated finding should be posted
+    expect(postResult.newComments).toHaveLength(1);
+  });
+
+  it('skips consolidation when only one finding exists', async () => {
+    const finding = createFinding();
+
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 1 issue',
+        findings: [finding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult({
+        review: {
+          event: 'COMMENT',
+          body: 'Test review',
+          comments: [{ path: 'test.ts', line: 10, body: 'Test comment' }],
+        },
+      }),
+      reportOn: 'info',
+    };
+
+    vi.mocked(findingToExistingComment).mockReturnValue(createExistingComment());
+
+    const ctx: ReviewPostingContext = {
+      result,
+      existingComments: [],
+      apiKey: 'test-key',
+    };
+
+    await postTriggerReview(ctx, mockDeps);
+
+    // Consolidation should NOT be called for a single finding
+    expect(consolidateBatchFindings).not.toHaveBeenCalled();
   });
 });

--- a/src/action/review/poster.ts
+++ b/src/action/review/poster.ts
@@ -15,6 +15,7 @@ import {
   deduplicateFindings,
   processDuplicateActions,
   findingToExistingComment,
+  consolidateBatchFindings,
 } from '../../output/dedup.js';
 import type { ExistingComment, DeduplicateResult } from '../../output/dedup.js';
 import { mergeAuxiliaryUsage } from '../../sdk/usage.js';
@@ -172,12 +173,33 @@ export async function postTriggerReview(
   }
 
   try {
-    // Deduplicate findings against existing comments
+    // Consolidate findings within this batch (intra-batch dedup)
     let findingsToPost = filteredFindings;
+
+    if (findingsToPost.length > 1) {
+      const consolidateResult = await consolidateBatchFindings(findingsToPost, {
+        apiKey,
+        hashOnly: !apiKey,
+      });
+      findingsToPost = consolidateResult.findings;
+
+      if (consolidateResult.usage) {
+        const consolidateAux = { consolidate: consolidateResult.usage };
+        result.report.auxiliaryUsage = mergeAuxiliaryUsage(result.report.auxiliaryUsage, consolidateAux);
+      }
+
+      if (consolidateResult.removedCount > 0) {
+        logAction(
+          `Consolidated ${consolidateResult.removedCount} duplicate findings within batch for ${result.triggerName}`
+        );
+      }
+    }
+
+    // Deduplicate findings against existing comments
     let dedupResult: DeduplicateResult | undefined;
 
-    if (existingComments.length > 0 && filteredFindings.length > 0) {
-      dedupResult = await deduplicateFindings(filteredFindings, existingComments, {
+    if (existingComments.length > 0 && findingsToPost.length > 0) {
+      dedupResult = await deduplicateFindings(findingsToPost, existingComments, {
         apiKey,
         currentSkill: result.report.skill,
       });
@@ -197,7 +219,7 @@ export async function postTriggerReview(
     }
 
     // Process duplicate actions (update Warden comments, add reactions)
-    if (dedupResult && dedupResult.duplicateActions.length > 0) {
+    if (dedupResult?.duplicateActions.length) {
       const actionCounts = await processDuplicateActions(
         octokit,
         context.repository.owner,

--- a/src/output/dedup.test.ts
+++ b/src/output/dedup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   generateContentHash,
   generateMarker,
@@ -9,6 +9,7 @@ import {
   findingToExistingComment,
   parseWardenSkills,
   updateWardenCommentBody,
+  consolidateBatchFindings,
 } from './dedup.js';
 import type { Finding } from '../types/index.js';
 import type { ExistingComment } from './dedup.js';
@@ -466,5 +467,175 @@ ${marker}`;
 
     const parsed = parseMarker(body);
     expect(parsed).toEqual({ path, line, contentHash: hash });
+  });
+});
+
+describe('consolidateBatchFindings', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns single finding unchanged', async () => {
+    const finding: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'SQL Injection',
+      description: 'User input passed to query',
+      location: { path: 'src/db.ts', startLine: 42 },
+    };
+
+    const result = await consolidateBatchFindings([finding]);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toBe(finding);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('returns empty array unchanged', async () => {
+    const result = await consolidateBatchFindings([]);
+    expect(result.findings).toHaveLength(0);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('removes exact hash duplicates within batch', async () => {
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'SQL Injection',
+      description: 'User input passed to query',
+      location: { path: 'src/db.ts', startLine: 42 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'high',
+      title: 'SQL Injection',
+      description: 'User input passed to query',
+      location: { path: 'src/db.ts', startLine: 42 },
+    };
+
+    const result = await consolidateBatchFindings([finding1, finding2], { hashOnly: true });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toBe(finding1);
+    expect(result.removedCount).toBe(1);
+  });
+
+  it('keeps findings with different hashes at same location in hashOnly mode', async () => {
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'allResolved incorrectly reports true',
+      description: 'Resolution API calls may fail',
+      location: { path: 'src/workflow.ts', startLine: 438 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'medium',
+      title: 'commentsResolvedByStale tracks all stale comments',
+      description: 'Not just successfully resolved ones',
+      location: { path: 'src/workflow.ts', startLine: 438 },
+    };
+
+    const result = await consolidateBatchFindings([finding1, finding2], { hashOnly: true });
+    expect(result.findings).toHaveLength(2);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('does not group findings more than 5 lines apart', async () => {
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'Bug A',
+      description: 'Description A',
+      location: { path: 'src/file.ts', startLine: 10 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'high',
+      title: 'Bug B',
+      description: 'Description B',
+      location: { path: 'src/file.ts', startLine: 20 },
+    };
+
+    // In hashOnly mode, these should both pass through since they're different hashes
+    const result = await consolidateBatchFindings([finding1, finding2], { hashOnly: true });
+    expect(result.findings).toHaveLength(2);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('does not group findings in different files', async () => {
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'Same Issue',
+      description: 'Same description',
+      location: { path: 'src/a.ts', startLine: 42 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'high',
+      title: 'Same Issue',
+      description: 'Same description but different file',
+      location: { path: 'src/b.ts', startLine: 42 },
+    };
+
+    const result = await consolidateBatchFindings([finding1, finding2], { hashOnly: true });
+    expect(result.findings).toHaveLength(2);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('skips LLM when no proximity clusters exist', async () => {
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'Bug A',
+      description: 'Description A',
+      location: { path: 'src/file.ts', startLine: 10 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'medium',
+      title: 'Bug B',
+      description: 'Description B',
+      location: { path: 'src/file.ts', startLine: 100 },
+    };
+
+    // Even with an API key, no LLM call should be made since findings are far apart
+    const result = await consolidateBatchFindings([finding1, finding2], { apiKey: 'test-key' });
+    expect(result.findings).toHaveLength(2);
+    expect(result.removedCount).toBe(0);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('groups findings within 5 lines of each other for proximity check', async () => {
+    // This tests the proximity grouping logic (without LLM since no API key)
+    const finding1: Finding = {
+      id: 'f1',
+      severity: 'high',
+      title: 'Bug A at line 10',
+      description: 'Issue at line 10',
+      location: { path: 'src/file.ts', startLine: 10 },
+    };
+
+    const finding2: Finding = {
+      id: 'f2',
+      severity: 'medium',
+      title: 'Bug B at line 13',
+      description: 'Issue at line 13',
+      location: { path: 'src/file.ts', startLine: 13 },
+    };
+
+    // Without API key, LLM phase is skipped, both findings kept
+    const result = await consolidateBatchFindings([finding1, finding2]);
+    expect(result.findings).toHaveLength(2);
+    expect(result.removedCount).toBe(0);
   });
 });

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { Octokit } from '@octokit/rest';
 import { z } from 'zod';
 import type { Finding, UsageStats } from '../types/index.js';
+import { SEVERITY_ORDER, CONFIDENCE_ORDER } from '../types/index.js';
 import { callHaiku } from '../sdk/haiku.js';
 
 /**
@@ -562,6 +563,223 @@ export function findingToExistingComment(finding: Finding, skill?: string): Exis
     isWarden: true,
     skills: skill ? [skill] : [],
   };
+}
+
+// -----------------------------------------------------------------------------
+// Intra-batch consolidation
+// -----------------------------------------------------------------------------
+
+const PROXIMITY_THRESHOLD = 5;
+
+/**
+ * Result from consolidating findings within a single batch.
+ */
+export interface ConsolidateResult {
+  findings: Finding[];
+  removedCount: number;
+  usage?: UsageStats;
+}
+
+/** Schema for LLM consolidation response: groups of finding indices that share a root cause. */
+const ConsolidationGroupsSchema = z.array(
+  z.array(z.number().int())
+);
+
+/**
+ * Get the effective line number for a finding (endLine if present, otherwise startLine).
+ */
+function findingLine(f: Finding): number {
+  return f.location?.endLine ?? f.location?.startLine ?? 0;
+}
+
+/**
+ * Compare two findings by severity (lower = more severe), then confidence, then position.
+ * Returns negative if `a` should be preferred over `b`.
+ */
+function compareFindingPriority(a: Finding, b: Finding): number {
+  const sevDiff = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+  if (sevDiff !== 0) return sevDiff;
+
+  const confA = CONFIDENCE_ORDER[a.confidence ?? 'low'];
+  const confB = CONFIDENCE_ORDER[b.confidence ?? 'low'];
+  const confDiff = confA - confB;
+  if (confDiff !== 0) return confDiff;
+
+  return findingLine(a) - findingLine(b);
+}
+
+/**
+ * Pick the best finding from a group (highest severity, then confidence, then position).
+ */
+function pickWinner(group: Finding[]): Finding {
+  const sorted = [...group].sort(compareFindingPriority);
+  // group is guaranteed to have at least 2 elements by callers
+  const winner = sorted[0];
+  if (!winner) throw new Error('pickWinner called with empty group');
+  return winner;
+}
+
+/**
+ * Group findings by file path, then identify clusters where findings are within
+ * PROXIMITY_THRESHOLD lines of each other. Returns only clusters with 2+ findings.
+ */
+function findProximityClusters(findings: Finding[]): Finding[][] {
+  // Group by file path
+  const byPath = new Map<string, Finding[]>();
+  for (const f of findings) {
+    const path = f.location?.path ?? '';
+    const existing = byPath.get(path);
+    if (existing) {
+      existing.push(f);
+    } else {
+      byPath.set(path, [f]);
+    }
+  }
+
+  const clusters: Finding[][] = [];
+
+  for (const group of byPath.values()) {
+    if (group.length < 2) continue;
+
+    // Sort by line number
+    const sorted = [...group].sort((a, b) => findingLine(a) - findingLine(b));
+
+    // Single-linkage clustering: consecutive findings within PROXIMITY_THRESHOLD
+    // lines of each other are grouped together.
+    const first = sorted[0];
+    if (!first) continue;
+    let current: Finding[] = [first];
+
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
+      if (!prev || !curr) continue;
+
+      if (findingLine(curr) - findingLine(prev) <= PROXIMITY_THRESHOLD) {
+        current.push(curr);
+      } else {
+        if (current.length >= 2) clusters.push(current);
+        current = [curr];
+      }
+    }
+    if (current.length >= 2) clusters.push(current);
+  }
+
+  return clusters;
+}
+
+/**
+ * Consolidate findings within a single batch to remove duplicates that describe
+ * the same root cause. Three-phase approach:
+ *
+ * 1. Hash dedup: remove exact duplicates (same path:line:contentHash)
+ * 2. Proximity grouping: identify clusters of findings within 5 lines of each other
+ * 3. LLM consolidation: ask Haiku to group findings by root cause (only when proximity matches exist)
+ *
+ * For each group, keeps the highest-severity finding.
+ */
+export async function consolidateBatchFindings(
+  findings: Finding[],
+  options: { apiKey?: string; hashOnly?: boolean } = {}
+): Promise<ConsolidateResult> {
+  if (findings.length <= 1) {
+    return { findings, removedCount: 0 };
+  }
+
+  // Phase 1: Hash dedup within batch
+  const seen = new Set<string>();
+  const hashDeduped: Finding[] = [];
+
+  for (const f of findings) {
+    const hash = generateContentHash(f.title, f.description);
+    const line = findingLine(f);
+    const path = f.location?.path ?? '';
+    const key = `${path}:${line}:${hash}`;
+
+    if (seen.has(key)) continue;
+    seen.add(key);
+    hashDeduped.push(f);
+  }
+
+  const hashRemovedCount = findings.length - hashDeduped.length;
+
+  if (hashRemovedCount > 0) {
+    console.log(`Consolidate: ${hashRemovedCount} exact duplicate findings removed within batch`);
+  }
+
+  // Phase 2: Proximity grouping
+  const clusters = findProximityClusters(hashDeduped);
+
+  // If no proximity clusters or hash-only mode or no API key, return hash-deduped results
+  if (clusters.length === 0 || options.hashOnly || !options.apiKey) {
+    return { findings: hashDeduped, removedCount: hashRemovedCount };
+  }
+
+  // Phase 3: LLM consolidation for proximity clusters
+  // Only send clustered findings to the LLM (deduplicated across clusters)
+  const clusteredList = [...new Set(clusters.flat())];
+  const findingsList = clusteredList
+    .map((f, i) => {
+      const line = findingLine(f);
+      const loc = f.location ? `${f.location.path}:${line}` : 'general';
+      return `${i + 1}. [${loc}] (${f.severity}) "${f.title}" - ${f.description}`;
+    })
+    .join('\n');
+
+  const prompt = `You are deduplicating code review findings. Group findings that describe the SAME root cause or bug.
+
+Findings:
+${findingsList}
+
+Return a JSON array of arrays, where each inner array contains the 1-based indices of findings that describe the same root cause.
+Only group findings that are truly about the same underlying issue. Findings about different issues should NOT be grouped even if they're nearby.
+Singletons (findings with no duplicates) should not appear in any group.
+
+Return ONLY the JSON array. Return [] if no findings share a root cause.`;
+
+  const result = await callHaiku({
+    apiKey: options.apiKey,
+    prompt,
+    schema: ConsolidationGroupsSchema,
+    maxTokens: 512,
+  });
+
+  if (!result.success) {
+    console.warn(`LLM batch consolidation failed, keeping all findings: ${result.error}`);
+    return { findings: hashDeduped, removedCount: hashRemovedCount, usage: result.usage };
+  }
+
+  // Process LLM groups: for each group, keep the winner and drop the rest
+  const droppedFindings = new Set<Finding>();
+
+  for (const group of result.data) {
+    if (group.length < 2) continue;
+
+    // Convert 1-based indices to findings
+    const groupFindings = group
+      .map((idx) => clusteredList[idx - 1])
+      .filter((f): f is Finding => f !== undefined);
+
+    if (groupFindings.length < 2) continue;
+
+    const winner = pickWinner(groupFindings);
+    for (const f of groupFindings) {
+      if (f !== winner) {
+        droppedFindings.add(f);
+      }
+    }
+  }
+
+  if (droppedFindings.size === 0) {
+    return { findings: hashDeduped, removedCount: hashRemovedCount, usage: result.usage };
+  }
+
+  const consolidated = hashDeduped.filter((f) => !droppedFindings.has(f));
+  const totalRemoved = hashRemovedCount + droppedFindings.size;
+
+  console.log(`Consolidate: ${droppedFindings.size} findings merged by LLM (same root cause)`);
+
+  return { findings: consolidated, removedCount: totalRemoved, usage: result.usage };
 }
 
 /**


### PR DESCRIPTION
Consolidate findings within the same batch before they reach the cross-trigger dedup pipeline.

The existing `deduplicateFindings()` only compares new findings against already-posted comments. When a skill produces two findings about the same root cause (same file, nearby lines, different wording), both pass through and get posted together. This happened on PR #134 where `notseer` posted two comments on `pr-workflow.ts:438` about the same bug framed differently.

New `consolidateBatchFindings()` runs a three-phase approach:
1. **Hash dedup** (free): removes exact duplicates within the batch (same path:line:contentHash)
2. **Proximity grouping** (free): clusters remaining findings by file, identifying groups within 5 lines of each other. If no clusters have 2+ findings, returns early with no LLM call
3. **LLM consolidation** (only when proximity matches exist): sends clustered findings to Haiku to group by root cause, keeps the highest-severity finding per group (breaking ties by confidence, then line position)

Integrated into `postTriggerReview()` after `reportOn` severity filtering but before `deduplicateFindings()`, so original findings stay untouched for `failOn` evaluation. Graceful fallback: if the LLM call fails, all findings are kept (same pattern as existing semantic dedup).