### PR TITLE
docs: Simplify getting started guide to use native warden add --remote

### DIFF
--- a/docs/src/pages/guide.astro
+++ b/docs/src/pages/guide.astro
@@ -227,31 +227,33 @@ Focus on issues in the changed code. For each issue found, report:
 
   <h2 id="adding-skills">Adding Skills</h2>
 
-  <p>Warden can discover and install community skills.</p>
+  <p>Warden can fetch and install skills from remote GitHub repositories.</p>
 
-  <h3>Interactive Mode</h3>
+  <h3>Add a Remote Skill</h3>
 
   <Terminal showCopy={true}>
     <Code
-      code={`warden add`}
+      code={`warden add vercel-react-best-practices --remote vercel-labs/agent-skills`}
       lang="bash"
       theme="vitesse-black"
     />
   </Terminal>
 
-  <p>Browse available skills and select which to add.</p>
+  <p>This fetches the skill and adds it with a trigger to <code>warden.toml</code>.</p>
 
-  <h3>List Available Skills</h3>
+  <h3>Browse Remote Skills</h3>
 
   <Terminal showCopy={true}>
     <Code
-      code={`warden add --list`}
+      code={`warden add --remote vercel-labs/agent-skills --list`}
       lang="bash"
       theme="vitesse-black"
     />
   </Terminal>
 
-  <h3>Add a Specific Skill</h3>
+  <h3>Add a Local Skill</h3>
+
+  <p>If you've written your own skills in <code>.agents/skills/</code>, add them by name:</p>
 
   <Terminal showCopy={true}>
     <Code
@@ -260,8 +262,6 @@ Focus on issues in the changed code. For each issue found, report:
       theme="vitesse-black"
     />
   </Terminal>
-
-  <p>This adds the skill and creates a trigger in <code>warden.toml</code>.</p>
 
   <h2 id="pull-request-reviews">Pull Request Reviews</h2>
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -48,14 +48,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <div class="step">
       <h3>Add some skills</h3>
       <p>Install a skill from the community. Vercel's React best practices is a great start.</p>
-      <PackageManagerTabs
-        npm={`npx skills add vercel-labs/agent-skills --skill vercel-react-best-practices
-warden add vercel-react-best-practices`}
-        pnpm={`pnpx skills add vercel-labs/agent-skills --skill vercel-react-best-practices
-warden add vercel-react-best-practices`}
-        bun={`bunx skills add vercel-labs/agent-skills --skill vercel-react-best-practices
-warden add vercel-react-best-practices`}
-      />
+      <Terminal showCopy={true} copyText="warden add vercel-react-best-practices --remote vercel-labs/agent-skills">
+        <pre class="cli-output"><span class="cli-dim">$</span> warden add vercel-react-best-practices --remote vercel-labs/agent-skills</pre>
+      </Terminal>
     </div>
 
     <div class="step">


### PR DESCRIPTION
Replaces the `npx skills` installer pattern with Warden's native `--remote` support, streamlining the quick start experience.

## Changes

- **Homepage quick start**: Remove `PackageManagerTabs` and replace with a single Terminal block showing `warden add vercel-react-best-practices --remote vercel-labs/agent-skills`
- **Guide Adding Skills section**: Reorganize to lead with remote skills as the primary path
- **Positional argument**: Use skill name as the first positional argument instead of `--skill` flag for cleaner syntax
- **Local skills**: Keep local skill adding as a secondary option for users with custom skills in `.agents/skills/`

This makes the onboarding flow simpler by highlighting Warden's native `--remote` capability without requiring external tooling.