### PR TITLE
feat(telemetry): Add per-turn tracing for Claude Code SDK agent calls

### DIFF
--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -49,8 +49,13 @@ workflow.run "review pull_request"
     skill.run "run {skill}"                    ← existing
       skill.analyze_file "analyze file {path}"
         skill.analyze_hunk "analyze hunk {path}:{range}"
-          gen_ai.invoke_agent "invoke_agent {model}"   ← Sentry AI dashboard
-            (auto: anthropic chat spans via integration)
+          gen_ai.invoke_agent "invoke_agent {skill}"   ← Sentry AI dashboard
+            gen_ai.chat "chat {skill} turn 1"          ← per-turn from SDK stream
+              gen_ai.execute_tool "Read"                ← tool use from SDK stream
+              gen_ai.execute_tool "Grep"
+            gen_ai.chat "chat {skill} turn 2"
+            gen_ai.chat "chat {skill} turn 3"
+              gen_ai.execute_tool "Read"
   workflow.review "post reviews"
   workflow.resolve "resolve stale comments"
     fix_eval.run "evaluate fix attempts"
@@ -63,7 +68,9 @@ workflow.run "review pull_request"
 | `op` | Scope | Notes |
 |------|-------|-------|
 | `gen_ai.invoke_agent` | Claude Code SDK subprocess | Required prefix for Sentry AI Agents dashboard |
-| `gen_ai.chat` | Direct Anthropic API calls | Auto-created by `anthropicAIIntegration` |
+| `gen_ai.chat` | Per-turn API call within SDK | Created from `SDKAssistantMessage` stream events; child of `invoke_agent` |
+| `gen_ai.execute_tool` | Tool execution within a turn | Created from `SDKAssistantMessage` tool_use blocks + `SDKToolProgressMessage`; child of `gen_ai.chat` |
+| `gen_ai.chat` (auto) | Direct Anthropic API calls | Auto-created by `anthropicAIIntegration` for non-SDK calls |
 | `skill.analyze_file` | Per-file orchestration | Internal workflow span |
 | `skill.analyze_hunk` | Per-hunk retry loop | Internal workflow span |
 | `fix_eval.run` | Fix evaluation batch | Internal workflow span |
@@ -110,9 +117,35 @@ The `gen_ai.invoke_agent` span on `executeQuery()` carries attributes for Sentry
 | `sdk.duration_api_ms` | `resultMessage.duration_api_ms` |
 | `sdk.num_turns` | `resultMessage.num_turns` |
 
+### Per-turn `gen_ai.chat` attributes
+
+Created from `SDKAssistantMessage` events streamed by `query()`. Each span represents a completed API turn within the agent session. Buffered until the next `assistant` or `result` message so tool progress data is captured.
+
+| Attribute | Source | Notes |
+|-----------|--------|-------|
+| `gen_ai.operation.name` | `'chat'` | OTel operation name |
+| `gen_ai.provider.name` | `'anthropic'` | OTel provider |
+| `gen_ai.agent.name` | Skill name | Links turn to skill |
+| `gen_ai.response.model` | `message.message.model` | Actual model used for this turn |
+| `gen_ai.usage.input_tokens` | `input + cache_read + cache_write` | Total input tokens (same accounting as parent) |
+| `gen_ai.usage.output_tokens` | `message.message.usage.output_tokens` | Output tokens for this turn |
+| `gen_ai.usage.input_tokens.cached` | `message.message.usage.cache_read_input_tokens` | Cache read subset |
+| `gen_ai.usage.input_tokens.cache_write` | `message.message.usage.cache_creation_input_tokens` | Cache write subset |
+| `gen_ai.usage.total_tokens` | `input + output` | Total tokens for this turn |
+| `gen_ai.tool_use.count` | Count of `tool_use` content blocks | Number of tools invoked in this turn |
+
+### Per-tool `gen_ai.execute_tool` attributes
+
+Created from `tool_use` content blocks in `SDKAssistantMessage`, enriched with timing from `SDKToolProgressMessage`. Child spans of `gen_ai.chat`.
+
+| Attribute | Source | Notes |
+|-----------|--------|-------|
+| `gen_ai.tool.name` | `tool_use.name` | Tool name (e.g. `Read`, `Grep`) |
+| `tool.elapsed_seconds` | `SDKToolProgressMessage.elapsed_time_seconds` | Execution duration; only set when progress message received |
+
 ### Why manual instrumentation for the SDK
 
-The Claude Code SDK runs as a subprocess via `query()`. It is not an `@anthropic-ai/sdk` client call, so `anthropicAIIntegration` cannot auto-instrument it. The SDK does return rich telemetry in its result message, which we capture manually. Direct Anthropic API calls (haiku extraction, fix evaluation judge) *are* auto-instrumented by the integration.
+The Claude Code SDK runs as a subprocess via `query()`. It is not an `@anthropic-ai/sdk` client call, so `anthropicAIIntegration` cannot auto-instrument it. The SDK streams rich message types (`SDKAssistantMessage`, `SDKToolProgressMessage`) that provide per-turn token usage and tool execution data. We process these to create `gen_ai.chat` and `gen_ai.execute_tool` child spans. The aggregate result message provides session-level totals for the parent `gen_ai.invoke_agent` span. Direct Anthropic API calls (haiku extraction, fix evaluation judge) *are* auto-instrumented by the integration.
 
 ---
 

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -79,6 +79,16 @@ async function parseHunkOutput(
   };
 }
 
+/** Buffered data for a single SDK turn, flushed into gen_ai.chat child spans. */
+interface TurnData {
+  toolUses: { id: string; name: string }[];
+  inputTokens: number;
+  outputTokens: number;
+  cacheRead: number;
+  cacheWrite: number;
+  model: string;
+}
+
 /**
  * Result from executing an SDK query, including any captured errors.
  */
