### PR TITLE
Add repository and source context to skill metrics

### DIFF
--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -233,12 +233,12 @@ Emitted via `Sentry.metrics.*`. Each function is a no-op when Sentry is not init
 
 | Metric | Type | Attributes |
 |--------|------|------------|
-| `skill.duration` | distribution (ms) | `skill` |
-| `tokens.input` | distribution | `skill` |
-| `tokens.output` | distribution | `skill` |
-| `cost.usd` | distribution | `skill` |
-| `findings.total` | count | `skill` |
-| `findings` | count | `skill`, `severity` |
+| `skill.duration` | distribution (ms) | `skill`, `repository`, `source` |
+| `tokens.input` | distribution | `skill`, `repository`, `source` |
+| `tokens.output` | distribution | `skill`, `repository`, `source` |
+| `cost.usd` | distribution | `skill`, `repository`, `source` |
+| `findings.total` | count | `skill`, `repository`, `source` |
+| `findings` | count | `skill`, `repository`, `source`, `severity` |
 
 ### Extraction (`emitExtractionMetrics`)
 

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -432,7 +432,9 @@ export async function runSkillTask(
         }
 
         // Emit metrics and log completion
-        emitSkillMetrics(report);
+        emitSkillMetrics(report, {
+          repository: context.repository.fullName,
+        });
         logger.info(logger.fmt`Skill execution complete: ${displayName}`, {
           'finding.count': report.findings.length,
           'duration_ms': report.durationMs,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,6 +6,7 @@ import { getVersion } from './utils/index.js';
 export type SentryContext = 'cli' | 'action';
 
 let initialized = false;
+let deploymentContext: SentryContext | undefined;
 
 export function initSentry(context: SentryContext): void {
   const dsn = process.env['WARDEN_SENTRY_DSN'];
@@ -25,6 +26,7 @@ export function initSentry(context: SentryContext): void {
     ],
   });
 
+  deploymentContext = context;
   Sentry.setTag('deployment.context', context);
   Sentry.setTag('service.version', getVersion());
 }
@@ -45,9 +47,20 @@ function safeEmit(fn: () => void): void {
   }
 }
 
-export function emitSkillMetrics(report: SkillReport): void {
+export interface SkillMetricsContext {
+  /** Full repository name (e.g. "owner/repo") */
+  repository?: string;
+}
+
+export function emitSkillMetrics(report: SkillReport, context?: SkillMetricsContext): void {
   safeEmit(() => {
-    const attrs = { skill: report.skill };
+    const attrs: Record<string, string> = { skill: report.skill };
+    if (context?.repository) {
+      attrs['repository'] = context.repository;
+    }
+    if (deploymentContext) {
+      attrs['source'] = deploymentContext;
+    }
 
     Sentry.metrics.distribution('skill.duration', report.durationMs ?? 0, {
       unit: 'millisecond',


### PR DESCRIPTION
## Summary
Enhanced telemetry collection for skill execution metrics by adding repository and deployment source context to all skill-related metrics emitted to Sentry.

## Key Changes
- Added `deploymentContext` module-level variable to track the Sentry initialization context (cli or action)
- Introduced `SkillMetricsContext` interface to allow passing additional context when emitting skill metrics
- Updated `emitSkillMetrics()` function signature to accept optional context parameter
- Enhanced metric attributes to include:
  - `repository`: Full repository name (owner/repo format) when available
  - `source`: Deployment context (cli or action) from initialization
- Updated all skill metric definitions in telemetry documentation to reflect new attributes
- Modified skill task execution to pass repository information when emitting metrics

## Implementation Details
- The `deploymentContext` is captured during Sentry initialization and reused for all subsequent metric emissions
- Repository context is passed from the task execution layer where it's available
- All attributes are conditionally added only when present, maintaining backward compatibility
- Metrics affected: `skill.duration`, `tokens.input`, `tokens.output`, `cost.usd`, `findings.total`, and `findings`

https://claude.ai/code/session_01TcAbGVYiyoCMNC7PYrJ1kS