### PR TITLE
fix(cli): Render warnings through Ink's Static component

### DIFF
--- a/src/cli/output/ink-runner.tsx
+++ b/src/cli/output/ink-runner.tsx
@@ -380,8 +380,10 @@ export async function runSkillTasksWithInk(
     { shouldAbort: () => tasks[0]?.runnerOptions?.abortController?.signal.aborted ?? false }
   );
 
-  // Cleanup - set unmounted flag before unmount to prevent pending setImmediate
-  // callbacks from calling rerender on the unmounted Ink instance
+  // Flush any pending setImmediate from updateUI so last-tick warnings are
+  // rendered before we tear down. setImmediate is FIFO, so our callback runs
+  // after the queued rerender.
+  await new Promise((resolve) => setImmediate(resolve));
   unmounted = true;
   clear();
   unmount();


### PR DESCRIPTION
Warning callbacks (`onLargePrompt`, `onHunkFailed`, `onExtractionFailure`, etc.) were writing directly to `process.stderr` while Ink actively managed the dynamic spinner area on the same stream. This caused warning lines to interleave with progress output, corrupting the display.

Switches to queuing warnings into an array and rendering them via Ink's `Static` component, which renders items once and keeps them permanently above the dynamic area. Also replaces raw ANSI escape sequences with chalk for consistency with the rest of the codebase.