### PR TITLE
fix(telemetry): Improve OTel GenAI semantic convention compliance

### DIFF
--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -98,7 +98,8 @@ async function executeQuery(
   systemPrompt: string,
   userPrompt: string,
   repoPath: string,
-  options: SkillRunnerOptions
+  options: SkillRunnerOptions,
+  skillName: string
 ): Promise<QueryExecutionResult> {
   const { maxTurns = 50, model, abortController, pathToClaudeCodeExecutable } = options;
   const modelId = model ?? 'unknown';
@@ -106,14 +107,13 @@ async function executeQuery(
   return Sentry.startSpan(
     {
       op: 'gen_ai.invoke_agent',
-      name: `invoke_agent ${modelId}`,
+      name: `invoke_agent ${skillName}`,
       attributes: {
         'gen_ai.operation.name': 'invoke_agent',
-        'gen_ai.system': 'anthropic',
         'gen_ai.provider.name': 'anthropic',
-        'gen_ai.agent.name': modelId,
+        'gen_ai.agent.name': skillName,
         'gen_ai.request.model': modelId,
-        'gen_ai.request.max_turns': maxTurns,
+        'warden.request.max_turns': maxTurns,
       },
     },
     async (span) => {
@@ -196,7 +196,7 @@ async function executeQuery(
 
         // Optional SDK metadata attributes
         const optionalAttrs: Record<string, string | number | undefined> = {
-          'sdk.session_id': resultMessage.session_id,
+          'gen_ai.conversation.id': resultMessage.session_id,
           'sdk.duration_ms': resultMessage.duration_ms,
           'sdk.duration_api_ms': resultMessage.duration_api_ms,
           'sdk.num_turns': resultMessage.num_turns,
@@ -273,7 +273,7 @@ async function analyzeHunk(
         }
 
         try {
-          const { result: resultMessage, authError } = await executeQuery(systemPrompt, userPrompt, repoPath, options);
+          const { result: resultMessage, authError } = await executeQuery(systemPrompt, userPrompt, repoPath, options, skill.name);
 
           // Check for authentication errors from auth_status messages
           // auth_status errors are always auth-related - throw immediately

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -2,6 +2,8 @@ import Anthropic from '@anthropic-ai/sdk';
 import { customAlphabet } from 'nanoid';
 import { FindingSchema } from '../types/index.js';
 import type { Finding, UsageStats } from '../types/index.js';
+import { Sentry } from '../sentry.js';
+import { HAIKU_MODEL, setGenAiResponseAttrs } from './haiku.js';
 import { apiUsageToStats } from './pricing.js';
 
 /** Pattern to match the start of findings JSON (allows whitespace after brace) */
@@ -125,6 +127,9 @@ export function extractFindingsJson(rawText: string): ExtractFindingsResult {
 /** Max characters to send to LLM fallback (roughly ~8k tokens) */
 const LLM_FALLBACK_MAX_CHARS = 32000;
 
+/** Max tokens for LLM fallback responses */
+const LLM_FALLBACK_MAX_TOKENS = 4096;
+
 /** Timeout for LLM fallback API calls in milliseconds */
 const LLM_FALLBACK_TIMEOUT_MS = 30000;
 
@@ -161,7 +166,7 @@ export function truncateForLLMFallback(rawText: string, maxChars: number): strin
 
 /**
  * Extract findings from malformed output using LLM as a fallback.
- * Uses claude-haiku-4-5 for lightweight, fast extraction.
+ * Uses Haiku for lightweight, fast extraction.
  */
 export async function extractFindingsWithLLM(
   rawText: string,
@@ -187,47 +192,62 @@ export async function extractFindingsWithLLM(
   // Truncate input while preserving JSON boundaries
   const truncatedText = truncateForLLMFallback(rawText, LLM_FALLBACK_MAX_CHARS);
 
-  try {
-    const client = new Anthropic({ apiKey, timeout: LLM_FALLBACK_TIMEOUT_MS });
-    const response = await client.messages.create({
-      model: 'claude-haiku-4-5',
-      max_tokens: 4096,
-      messages: [
-        {
-          role: 'user',
-          content: `Extract the findings JSON from this model output.
+  return Sentry.startSpan(
+    {
+      op: 'gen_ai.chat',
+      name: `chat ${HAIKU_MODEL}`,
+      attributes: {
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.provider.name': 'anthropic',
+        'gen_ai.request.model': HAIKU_MODEL,
+        'gen_ai.request.max_tokens': LLM_FALLBACK_MAX_TOKENS,
+      },
+    },
+    async (span) => {
+      try {
+        const client = new Anthropic({ apiKey, timeout: LLM_FALLBACK_TIMEOUT_MS });
+        const response = await client.messages.create({
+          model: HAIKU_MODEL,
+          max_tokens: LLM_FALLBACK_MAX_TOKENS,
+          messages: [
+            {
+              role: 'user',
+              content: `Extract the findings JSON from this model output.
 Return ONLY valid JSON in format: {"findings": [...]}
 If no findings exist, return: {"findings": []}
 
 Model output:
 ${truncatedText}`,
-        },
-      ],
-    });
+            },
+          ],
+        });
 
-    const usage = apiUsageToStats('claude-haiku-4-5', response.usage);
+        const usage = apiUsageToStats(HAIKU_MODEL, response.usage);
+        setGenAiResponseAttrs(span, response.usage, response.stop_reason);
 
-    const content = response.content[0];
-    if (!content || content.type !== 'text') {
-      return {
-        success: false,
-        error: 'llm_unexpected_response',
-        preview: rawText.slice(0, 200),
-        usage,
-      };
-    }
+        const content = response.content[0];
+        if (!content || content.type !== 'text') {
+          return {
+            success: false,
+            error: 'llm_unexpected_response',
+            preview: rawText.slice(0, 200),
+            usage,
+          };
+        }
 
-    // Parse the LLM response as JSON
-    const result = extractFindingsJson(content.text);
-    return { ...result, usage };
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      success: false,
-      error: `llm_extraction_failed: ${errorMessage}`,
-      preview: rawText.slice(0, 200),
-    };
-  }
+        // Parse the LLM response as JSON
+        const result = extractFindingsJson(content.text);
+        return { ...result, usage };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          error: `llm_extraction_failed: ${errorMessage}`,
+          preview: rawText.slice(0, 200),
+        };
+      }
+    },
+  );
 }
 
 /** Unambiguous uppercase alphanumeric alphabet (no O/0, I/1). */

--- a/src/sdk/haiku.ts
+++ b/src/sdk/haiku.ts
@@ -1,12 +1,29 @@
 import Anthropic from '@anthropic-ai/sdk';
+import type { Span } from '@sentry/node';
 import type { z } from 'zod';
 import type { UsageStats } from '../types/index.js';
+import { Sentry } from '../sentry.js';
 import { apiUsageToStats } from './pricing.js';
 import { aggregateUsage, emptyUsage } from './usage.js';
 
-const HAIKU_MODEL = 'claude-haiku-4-5';
+export const HAIKU_MODEL = 'claude-haiku-4-5';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Set standard gen_ai response attributes on a Sentry span.
+ */
+export function setGenAiResponseAttrs(
+  span: Span,
+  usage: { input_tokens: number; output_tokens: number },
+  stopReason?: string | null
+): void {
+  span.setAttribute('gen_ai.usage.input_tokens', usage.input_tokens);
+  span.setAttribute('gen_ai.usage.output_tokens', usage.output_tokens);
+  if (stopReason) {
+    span.setAttribute('gen_ai.response.finish_reasons', [stopReason]);
+  }
+}
 
 /**
  * Strip markdown code fences from text.
@@ -103,51 +120,66 @@ function inferPrefill(schema: z.ZodType): string | undefined {
 export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuResult<T>> {
   const { apiKey, prompt, schema, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS } = options;
 
-  const client = new Anthropic({ apiKey, timeout });
-  const prefill = inferPrefill(schema);
+  return Sentry.startSpan(
+    {
+      op: 'gen_ai.chat',
+      name: `chat ${HAIKU_MODEL}`,
+      attributes: {
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.provider.name': 'anthropic',
+        'gen_ai.request.model': HAIKU_MODEL,
+        'gen_ai.request.max_tokens': maxTokens,
+      },
+    },
+    async (span) => {
+      const client = new Anthropic({ apiKey, timeout });
+      const prefill = inferPrefill(schema);
 
-  const messages: Anthropic.MessageParam[] = [
-    { role: 'user', content: prompt },
-  ];
-  if (prefill) {
-    messages.push({ role: 'assistant', content: prefill });
-  }
+      const messages: Anthropic.MessageParam[] = [
+        { role: 'user', content: prompt },
+      ];
+      if (prefill) {
+        messages.push({ role: 'assistant', content: prefill });
+      }
 
-  try {
-    const response = await client.messages.create({
-      model: HAIKU_MODEL,
-      max_tokens: maxTokens,
-      messages,
-    });
+      try {
+        const response = await client.messages.create({
+          model: HAIKU_MODEL,
+          max_tokens: maxTokens,
+          messages,
+        });
 
-    const usage = apiUsageToStats(HAIKU_MODEL, response.usage);
+        const usage = apiUsageToStats(HAIKU_MODEL, response.usage);
+        setGenAiResponseAttrs(span, response.usage, response.stop_reason);
 
-    const content = response.content[0];
-    if (!content || content.type !== 'text') {
-      return { success: false, error: 'Empty response from model', usage };
-    }
+        const content = response.content[0];
+        if (!content || content.type !== 'text') {
+          return { success: false, error: 'Empty response from model', usage };
+        }
 
-    let fullText = content.text;
-    if (prefill) {
-      fullText = prefill + fullText;
-    }
-    const jsonStr = extractJson(fullText);
-    if (!jsonStr) {
-      return { success: false, error: 'No JSON found in response', usage };
-    }
+        let fullText = content.text;
+        if (prefill) {
+          fullText = prefill + fullText;
+        }
+        const jsonStr = extractJson(fullText);
+        if (!jsonStr) {
+          return { success: false, error: 'No JSON found in response', usage };
+        }
 
-    const parsed = JSON.parse(jsonStr);
-    const validated = schema.safeParse(parsed);
+        const parsed = JSON.parse(jsonStr);
+        const validated = schema.safeParse(parsed);
 
-    if (!validated.success) {
-      return { success: false, error: `Validation failed: ${validated.error.message}`, usage };
-    }
+        if (!validated.success) {
+          return { success: false, error: `Validation failed: ${validated.error.message}`, usage };
+        }
 
-    return { success: true, data: validated.data, usage };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { success: false, error: message, usage: emptyUsage() };
-  }
+        return { success: true, data: validated.data, usage };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { success: false, error: message, usage: emptyUsage() };
+      }
+    },
+  );
 }
 
 /**
@@ -181,85 +213,128 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
     timeout = DEFAULT_TIMEOUT_MS,
   } = options;
 
-  const client = new Anthropic({ apiKey, timeout });
+  return Sentry.startSpan(
+    {
+      op: 'gen_ai.chat',
+      name: `chat ${HAIKU_MODEL}`,
+      attributes: {
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.provider.name': 'anthropic',
+        'gen_ai.request.model': HAIKU_MODEL,
+        'gen_ai.request.max_tokens': maxTokens,
+      },
+    },
+    async (span) => {
+      const client = new Anthropic({ apiKey, timeout });
 
-  // No prefill for tool-use loops: prefill biases the model to output JSON
-  // immediately instead of calling tools to gather information first.
-  const messages: Anthropic.MessageParam[] = [
-    { role: 'user', content: prompt },
-  ];
+      // No prefill for tool-use loops: prefill biases the model to output JSON
+      // immediately instead of calling tools to gather information first.
+      const messages: Anthropic.MessageParam[] = [
+        { role: 'user', content: prompt },
+      ];
 
-  const usages: UsageStats[] = [];
+      const usages: UsageStats[] = [];
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
 
-  for (let iteration = 0; iteration < maxIterations; iteration++) {
-    let response: Anthropic.Message;
-    try {
-      response = await client.messages.create({
-        model: HAIKU_MODEL,
-        max_tokens: maxTokens,
-        messages,
-        tools,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return { success: false, error: message, usage: usages.length > 0 ? aggregateUsage(usages) : emptyUsage() };
-    }
-
-    usages.push(apiUsageToStats(HAIKU_MODEL, response.usage));
-
-    // Handle tool use
-    if (response.stop_reason === 'tool_use') {
-      const toolUseBlocks = response.content.filter(
-        (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
-      );
-
-      if (toolUseBlocks.length === 0) {
-        return { success: false, error: 'Tool use indicated but no tool calls found', usage: aggregateUsage(usages) };
+      function setFinalSpanAttrs(stopReason?: string | null): void {
+        setGenAiResponseAttrs(span, { input_tokens: totalInputTokens, output_tokens: totalOutputTokens }, stopReason);
       }
 
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
-      for (const block of toolUseBlocks) {
+      function currentUsage(): UsageStats {
+        return usages.length > 0 ? aggregateUsage(usages) : emptyUsage();
+      }
+
+      for (let iteration = 0; iteration < maxIterations; iteration++) {
+        let response: Anthropic.Message;
         try {
-          const result = await executeTool(block.name, block.input as Record<string, unknown>);
-          toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: result });
+          response = await client.messages.create({
+            model: HAIKU_MODEL,
+            max_tokens: maxTokens,
+            messages,
+            tools,
+          });
         } catch (error) {
-          const errMsg = error instanceof Error ? error.message : String(error);
-          toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: errMsg, is_error: true });
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, error: message, usage: currentUsage() };
         }
+
+        usages.push(apiUsageToStats(HAIKU_MODEL, response.usage));
+        totalInputTokens += response.usage.input_tokens;
+        totalOutputTokens += response.usage.output_tokens;
+
+        // Handle tool use
+        if (response.stop_reason === 'tool_use') {
+          const toolUseBlocks = response.content.filter(
+            (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
+          );
+
+          if (toolUseBlocks.length === 0) {
+            return { success: false, error: 'Tool use indicated but no tool calls found', usage: aggregateUsage(usages) };
+          }
+
+          const toolResults: Anthropic.ToolResultBlockParam[] = [];
+          for (const block of toolUseBlocks) {
+            await Sentry.startSpan(
+              {
+                op: 'gen_ai.execute_tool',
+                name: `execute_tool ${block.name}`,
+                attributes: {
+                  'gen_ai.operation.name': 'execute_tool',
+                  'gen_ai.tool.name': block.name,
+                },
+              },
+              async () => {
+                try {
+                  const result = await executeTool(block.name, block.input as Record<string, unknown>);
+                  toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: result });
+                } catch (error) {
+                  const errMsg = error instanceof Error ? error.message : String(error);
+                  toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: errMsg, is_error: true });
+                }
+              },
+            );
+          }
+
+          messages.push({ role: 'assistant', content: response.content });
+          messages.push({ role: 'user', content: toolResults });
+          continue;
+        }
+
+        // Final response - set span attributes and extract JSON verdict
+        setFinalSpanAttrs(response.stop_reason);
+
+        if (response.stop_reason !== 'end_turn' && response.stop_reason !== 'max_tokens') {
+          return { success: false, error: `Unexpected stop reason: ${response.stop_reason}`, usage: aggregateUsage(usages) };
+        }
+
+        const textBlock = response.content.find(
+          (b): b is Anthropic.TextBlock => b.type === 'text'
+        );
+
+        if (!textBlock) {
+          return { success: false, error: 'No text in final response', usage: aggregateUsage(usages) };
+        }
+
+        const jsonStr = extractJson(textBlock.text);
+        if (!jsonStr) {
+          return { success: false, error: 'No JSON found in response', usage: aggregateUsage(usages) };
+        }
+
+        const parsed = JSON.parse(jsonStr);
+        const validated = schema.safeParse(parsed);
+
+        if (!validated.success) {
+          return { success: false, error: `Validation failed: ${validated.error.message}`, usage: aggregateUsage(usages) };
+        }
+
+        return { success: true, data: validated.data, usage: aggregateUsage(usages) };
       }
 
-      messages.push({ role: 'assistant', content: response.content });
-      messages.push({ role: 'user', content: toolResults });
-      continue;
-    }
+      // Max iterations exceeded - still record usage on span
+      setFinalSpanAttrs();
 
-    // Final response - extract JSON verdict
-    if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
-      const textBlock = response.content.find(
-        (b): b is Anthropic.TextBlock => b.type === 'text'
-      );
-
-      if (!textBlock) {
-        return { success: false, error: 'No text in final response', usage: aggregateUsage(usages) };
-      }
-
-      const jsonStr = extractJson(textBlock.text);
-      if (!jsonStr) {
-        return { success: false, error: 'No JSON found in response', usage: aggregateUsage(usages) };
-      }
-
-      const parsed = JSON.parse(jsonStr);
-      const validated = schema.safeParse(parsed);
-
-      if (!validated.success) {
-        return { success: false, error: `Validation failed: ${validated.error.message}`, usage: aggregateUsage(usages) };
-      }
-
-      return { success: true, data: validated.data, usage: aggregateUsage(usages) };
-    }
-
-    return { success: false, error: `Unexpected stop reason: ${response.stop_reason}`, usage: aggregateUsage(usages) };
-  }
-
-  return { success: false, error: 'Max tool iterations exceeded', usage: aggregateUsage(usages) };
+      return { success: false, error: 'Max tool iterations exceeded', usage: aggregateUsage(usages) };
+    },
+  );
 }


### PR DESCRIPTION
Aligns Warden's trace instrumentation with the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) and [agent span conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/).

The `gen_ai.invoke_agent` span had several attribute issues: `gen_ai.agent.name` was set to the model ID instead of the skill name, the deprecated `gen_ai.system` attribute was still present alongside `gen_ai.provider.name`, and `gen_ai.request.max_turns` isn't in the OTel spec. Additionally, direct Anthropic API calls (Haiku extraction fallback, fix evaluation) had no semantic spans, making them invisible in traces beyond auto-instrumented HTTP calls.

**Attribute fixes on `gen_ai.invoke_agent` span (`analyze.ts`):**
- `gen_ai.agent.name` uses skill name instead of model ID
- Removed deprecated `gen_ai.system` (redundant with `gen_ai.provider.name`)
- Renamed `gen_ai.request.max_turns` → `warden.request.max_turns`
- Renamed `sdk.session_id` → `gen_ai.conversation.id` (standard)

**New spans (`haiku.ts`, `extract.ts`):**
- `gen_ai.chat` parent spans wrapping `callHaiku()` and `callHaikuWithTools()`
- `gen_ai.execute_tool` child spans for each tool execution in multi-turn loops
- `gen_ai.chat` span wrapping the LLM extraction fallback API call

Also extracted a `setGenAiResponseAttrs` helper and exported `HAIKU_MODEL` to reduce duplication across the three files.