### PR TITLE
feat(output): Default to COMMENT instead of REQUEST_CHANGES on PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
   request-changes:
     description: 'Whether to use REQUEST_CHANGES review event when findings exceed fail-on threshold'
     required: false
-    default: 'true'
+    default: 'false'
   fail-check:
     description: 'Whether to fail the check run when findings exceed fail-on threshold'
     required: false

--- a/docs/src/pages/config.astro
+++ b/docs/src/pages/config.astro
@@ -128,7 +128,7 @@ actions = ["opened", "synchronize"]`}
     <dt>reportOnSuccess</dt>
     <dd>Post comment when no findings. Default: <code>false</code></dd>
     <dt>requestChanges</dt>
-    <dd>Use REQUEST_CHANGES review event when findings exceed <code>failOn</code>. Default: <code>true</code></dd>
+    <dd>Use REQUEST_CHANGES review event when findings exceed <code>failOn</code>. Default: <code>false</code></dd>
     <dt>failCheck</dt>
     <dd>Fail the check run when findings exceed <code>failOn</code>. Default: <code>false</code></dd>
   </dl>
@@ -165,7 +165,7 @@ maxFindings = 20`}
     <dt>reportOnSuccess</dt>
     <dd>Post comment when no findings. Default: <code>false</code></dd>
     <dt>requestChanges</dt>
-    <dd>Default REQUEST_CHANGES behavior. Default: <code>true</code></dd>
+    <dd>Default REQUEST_CHANGES behavior. Default: <code>false</code></dd>
     <dt>failCheck</dt>
     <dd>Default check failure behavior. Default: <code>false</code></dd>
     <dt>ignorePaths</dt>
@@ -181,7 +181,7 @@ model = "claude-sonnet-4-20250514"
 maxTurns = 30
 failOn = "high"
 reportOn = "medium"
-requestChanges = true
+requestChanges = false
 failCheck = false
 ignorePaths = ["**/vendor/**", "**/node_modules/**"]`}
       lang="toml"
@@ -432,7 +432,7 @@ jobs:
     <dt>max-findings</dt>
     <dd>Maximum findings to report. Default: <code>50</code></dd>
     <dt>request-changes</dt>
-    <dd>Whether to request changes on PR reviews. Default: <code>true</code></dd>
+    <dd>Whether to request changes on PR reviews. Default: <code>false</code></dd>
     <dt>fail-check</dt>
     <dd>Whether to fail the check run. Default: <code>false</code></dd>
     <dt>parallel</dt>

--- a/docs/src/pages/guide.astro
+++ b/docs/src/pages/guide.astro
@@ -340,7 +340,7 @@ actions = ["opened", "synchronize"]`}
     <Code
       code={`[defaults]
 failOn = "high"          # Threshold for blocking findings
-requestChanges = true    # Request changes on the PR
+requestChanges = false   # Only comment, don't request changes
 failCheck = false        # Fail the check run
 reportOn = "medium"      # Report findings at medium and above`}
       lang="toml"

--- a/src/action/review/poster.test.ts
+++ b/src/action/review/poster.test.ts
@@ -236,6 +236,7 @@ describe('postTriggerReview', () => {
       }),
       reportOn: 'info',
       failOn: 'high',
+      requestChanges: true,
     };
 
     const existingComment = createExistingComment({ isWarden: true });

--- a/src/action/review/poster.ts
+++ b/src/action/review/poster.ts
@@ -240,7 +240,7 @@ export async function postTriggerReview(
     }
 
     // Check if failOn threshold is met (even if all findings deduplicated, we still need REQUEST_CHANGES)