@@ -143,12 +153,87 @@ async function executeQuery(
       let resultMessage: SDKResultMessage | undefined;
       let authError: string | undefined;
 
+      // Per-turn tracing: buffer assistant messages and tool progress to create
+      // child spans (gen_ai.chat + gen_ai.execute_tool) under the invoke_agent span.
+      // We flush the previous turn when a new assistant message or result arrives,
+      // ensuring tool_progress events are captured before span creation.
+      let turnCount = 0;
+      let pendingTurn: TurnData | null = null;
+      const pendingToolProgress = new Map<string, number>();
+
+      /** Flush buffered turn data into gen_ai.chat and gen_ai.execute_tool child spans. */
+      function flushPendingTurn(): void {
+        if (!pendingTurn) return;
+        turnCount++;
+        const turn = pendingTurn;
+        const toolProgress = new Map(pendingToolProgress);
+        pendingTurn = null;
+        pendingToolProgress.clear();
+
+        try {
+          const totalInput = turn.inputTokens + turn.cacheRead + turn.cacheWrite;
+
+          Sentry.startSpan(
+            {
+              op: 'gen_ai.chat',
+              name: `chat ${skillName} turn ${turnCount}`,
+              attributes: {
+                'gen_ai.operation.name': 'chat',
+                'gen_ai.provider.name': 'anthropic',
+                'gen_ai.agent.name': skillName,
+                'gen_ai.response.model': turn.model,
+                'gen_ai.usage.input_tokens': totalInput,
+                'gen_ai.usage.output_tokens': turn.outputTokens,
+                'gen_ai.usage.input_tokens.cached': turn.cacheRead,
+                'gen_ai.usage.input_tokens.cache_write': turn.cacheWrite,
+                'gen_ai.usage.total_tokens': totalInput + turn.outputTokens,
+                'gen_ai.tool_use.count': turn.toolUses.length,
+              },
+            },
+            () => {
+              for (const toolUse of turn.toolUses) {
+                const elapsed = toolProgress.get(toolUse.id);
+                Sentry.startSpan(
+                  {
+                    op: 'gen_ai.execute_tool',
+                    name: toolUse.name,
+                    attributes: {
+                      'gen_ai.tool.name': toolUse.name,
+                      ...(elapsed !== undefined && { 'tool.elapsed_seconds': elapsed }),
+                    },
+                  },
+                  () => { /* point-in-time span */ }
+                );
+              }
+            }
+          );
+        } catch {
+          // Telemetry should never break the workflow
+        }
+      }
+
       try {
         for await (const message of stream) {
-          if (message.type === 'result') {
+          if (message.type === 'assistant') {
+            flushPendingTurn();
+            const msg = message.message;
+            const toolUses = msg.content
+              .filter((block): block is typeof block & { type: 'tool_use' } => block.type === 'tool_use')
+              .map(({ id, name }) => ({ id, name }));
+            pendingTurn = {
+              toolUses,
+              inputTokens: msg.usage?.input_tokens ?? 0,
+              outputTokens: msg.usage?.output_tokens ?? 0,
+              cacheRead: msg.usage?.cache_read_input_tokens ?? 0,
+              cacheWrite: msg.usage?.cache_creation_input_tokens ?? 0,
+              model: msg.model,
+            };
+          } else if (message.type === 'tool_progress') {
+            pendingToolProgress.set(message.tool_use_id, message.elapsed_time_seconds);
+          } else if (message.type === 'result') {
+            flushPendingTurn();
             resultMessage = message;
           } else if (message.type === 'auth_status' && message.error) {
-            // Capture authentication errors from auth_status messages
             authError = message.error;
           }
         }
@@ -162,6 +247,9 @@ async function executeQuery(
           throw enhancedError;
         }
         throw error;
+      } finally {
+        // Flush any pending turn data for trace completeness
+        flushPendingTurn();
       }
 
       // Set response attributes from SDK result
@@ -189,9 +277,12 @@ async function executeQuery(
         }
         if (resultMessage.modelUsage) {
           const models = Object.keys(resultMessage.modelUsage);
-          if (models[0]) {
+          if (models.length === 1 && models[0]) {
+            // Single model: set per OTel spec (string, one model)
             span.setAttribute('gen_ai.response.model', models[0]);
           }
+          // Multiple models: don't set gen_ai.response.model on the parent.
+          // Per-turn gen_ai.chat child spans carry the correct model each.
         }
 
         // Optional SDK metadata attributes


### PR DESCRIPTION
Process `SDKAssistantMessage` and `SDKToolProgressMessage` from the `query()` stream to create `gen_ai.chat` and `gen_ai.execute_tool` child spans under the `gen_ai.invoke_agent` span. Previously, everything inside an SDK call was a black box. Now each API turn and tool execution is visible in Sentry traces.

The SDK streams rich message types that we were ignoring. `SDKAssistantMessage` carries per-turn token usage and model identity. `SDKToolProgressMessage` carries tool execution timing. We buffer each turn until the next assistant or result message arrives, ensuring tool progress data is captured before span creation.

Multi-model sessions (where the SDK routes between different models across turns) omit `gen_ai.response.model` on the parent span per OTel spec, since the attribute is typed as a single string. Per-turn child spans carry the correct model each.

Updated span hierarchy:

```
gen_ai.invoke_agent "invoke_agent {skill}"
  gen_ai.chat "chat {skill} turn 1"
    gen_ai.execute_tool "Read"
    gen_ai.execute_tool "Grep"
  gen_ai.chat "chat {skill} turn 2"
  gen_ai.chat "chat {skill} turn 3"
    gen_ai.execute_tool "Read"
```