### PR TITLE
test: Tighten weak mock assertions in test suite

### DIFF
--- a/src/action/review/poster.test.ts
+++ b/src/action/review/poster.test.ts
@@ -170,7 +170,15 @@ describe('postTriggerReview', () => {
 
     expect(postResult.posted).toBe(true);
     expect(postResult.newComments).toHaveLength(1);
-    expect(mockOctokit.pulls.createReview).toHaveBeenCalled();
+    expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith({
+      owner: 'test-owner',
+      repo: 'test-repo',
+      pull_number: 1,
+      commit_id: 'abc123',
+      event: 'COMMENT',
+      body: 'Test review',
+      comments: [expect.objectContaining({ path: 'test.ts', line: 10, side: 'RIGHT', body: 'Test comment' })],
+    });
   });
 
   it('deduplicates findings against existing comments', async () => {
@@ -211,8 +219,15 @@ describe('postTriggerReview', () => {
 
     const postResult = await postTriggerReview(ctx, mockDeps);
 
-    expect(deduplicateFindings).toHaveBeenCalledWith([finding], [existingComment], expect.any(Object));
-    expect(processDuplicateActions).toHaveBeenCalled();
+    expect(deduplicateFindings).toHaveBeenCalledWith([finding], [existingComment], {
+      apiKey: 'test-key',
+      currentSkill: 'test-skill',
+    });
+    expect(processDuplicateActions).toHaveBeenCalledWith(
+      mockOctokit, 'test-owner', 'test-repo',
+      [{ type: 'react_external', finding, existingComment, matchType: 'hash' }],
+      'test-skill'
+    );
     // Since all findings were duplicates and failOn not triggered, nothing new to post
     expect(postResult.posted).toBe(false);
   });
@@ -267,11 +282,23 @@ describe('postTriggerReview', () => {
 
     const postResult = await postTriggerReview(ctx, mockDeps);
 
-    expect(deduplicateFindings).toHaveBeenCalled();
-    expect(processDuplicateActions).toHaveBeenCalled();
+    expect(deduplicateFindings).toHaveBeenCalledWith([finding], [existingComment], {
+      apiKey: 'test-key',
+      currentSkill: 'test-skill',
+    });
+    expect(processDuplicateActions).toHaveBeenCalledWith(
+      mockOctokit, 'test-owner', 'test-repo',
+      [{ type: 'update_warden', finding, existingComment, matchType: 'hash' }],
+      'test-skill'
+    );
     // Even though all findings were deduplicated, REQUEST_CHANGES should still be posted
     expect(postResult.posted).toBe(true);
-    expect(mockOctokit.pulls.createReview).toHaveBeenCalled();
+    expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'REQUEST_CHANGES',
+        comments: [],
+      })
+    );
   });
 
   it('handles API errors gracefully', async () => {

--- a/src/action/triggers/executor.test.ts
+++ b/src/action/triggers/executor.test.ts
@@ -108,8 +108,19 @@ describe('executeTrigger', () => {
     expect(result.report).toBe(mockReport);
     expect(result.renderResult).toBe(mockRenderResult);
     expect(result.error).toBeUndefined();
-    expect(createSkillCheck).toHaveBeenCalled();
-    expect(updateSkillCheck).toHaveBeenCalled();
+    expect(createSkillCheck).toHaveBeenCalledWith(mockOctokit, 'test-skill', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      headSha: 'abc123',
+    });
+    expect(updateSkillCheck).toHaveBeenCalledWith(mockOctokit, 123, mockReport, {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      headSha: 'abc123',
+      failOn: undefined,
+      reportOn: undefined,
+      failCheck: undefined,
+    });
   });
 
   it('executes a trigger successfully with no findings', async () => {
@@ -136,7 +147,10 @@ describe('executeTrigger', () => {
     expect(result.triggerName).toBe('test-trigger');
     expect(result.error).toBeDefined();
     expect(result.report).toBeUndefined();
-    expect(failSkillCheck).toHaveBeenCalled();
+    expect(failSkillCheck).toHaveBeenCalledWith(
+      mockOctokit, 123, expect.objectContaining({ message: 'Skill not found' }),
+      { owner: 'test-owner', repo: 'test-repo', headSha: 'abc123' }
+    );
   });
 
   it('handles skill execution failure', async () => {
@@ -149,7 +163,10 @@ describe('executeTrigger', () => {
     expect(result.triggerName).toBe('test-trigger');
     expect(result.error).toBeDefined();
     expect(result.report).toBeUndefined();
-    expect(failSkillCheck).toHaveBeenCalled();
+    expect(failSkillCheck).toHaveBeenCalledWith(
+      mockOctokit, 123, expect.objectContaining({ message: 'API error' }),
+      { owner: 'test-owner', repo: 'test-repo', headSha: 'abc123' }
+    );
   });
 
   it('continues if check creation fails', async () => {

--- a/src/action/workflow/schedule.test.ts
+++ b/src/action/workflow/schedule.test.ts
@@ -370,7 +370,8 @@ describe('runScheduleWorkflow', () => {
     });
 
     it('uses custom issue title from schedule config', async () => {
-      mockRunSkill.mockResolvedValue(createSkillReport({ findings: [] }));
+      const report = createSkillReport({ findings: [] });
+      mockRunSkill.mockResolvedValue(report);
 
       await runScheduleWorkflow(
         mockOctokit,
@@ -382,7 +383,7 @@ describe('runScheduleWorkflow', () => {
         mockOctokit,
         'test-owner',
         'test-repo',
-        expect.any(Array),
+        [report],
         expect.objectContaining({
           title: 'Custom Issue Title',
         })


### PR DESCRIPTION
Replace overly broad mock assertions (`expect.any(Object)`, bare `.toHaveBeenCalled()`) with specific value assertions to catch regressions.

**Changes:**
- `executor.test.ts`: Tightened 4 assertions verifying `createSkillCheck`, `updateSkillCheck`, and `failSkillCheck` arguments (owner, repo, headSha, report data, error messages)
- `poster.test.ts`: Tightened 4 assertions verifying `createReview` event types, `deduplicateFindings` options structure, and `processDuplicateActions` parameters
- `schedule.test.ts`: Replaced `expect.any(Array)` with captured report reference for exact match

All tests pass. No behavior changes.

Closes #157