-    const useRequestChanges = result.requestChanges ?? true;
+    const useRequestChanges = result.requestChanges ?? false;
     const needsRequestChanges = useRequestChanges && result.failOn && shouldFail(result.report, result.failOn);
 
     // Only post if we have non-duplicate findings, reportOnSuccess, or REQUEST_CHANGES needed

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -527,7 +527,7 @@ describe('runPRWorkflow', () => {
 
       await runPRWorkflow(
         mockOctokit,
-        createDefaultInputs({ failOn: 'high' }),
+        createDefaultInputs({ failOn: 'high', requestChanges: true }),
         'pull_request',
         EVENT_PAYLOAD_PATH,
         FIXTURES_DIR

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -476,7 +476,7 @@ async function finalizeWorkflow(
   // Requires: all triggers succeeded, current run would not request changes,
   // and at least one trigger has an active failOn (prevents accidental dismiss when config changes).
   const wouldRequestChanges = results.some(
-    (r) => r.failOn && r.failOn !== 'off' && (r.requestChanges ?? true) &&
+    (r) => r.failOn && r.failOn !== 'off' && (r.requestChanges ?? false) &&
       r.report && shouldFail(r.report, r.failOn)
   );
   const hasActiveFailOn = results.some((r) => r.failOn && r.failOn !== 'off');

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -154,7 +154,7 @@ export const DefaultsSchema = z.object({
   maxFindings: z.number().int().positive().optional(),
   /** Report even when there are no findings (default: false) */
   reportOnSuccess: z.boolean().optional(),
-  /** Use REQUEST_CHANGES review event when findings exceed failOn. Default: true */
+  /** Use REQUEST_CHANGES review event when findings exceed failOn. Default: false */
   requestChanges: z.boolean().optional(),
   /** Fail the check run when findings exceed failOn. Default: false */
   failCheck: z.boolean().optional(),

--- a/src/output/renderer.test.ts
+++ b/src/output/renderer.test.ts
@@ -372,7 +372,7 @@ describe('renderSkillReport', () => {
         ],
       };
 
-      const result = renderSkillReport(report, { failOn: 'critical' });
+      const result = renderSkillReport(report, { failOn: 'critical', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
     });
 
@@ -408,7 +408,7 @@ describe('renderSkillReport', () => {
         ],
       };
 
-      const result = renderSkillReport(report, { failOn: 'high' });
+      const result = renderSkillReport(report, { failOn: 'high', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
     });
 
@@ -426,7 +426,7 @@ describe('renderSkillReport', () => {
         ],
       };
 
-      const result = renderSkillReport(report, { failOn: 'high' });
+      const result = renderSkillReport(report, { failOn: 'high', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
     });
 
@@ -469,7 +469,7 @@ describe('renderSkillReport', () => {
         ],
       };
 
-      const result = renderSkillReport(report, { failOn: 'high' });
+      const result = renderSkillReport(report, { failOn: 'high', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
     });
 
@@ -496,7 +496,7 @@ describe('renderSkillReport', () => {
 
       // reportOn=high filters out low finding from comments
       // failOn=critical causes REQUEST_CHANGES because of critical finding
-      const result = renderSkillReport(report, { failOn: 'critical', reportOn: 'high' });
+      const result = renderSkillReport(report, { failOn: 'critical', reportOn: 'high', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
       expect(result.review!.comments).toHaveLength(1);
       expect(result.review!.comments[0]!.body).toContain('Critical Issue');
@@ -515,7 +515,7 @@ describe('renderSkillReport', () => {
         ],
       };
 
-      const result = renderSkillReport(report, { failOn: 'critical' });
+      const result = renderSkillReport(report, { failOn: 'critical', requestChanges: true });
       expect(result.review).toBeDefined();
       expect(result.review!.event).toBe('REQUEST_CHANGES');
       expect(result.review!.comments).toHaveLength(0);
@@ -541,7 +541,7 @@ describe('renderSkillReport', () => {
       // reportOn=critical filters out high finding from comments (no comments posted)
       // failOn=high should still cause REQUEST_CHANGES because high finding meets threshold
       // Per spec: "a finding can block the PR but be filtered from comments"
-      const result = renderSkillReport(report, { failOn: 'high', reportOn: 'critical' });
+      const result = renderSkillReport(report, { failOn: 'high', reportOn: 'critical', requestChanges: true });
       expect(result.review).toBeDefined();
       expect(result.review!.event).toBe('REQUEST_CHANGES');
       expect(result.review!.comments).toHaveLength(0);
@@ -600,7 +600,7 @@ describe('renderSkillReport', () => {
 
       // Without allFindings, would use report.findings (only low) -> COMMENT
       // With allFindings (includes critical), should be REQUEST_CHANGES
-      const result = renderSkillReport(report, { failOn: 'high', allFindings });
+      const result = renderSkillReport(report, { failOn: 'high', allFindings, requestChanges: true });
       expect(result.review).toBeDefined();
       expect(result.review!.event).toBe('REQUEST_CHANGES');
       // Comments only include the low finding (what's in report.findings)
@@ -644,7 +644,7 @@ describe('renderSkillReport', () => {
       expect(result.review!.event).toBe('REQUEST_CHANGES');
     });
 
-    it('defaults to REQUEST_CHANGES when requestChanges is undefined and threshold is met', () => {
+    it('defaults to COMMENT when requestChanges is undefined even if threshold is met', () => {
       const report: SkillReport = {
         ...baseReport,
         findings: [
@@ -659,7 +659,7 @@ describe('renderSkillReport', () => {
       };
 
       const result = renderSkillReport(report, { failOn: 'high' });
-      expect(result.review!.event).toBe('REQUEST_CHANGES');
+      expect(result.review!.event).toBe('COMMENT');
     });
 
     it('REQUEST_CHANGES when some findings are filtered by reportOn but others meet both thresholds', () => {
@@ -692,7 +692,7 @@ describe('renderSkillReport', () => {
 
       // reportOn=critical filters to only critical finding
       // failOn=high: critical and high findings both meet threshold -> REQUEST_CHANGES
-      const result = renderSkillReport(report, { failOn: 'high', reportOn: 'critical' });
+      const result = renderSkillReport(report, { failOn: 'high', reportOn: 'critical', requestChanges: true });
       expect(result.review!.event).toBe('REQUEST_CHANGES');
       expect(result.review!.comments).toHaveLength(1);
       expect(result.review!.comments[0]!.body).toContain('Critical Issue');

--- a/src/output/renderer.ts
+++ b/src/output/renderer.ts
@@ -129,7 +129,7 @@ function determineReviewEvent(
   failOn?: SeverityThreshold,
   requestChanges?: boolean,
 ): GitHubReview['event'] {
-  if (requestChanges === false) return 'COMMENT';
+  if (!requestChanges) return 'COMMENT';
 
   const hasActiveThreshold = failOn && failOn !== 'off';
 

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -32,7 +32,7 @@ export interface RenderOptions {
   reportOn?: SeverityThreshold;
   /** Fail threshold - determines REQUEST_CHANGES vs COMMENT for PR reviews */
   failOn?: SeverityThreshold;
-  /** Whether to use REQUEST_CHANGES when failOn threshold is met. Default: true */
+  /** Whether to use REQUEST_CHANGES when failOn threshold is met. Default: false */
   requestChanges?: boolean;
   /** URL to the GitHub Check run containing the full report (used when findings are filtered) */
   checkRunUrl?: string;


### PR DESCRIPTION
Findings are not guaranteed to be valid, so requesting changes by default
is too aggressive. This flips the default `requestChanges` from `true` to
`false` across all code paths, the GitHub Action input, and documentation.

Users can still opt in explicitly with `requestChanges = true` in
`warden.toml` or `request-changes: true` in the action input.

Changes span the renderer, action poster, PR workflow dismissal logic,
`action.yml` default, config schema docs, and the docs site.