### PR TITLE
fix(evals): Update default model to claude-sonnet-4-6

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -87,7 +87,7 @@ evals/
 | Field | Required | Description |
 |-------|----------|-------------|
 | `skill` | Yes | Path to test skill, relative to `evals/` |
-| `model` | No | Default model for all evals (default: `claude-sonnet-4-5-20250514`) |
+| `model` | No | Default model for all evals (default: `claude-sonnet-4-6`) |
 | `evals` | Yes | List of eval scenarios (at least one) |
 
 ### Per-eval fields
@@ -117,7 +117,7 @@ pnpm test:evals -- --grep "bug-detection"
 pnpm test:evals -- --grep "null-property-access"
 ```
 
-Evals make real API calls. They run skills on `claude-sonnet-4-5-20250514` by
+Evals make real API calls. They run skills on `claude-sonnet-4-6` by
 default.
 
 ## Adding a New Eval

--- a/src/evals/index.test.ts
+++ b/src/evals/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 import { discoverEvalFiles, loadEvalFile, resolveEvalMetas, discoverEvals } from './index.js';
-import { EvalFileSchema, EvalScenarioSchema } from './types.js';
+import { DEFAULT_EVAL_MODEL, EvalFileSchema, EvalScenarioSchema } from './types.js';
 
 const evalsDir = join(import.meta.dirname, '..', '..', 'evals');
 
@@ -151,7 +151,7 @@ describe('EvalFileSchema', () => {
     const result = EvalFileSchema.safeParse(valid);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.model).toBe('claude-sonnet-4-5-20250514');
+      expect(result.data.model).toBe(DEFAULT_EVAL_MODEL);
     }
   });
 

--- a/src/evals/judge.ts
+++ b/src/evals/judge.ts
@@ -4,10 +4,10 @@ import { apiUsageToStats } from '../sdk/pricing.js';
 import { emptyUsage } from '../sdk/usage.js';
 import { extractJson } from '../sdk/haiku.js';
 import type { EvalMeta, JudgeResponse } from './types.js';
-import { JudgeResponseSchema } from './types.js';
+import { DEFAULT_EVAL_MODEL, JudgeResponseSchema } from './types.js';
 import type { UsageStats } from '../types/index.js';
 
-const JUDGE_MODEL = 'claude-sonnet-4-5-20250514';
+const JUDGE_MODEL = DEFAULT_EVAL_MODEL;
 const JUDGE_MAX_TOKENS = 4096;
 const JUDGE_TIMEOUT_MS = 60_000;
 
@@ -105,7 +105,6 @@ export async function runJudge(
 
   const messages: Anthropic.MessageParam[] = [
     { role: 'user', content: prompt },
-    { role: 'assistant', content: '{' },
   ];
 
   let response: Anthropic.Message;
@@ -146,9 +145,7 @@ export async function runJudge(
     };
   }
 
-  // Prepend the prefill character
-  const fullText = '{' + textBlock.text;
-  const jsonStr = extractJson(fullText);
+  const jsonStr = extractJson(textBlock.text);
 
   if (!jsonStr) {
     return {

--- a/src/evals/types.test.ts
+++ b/src/evals/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evalPassed, formatEvalResult } from './types.js';
+import { DEFAULT_EVAL_MODEL, evalPassed, formatEvalResult } from './types.js';
 import type { EvalMeta, JudgeResponse, EvalResult } from './types.js';
 
 function makeMeta(overrides: Partial<EvalMeta> = {}): EvalMeta {
@@ -9,7 +9,7 @@ function makeMeta(overrides: Partial<EvalMeta> = {}): EvalMeta {
     given: 'code with a known bug',
     skillPath: '/path/to/skills/bug-detection.md',
     filePaths: ['/path/to/fixtures/test/file.ts'],
-    model: 'claude-sonnet-4-5-20250514',
+    model: DEFAULT_EVAL_MODEL,
     should_find: [{ finding: 'the bug', required: true }],
     should_not_find: [],
     ...overrides,

--- a/src/evals/types.ts
+++ b/src/evals/types.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { SeveritySchema } from '../types/index.js';
 import type { SkillReport, UsageStats } from '../types/index.js';
 
+/** Default model for eval skill execution and judging. */
+export const DEFAULT_EVAL_MODEL = 'claude-sonnet-4-6';
+
 /**
  * A "should find" assertion in BDD style.
  */
@@ -52,7 +55,7 @@ export const EvalFileSchema = z.object({
   /** Skill to run, relative to evals/ directory */
   skill: z.string(),
   /** Default model for all evals in this file */
-  model: z.string().default('claude-sonnet-4-5-20250514'),
+  model: z.string().default(DEFAULT_EVAL_MODEL),
   /** List of eval scenarios */
   evals: z.array(EvalScenarioSchema).min(1),
 });

--- a/src/sdk/model-pricing.json
+++ b/src/sdk/model-pricing.json
@@ -47,18 +47,6 @@
     "cacheReadPerMTok": 0.1,
     "cacheWritePerMTok": 1.25
   },
-  "claude-instant-1": {
-    "inputPerMTok": 1.63,
-    "outputPerMTok": 55.1,
-    "cacheReadPerMTok": 0,
-    "cacheWritePerMTok": 0
-  },
-  "claude-instant-1.2": {
-    "inputPerMTok": 1.63,
-    "outputPerMTok": 5.51,
-    "cacheReadPerMTok": 0,
-    "cacheWritePerMTok": 0
-  },
   "claude-opus-4-0": {
     "inputPerMTok": 15,
     "outputPerMTok": 75,
@@ -90,6 +78,12 @@
     "cacheWritePerMTok": 3.75
   },
   "claude-sonnet-4-5": {
+    "inputPerMTok": 3,
+    "outputPerMTok": 15,
+    "cacheReadPerMTok": 0.3,
+    "cacheWritePerMTok": 3.75
+  },
+  "claude-sonnet-4-6": {
     "inputPerMTok": 3,
     "outputPerMTok": 15,
     "cacheReadPerMTok": 0.3,


### PR DESCRIPTION
The previous default model (`claude-sonnet-4-5-20250514`) was removed from the
Anthropic API, causing all evals to fail with a 404 → exit code 1 from the
Claude Code subprocess.

Two issues fixed:

1. **Model 404** — every skill execution failed because the model no longer
   exists. Replaced with `claude-sonnet-4-6` via a shared `DEFAULT_EVAL_MODEL`
   constant so there's a single place to update next time.

2. **Assistant prefill unsupported** — the eval judge used assistant message
   prefill (`{ role: 'assistant', content: '{' }`), which `claude-sonnet-4-6`
   does not support. Removed the prefill and adjusted JSON extraction.

Also ran `pnpm update-pricing` to refresh `model-pricing.json` from upstream,
which added `claude-sonnet-4-6` pricing and dropped deprecated `claude-instant`
entries.

All 8 evals pass after the fix. All 1089 unit tests pass.