### PR TITLE
feat(telemetry): Add input/output attributes to gen_ai spans

### DIFF
--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -85,6 +85,7 @@ The `gen_ai.invoke_agent` span on `executeQuery()` carries attributes for Sentry
 | `gen_ai.agent.name` | Model ID from options | [OTel SHOULD](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) |
 | `gen_ai.request.model` | Model ID from options | [OTel conditionally required](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) |
 | `gen_ai.request.max_turns` | `maxTurns` value | Warden extension (not in spec) |
+| `gen_ai.request.messages` | Stringified `[{role, content}]` array | [Sentry AI Agents](https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/). Set on all `gen_ai.*` spans. |
 
 ### Response attributes (set after SDK result)
 
@@ -98,6 +99,7 @@ The `gen_ai.invoke_agent` span on `executeQuery()` carries attributes for Sentry
 | `gen_ai.cost.total_tokens` | `resultMessage.total_cost_usd` | [Sentry extension](https://develop.sentry.dev/sdk/telemetry/traces/modules/ai-agents/). USD cost from SDK. |
 | `gen_ai.response.id` | `resultMessage.uuid` | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
 | `gen_ai.response.model` | First key in `resultMessage.modelUsage` | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
+| `gen_ai.response.text` | Stringified `["response text"]` array | [Sentry AI Agents](https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/). Set when response text is available. |
 
 **Token accounting:** The Anthropic API's `input_tokens` field counts only non-cached input tokens. `cache_read_input_tokens` and `cache_creation_input_tokens` are separate, non-overlapping counts. The OTel `gen_ai.usage.input_tokens` attribute represents the *total* input tokens, so we sum all three. Sentry then [subtracts the cached/reasoning counts from the totals](https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/) to compute the raw portion. Setting `input_tokens` to only the non-cached value causes Sentry to compute negative costs.
 

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -117,6 +117,11 @@ async function executeQuery(
       },
     },
     async (span) => {
+      span.setAttribute('gen_ai.request.messages', JSON.stringify([
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ]));
+
       // Capture stderr output for better error diagnostics
       const stderrChunks: string[] = [];
 
@@ -192,6 +197,10 @@ async function executeQuery(
           if (models[0]) {
             span.setAttribute('gen_ai.response.model', models[0]);
           }
+        }
+
+        if (resultMessage.subtype === 'success' && resultMessage.result) {
+          span.setAttribute('gen_ai.response.text', JSON.stringify([resultMessage.result]));
         }
 
         // Optional SDK metadata attributes

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -206,27 +206,29 @@ export async function extractFindingsWithLLM(
     async (span) => {
       try {
         const client = new Anthropic({ apiKey, timeout: LLM_FALLBACK_TIMEOUT_MS });
-        const response = await client.messages.create({
-          model: HAIKU_MODEL,
-          max_tokens: LLM_FALLBACK_MAX_TOKENS,
-          messages: [
-            {
-              role: 'user',
-              content: `Extract the findings JSON from this model output.
+        const userContent = `Extract the findings JSON from this model output.
 Return ONLY valid JSON in format: {"findings": [...]}
 If no findings exist, return: {"findings": []}
 
 Model output:
-${truncatedText}`,
-            },
-          ],
+${truncatedText}`;
+        const messages: Anthropic.MessageParam[] = [
+          { role: 'user', content: userContent },
+        ];
+
+        span.setAttribute('gen_ai.request.messages', JSON.stringify(messages));
+
+        const response = await client.messages.create({
+          model: HAIKU_MODEL,
+          max_tokens: LLM_FALLBACK_MAX_TOKENS,
+          messages,
         });
 
         const usage = apiUsageToStats(HAIKU_MODEL, response.usage);
-        setGenAiResponseAttrs(span, response.usage, response.stop_reason);
 
         const content = response.content[0];
         if (!content || content.type !== 'text') {
+          setGenAiResponseAttrs(span, response.usage, response.stop_reason);
           return {
             success: false,
             error: 'llm_unexpected_response',
@@ -234,6 +236,8 @@ ${truncatedText}`,
             usage,
           };
         }
+
+        setGenAiResponseAttrs(span, response.usage, response.stop_reason, content.text);
 
         // Parse the LLM response as JSON
         const result = extractFindingsJson(content.text);

--- a/src/sdk/haiku.test.ts
+++ b/src/sdk/haiku.test.ts
@@ -1,5 +1,36 @@
-import { describe, it, expect } from 'vitest';
-import { extractJson } from './haiku.js';
+import { describe, it, expect, vi } from 'vitest';
+import { extractJson, setGenAiResponseAttrs } from './haiku.js';
+
+describe('setGenAiResponseAttrs', () => {
+  function makeSpan() {
+    const attrs = new Map<string, unknown>();
+    return {
+      setAttribute: vi.fn((key: string, value: unknown) => attrs.set(key, value)),
+      _attrs: attrs,
+    };
+  }
+
+  it('sets usage and stop reason', () => {
+    const span = makeSpan();
+    setGenAiResponseAttrs(span as never, { input_tokens: 10, output_tokens: 20 }, 'end_turn');
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens', 10);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.output_tokens', 20);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.response.finish_reasons', ['end_turn']);
+    expect(span._attrs.has('gen_ai.response.text')).toBe(false);
+  });
+
+  it('sets gen_ai.response.text when responseText is provided', () => {
+    const span = makeSpan();
+    setGenAiResponseAttrs(span as never, { input_tokens: 5, output_tokens: 15 }, 'end_turn', 'hello world');
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.response.text', JSON.stringify(['hello world']));
+  });
+
+  it('omits gen_ai.response.text when responseText is undefined', () => {
+    const span = makeSpan();
+    setGenAiResponseAttrs(span as never, { input_tokens: 5, output_tokens: 15 }, 'end_turn');
+    expect(span._attrs.has('gen_ai.response.text')).toBe(false);
+  });
+});
 
 describe('extractJson', () => {
   it('extracts a simple JSON object', () => {

--- a/src/sdk/haiku.ts
+++ b/src/sdk/haiku.ts
@@ -16,12 +16,16 @@ const DEFAULT_MAX_TOKENS = 4096;
 export function setGenAiResponseAttrs(
   span: Span,
   usage: { input_tokens: number; output_tokens: number },
-  stopReason?: string | null
+  stopReason?: string | null,
+  responseText?: string
 ): void {
   span.setAttribute('gen_ai.usage.input_tokens', usage.input_tokens);
   span.setAttribute('gen_ai.usage.output_tokens', usage.output_tokens);
   if (stopReason) {
     span.setAttribute('gen_ai.response.finish_reasons', [stopReason]);
+  }
+  if (responseText !== undefined) {
+    span.setAttribute('gen_ai.response.text', JSON.stringify([responseText]));
   }
 }
 
@@ -142,6 +146,8 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
         messages.push({ role: 'assistant', content: prefill });
       }
 
+      span.setAttribute('gen_ai.request.messages', JSON.stringify(messages));
+
       try {
         const response = await client.messages.create({
           model: HAIKU_MODEL,
@@ -150,10 +156,10 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
         });
 
         const usage = apiUsageToStats(HAIKU_MODEL, response.usage);
-        setGenAiResponseAttrs(span, response.usage, response.stop_reason);
 
         const content = response.content[0];
         if (!content || content.type !== 'text') {
+          setGenAiResponseAttrs(span, response.usage, response.stop_reason);
           return { success: false, error: 'Empty response from model', usage };
         }
 
@@ -161,6 +167,7 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
         if (prefill) {
           fullText = prefill + fullText;
         }
+        setGenAiResponseAttrs(span, response.usage, response.stop_reason, fullText);
         const jsonStr = extractJson(fullText);
         if (!jsonStr) {
           return { success: false, error: 'No JSON found in response', usage };
@@ -233,12 +240,14 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
         { role: 'user', content: prompt },
       ];
 
+      span.setAttribute('gen_ai.request.messages', JSON.stringify(messages));
+
       const usages: UsageStats[] = [];
       let totalInputTokens = 0;
       let totalOutputTokens = 0;
 
-      function setFinalSpanAttrs(stopReason?: string | null): void {
-        setGenAiResponseAttrs(span, { input_tokens: totalInputTokens, output_tokens: totalOutputTokens }, stopReason);
+      function setFinalSpanAttrs(stopReason?: string | null, responseText?: string): void {
+        setGenAiResponseAttrs(span, { input_tokens: totalInputTokens, output_tokens: totalOutputTokens }, stopReason, responseText);
       }
 
       function currentUsage(): UsageStats {
@@ -301,10 +310,9 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
           continue;
         }
 
-        // Final response - set span attributes and extract JSON verdict
-        setFinalSpanAttrs(response.stop_reason);
-
+        // Final response - extract text and set span attributes
         if (response.stop_reason !== 'end_turn' && response.stop_reason !== 'max_tokens') {
+          setFinalSpanAttrs(response.stop_reason);
           return { success: false, error: `Unexpected stop reason: ${response.stop_reason}`, usage: aggregateUsage(usages) };
         }
 
@@ -313,8 +321,11 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
         );
 
         if (!textBlock) {
+          setFinalSpanAttrs(response.stop_reason);
           return { success: false, error: 'No text in final response', usage: aggregateUsage(usages) };
         }
+
+        setFinalSpanAttrs(response.stop_reason, textBlock.text);
 
         const jsonStr = extractJson(textBlock.text);
         if (!jsonStr) {


### PR DESCRIPTION
Add `gen_ai.request.messages` and `gen_ai.response.text` span attributes
to all manually created gen_ai spans. Sentry AI Agent Monitoring uses
these to display prompt inputs and model outputs, but our manual parent
spans were missing them (only auto-instrumented child spans had them).

Sets input messages (stringified `[{role, content}]`) and response text
(stringified `["text"]`) on:

- `executeQuery` — invoke_agent span (system + user prompts, SDK result)
- `callHaiku` — chat span (user prompt, full text response)
- `callHaikuWithTools` — chat span (user prompt, final text block)
- `extractFindingsWithLLM` — chat span (extraction prompt, LLM response)

Also extends `setGenAiResponseAttrs` with an optional `responseText`
parameter so callers can set response text alongside usage attributes
in a single call.