### PR TITLE
fix(cli): Run all skills locally regardless of trigger type

### DIFF
--- a/plugins/warden/skills/warden/references/config-schema.md
+++ b/plugins/warden/skills/warden/references/config-schema.md
@@ -69,8 +69,10 @@ fixBranchPrefix = "security-fix"       # Branch name prefix
 
 **Trigger types:**
 - `pull_request` - Triggers on PR events
-- `local` - Triggers on local CLI runs
-- `schedule` - Triggers on cron schedule (GitHub Action)
+- `local` - Local CLI only (will not run in CI)
+- `schedule` - Cron schedule (GitHub Action only)
+
+All skills run locally regardless of trigger type. Skills with no triggers run everywhere (wildcard). Use `type = "local"` for skills that should *only* run locally.
 
 **Actions (for pull_request):**
 - `opened`, `synchronize`, `reopened`, `closed`

--- a/plugins/warden/skills/warden/references/configuration.md
+++ b/plugins/warden/skills/warden/references/configuration.md
@@ -21,7 +21,7 @@ actions = ["opened", "synchronize"]
 
 ## Skill Configuration
 
-Skills define what to analyze and when. Each skill requires a name and at least one trigger:
+Skills define what to analyze and when. Each skill requires a name. Triggers are optional — skills with no triggers run everywhere (PR, local, schedule). All skills run locally regardless of trigger type.
 
 ```toml
 [[skills]]
@@ -36,7 +36,7 @@ type = "pull_request"
 actions = ["opened", "synchronize"]
 ```
 
-**Trigger types:** `pull_request`, `local`, `schedule`
+**Trigger types:** `pull_request`, `local` (local-only), `schedule` (CI-only)
 
 **Actions (pull_request):** `opened`, `synchronize`, `reopened`, `closed`
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -484,9 +484,19 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
   const matchedTriggers = resolvedTriggers.filter((t) => matchTrigger(t, context, 'local'));
 
   // Filter by skill if specified
-  const triggersToRun = options.skill
+  const filtered = options.skill
     ? matchedTriggers.filter((t) => t.skill === options.skill)
     : matchedTriggers;
+
+  // Deduplicate by skill name — prefer 'local' triggers (may have local-specific overrides)
+  const seen = new Map<string, typeof filtered[number]>();
+  for (const t of filtered) {
+    const existing = seen.get(t.skill);
+    if (!existing || (t.type === 'local' && existing.type !== 'local')) {
+      seen.set(t.skill, t);
+    }
+  }
+  const triggersToRun = [...seen.values()];
 
   if (triggersToRun.length === 0) {
     if (!options.json) {

--- a/src/triggers/matcher.test.ts
+++ b/src/triggers/matcher.test.ts
@@ -147,8 +147,8 @@ describe('matchTrigger', () => {
     expect(matchTrigger(baseTrigger, baseContext, 'github')).toBe(true);
   });
 
-  it('does not match PR trigger in local environment', () => {
-    expect(matchTrigger(baseTrigger, baseContext, 'local')).toBe(false);
+  it('matches PR trigger in local environment', () => {
+    expect(matchTrigger(baseTrigger, baseContext, 'local')).toBe(true);
   });
 
   it('does not match wrong action', () => {
@@ -232,8 +232,13 @@ describe('matchTrigger', () => {
       expect(matchTrigger(baseTrigger, baseContext, 'github')).toBe(true);
     });
 
-    it('pull_request trigger does not match in local environment', () => {
-      expect(matchTrigger(baseTrigger, baseContext, 'local')).toBe(false);
+    it('pull_request trigger matches in local environment', () => {
+      expect(matchTrigger(baseTrigger, baseContext, 'local')).toBe(true);
+    });
+
+    it('pull_request trigger still applies path filters in local environment', () => {
+      const trigger = { ...baseTrigger, filters: { paths: ['lib/**/*.ts'] } };
+      expect(matchTrigger(trigger, baseContext, 'local')).toBe(false);
     });
 
     it('wildcard trigger matches in any environment', () => {

--- a/src/triggers/matcher.ts
+++ b/src/triggers/matcher.ts
@@ -155,8 +155,8 @@ export function filterContextByPaths(
  *
  * Trigger types:
  * - '*' (wildcard): matches all environments, skips event/action checks
- * - 'local': matches only when environment is 'local'
- * - 'pull_request': matches when environment is 'github' and event is pull_request
+ * - 'local': matches only when environment is 'local' (local-only skills)
+ * - 'pull_request': matches in 'github' (with event/action checks) and 'local' (path filters only)
  * - 'schedule': matches when event is schedule
  */
 export function matchTrigger(
@@ -179,13 +179,14 @@ export function matchTrigger(
 
   if (trigger.type === 'pull_request') {
     if (environment === 'local') {
-      return false;
-    }
-    if (context.eventType !== 'pull_request') {
-      return false;
-    }
-    if (!trigger.actions?.includes(context.action)) {
-      return false;
+      // Local mode runs all skills — skip event/action checks, fall through to path filters
+    } else {
+      if (context.eventType !== 'pull_request') {
+        return false;
+      }
+      if (!trigger.actions?.includes(context.action)) {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
Local mode previously required an explicit `type = "local"` trigger for each skill to run from the CLI. This meant every skill in warden.toml needed duplicate trigger blocks just to work locally, which was backwards from the original intent.

Now all skills run locally regardless of trigger type. `pull_request` triggers match in local mode (skipping event/action checks, still applying path filters). The `local` trigger type means "local-only" — for skills that should not run in CI.

When a skill has both `pull_request` and `local` triggers matching, deduplicates by skill name, preferring the `local` trigger (which may carry local-specific overrides like a different model or failOn).