### PR TITLE
feat(config): Make auxiliary max retries configurable via defaults.auxiliaryMaxRetries

### DIFF
--- a/src/action/fix-evaluation/index.ts
+++ b/src/action/fix-evaluation/index.ts
@@ -84,7 +84,8 @@ export async function evaluateFixAttempts(
   comments: ExistingComment[],
   context: EvaluateFixAttemptsContext,
   currentFindings: Finding[],
-  apiKey: string
+  apiKey: string,
+  maxRetries?: number
 ): Promise<EvaluateFixAttemptsResult> {
   return Sentry.startSpan(
     {
@@ -194,7 +195,8 @@ export async function evaluateFixAttempts(
             const evalResult = await evaluateFix(
               { comment, changedFiles, codeBeforeFix, codeAfterFix, commitMessages },
               toolContext,
-              apiKey
+              apiKey,
+              maxRetries
             );
             const durationMs = performance.now() - startTime;
 

--- a/src/action/fix-evaluation/judge.ts
+++ b/src/action/fix-evaluation/judge.ts
@@ -211,7 +211,8 @@ function createToolExecutor(ctx: FixJudgeContext): (name: string, input: Record<
 export async function evaluateFix(
   input: FixJudgeInput,
   context: FixJudgeContext,
-  apiKey: string
+  apiKey: string,
+  maxRetries?: number
 ): Promise<FixJudgeResult> {
   const fallback: FixJudgeResult = {
     verdict: { status: 'not_attempted', reasoning: 'Evaluation failed' },
@@ -229,6 +230,7 @@ export async function evaluateFix(
     tools: TOOL_DEFINITIONS,
     executeTool,
     maxIterations: 5,
+    maxRetries,
   });
 
   if (result.success) {

--- a/src/action/review/poster.ts
+++ b/src/action/review/poster.ts
@@ -33,6 +33,7 @@ export interface ReviewPostingContext {
   result: TriggerResult;
   existingComments: ExistingComment[];
   apiKey: string;
+  maxRetries?: number;
 }
 
 /**
@@ -181,6 +182,7 @@ export async function postTriggerReview(
       const consolidateResult = await consolidateBatchFindings(findingsToPost, {
         apiKey,
         hashOnly: !apiKey,
+        maxRetries: ctx.maxRetries,
       });
       findingsToPost = consolidateResult.findings;
 
@@ -203,6 +205,7 @@ export async function postTriggerReview(
       dedupResult = await deduplicateFindings(findingsToPost, existingComments, {
         apiKey,
         currentSkill: result.report.skill,
+        maxRetries: ctx.maxRetries,
       });
       findingsToPost = dedupResult.newFindings;
 

--- a/src/action/triggers/executor.ts
+++ b/src/action/triggers/executor.ts
@@ -137,6 +137,7 @@ export async function executeTrigger(
             maxTurns: trigger.maxTurns,
             batchDelayMs: config.defaults?.batchDelayMs,
             pathToClaudeCodeExecutable: claudePath,
+            auxiliaryMaxRetries: config.defaults?.auxiliaryMaxRetries,
           },
         };
 

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -603,7 +603,8 @@ describe('runPRWorkflow', () => {
           headSha: 'abc123def456',
         }),
         expect.any(Array),
-        'test-api-key'
+        'test-api-key',
+        undefined
       );
     });
 
@@ -654,7 +655,8 @@ describe('runPRWorkflow', () => {
           repo: 'test-repo',
         }),
         [],
-        'test-api-key'
+        'test-api-key',
+        undefined
       );
 
       // Should NOT run skill tasks (no triggers matched)

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -272,7 +272,8 @@ async function postReviewsAndTrackFailures(
   octokit: Octokit,
   context: EventContext,
   results: TriggerResult[],
-  inputs: ActionInputs
+  inputs: ActionInputs,
+  auxiliaryMaxRetries?: number
 ): Promise<ReviewPhaseResult> {
   // Fetch existing comments for deduplication (only for PRs)
   // Keep original list separate for stale detection (modified list includes newly posted comments)
@@ -315,6 +316,7 @@ async function postReviewsAndTrackFailures(
           result,
           existingComments,
           apiKey: inputs.anthropicApiKey,
+          maxRetries: auxiliaryMaxRetries,
         },
         { octokit, context }
       );
@@ -346,7 +348,8 @@ async function evaluateFixesAndResolveStale(
   fetchedComments: ExistingComment[],
   allFindings: Finding[],
   canResolveStale: boolean,
-  anthropicApiKey: string
+  anthropicApiKey: string,
+  auxiliaryMaxRetries?: number
 ): Promise<{ allResolved: boolean }> {
   const wardenComments = fetchedComments.filter((c) => c.isWarden);
   const commentsResolvedByFixEval = new Set<number>();
@@ -377,7 +380,8 @@ async function evaluateFixesAndResolveStale(
           headSha: context.pullRequest.headSha,
         },
         allFindings,
-        anthropicApiKey
+        anthropicApiKey,
+        auxiliaryMaxRetries
       );
 
       // Log per-evaluation details
@@ -544,7 +548,8 @@ async function finalizeWorkflow(
 async function cleanupOrphanedComments(
   octokit: Octokit,
   context: EventContext,
-  anthropicApiKey: string
+  anthropicApiKey: string,
+  auxiliaryMaxRetries?: number
 ): Promise<void> {
   if (!context.pullRequest) {
     return;
@@ -571,7 +576,7 @@ async function cleanupOrphanedComments(
   logAction(`No triggers matched, but found ${wardenComments.length} existing Warden comments. Running cleanup.`);
 
   const { allResolved } = await evaluateFixesAndResolveStale(
-    octokit, context, existingComments, [], true, anthropicApiKey
+    octokit, context, existingComments, [], true, anthropicApiKey, auxiliaryMaxRetries
   );
 
   // Dismiss CHANGES_REQUESTED only if every unresolved comment was resolved
@@ -641,7 +646,7 @@ export async function runPRWorkflow(
       });
 
       if (matchedTriggers.length === 0) {
-        await cleanupOrphanedComments(octokit, context, inputs.anthropicApiKey);
+        await cleanupOrphanedComments(octokit, context, inputs.anthropicApiKey, config.defaults?.auxiliaryMaxRetries);
         setOutput('findings-count', 0);
         setOutput('critical-count', 0);
         setOutput('high-count', 0);
@@ -661,7 +666,7 @@ export async function runPRWorkflow(
 
       const reviewPhase = await Sentry.startSpan(
         { op: 'workflow.review', name: 'post reviews' },
-        () => postReviewsAndTrackFailures(octokit, context, results, inputs),
+        () => postReviewsAndTrackFailures(octokit, context, results, inputs, config.defaults?.auxiliaryMaxRetries),
       );
 
       const triggerErrors = collectTriggerErrors(results);
@@ -676,6 +681,7 @@ export async function runPRWorkflow(
           evaluateFixesAndResolveStale(
             octokit, context, reviewPhase.fetchedComments,
             allFindings, canResolveStale, inputs.anthropicApiKey,
+            config.defaults?.auxiliaryMaxRetries,
           ),
       );
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -293,6 +293,7 @@ async function runSkills(
     maxTurns: config?.defaults?.maxTurns,
     batchDelayMs: config?.defaults?.batchDelayMs,
     maxContextFiles: config?.defaults?.chunking?.maxContextFiles,
+    auxiliaryMaxRetries: config?.defaults?.auxiliaryMaxRetries,
   };
   const tasks: SkillTaskOptions[] = skillsToRun.map(({ skill, remote, filters }) => ({
     name: skill,
@@ -560,6 +561,7 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
       abortController,
       maxTurns: trigger.maxTurns,
       maxContextFiles: config.defaults?.chunking?.maxContextFiles,
+      auxiliaryMaxRetries: config.defaults?.auxiliaryMaxRetries,
     },
   }));
 

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -399,6 +399,7 @@ export async function runSkillTask(
         const mergeResult = await mergeCrossLocationFindings(uniqueFindings, {
           apiKey: runnerOptions.apiKey,
           repoPath: context.repoPath,
+          maxRetries: runnerOptions.auxiliaryMaxRetries,
         });
         const mergedFindings = mergeResult.findings;
         if (mergeResult.usage) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -171,6 +171,8 @@ export const DefaultsSchema = z.object({
   chunking: ChunkingConfigSchema.optional(),
   /** Delay in milliseconds between batch starts when processing files in parallel. Default: 0 */
   batchDelayMs: z.number().int().nonnegative().optional(),
+  /** Max retries for auxiliary Haiku calls (extraction repair, merging, dedup, fix evaluation). Default: 5 */
+  auxiliaryMaxRetries: z.number().int().positive().optional(),
 });
 export type Defaults = z.infer<typeof DefaultsSchema>;
 

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -381,7 +381,8 @@ interface SemanticDuplicateResult {
 async function findSemanticDuplicates(
   findings: Finding[],
   existingComments: ExistingComment[],
-  apiKey: string
+  apiKey: string,
+  maxRetries?: number
 ): Promise<SemanticDuplicateResult> {
   if (findings.length === 0 || existingComments.length === 0) {
     return { matches: new Map() };
@@ -421,6 +422,7 @@ Return [] if none are duplicates.`;
     prompt,
     schema: DuplicateMatchesSchema,
     maxTokens: 512,
+    maxRetries,
   });
 
   if (!result.success) {
@@ -450,6 +452,8 @@ export interface DeduplicateOptions {
   hashOnly?: boolean;
   /** Current skill name (for updating Warden comment attribution) */
   currentSkill?: string;
+  /** Max retries for auxiliary Haiku calls */
+  maxRetries?: number;
 }
 
 const ADD_REACTION_MUTATION = `
@@ -647,7 +651,7 @@ function findProximityClusters(findings: Finding[]): Finding[][] {
  */
 export async function consolidateBatchFindings(
   findings: Finding[],
-  options: { apiKey?: string; hashOnly?: boolean } = {}
+  options: { apiKey?: string; hashOnly?: boolean; maxRetries?: number } = {}
 ): Promise<ConsolidateResult> {
   if (findings.length <= 1) {
     return { findings, removedCount: 0 };
@@ -709,6 +713,7 @@ Return ONLY the JSON array. Return [] if no findings share a root cause.`;
     prompt,
     schema: ConsolidationGroupsSchema,
     maxTokens: 512,
+    maxRetries: options.maxRetries,
   });
 
   if (!result.success) {
@@ -813,7 +818,7 @@ export async function deduplicateFindings(
   }
 
   // Second pass: LLM semantic comparison for remaining findings
-  const semanticResult = await findSemanticDuplicates(hashDedupedFindings, existingComments, options.apiKey);
+  const semanticResult = await findSemanticDuplicates(hashDedupedFindings, existingComments, options.apiKey, options.maxRetries);
 
   if (semanticResult.matches.size > 0) {
     console.log(`Dedup: ${semanticResult.matches.size} findings identified as semantic duplicates by LLM`);

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -47,7 +47,8 @@ interface ParseHunkOutputResult {
 async function parseHunkOutput(
   result: SDKResultMessage,
   filename: string,
-  apiKey?: string
+  apiKey?: string,
+  auxiliaryMaxRetries?: number
 ): Promise<ParseHunkOutputResult> {
   if (result.subtype !== 'success') {
     // SDK error - not an extraction failure, just no findings
@@ -62,7 +63,7 @@ async function parseHunkOutput(
   }
 
   // Tier 2: Try LLM fallback for malformed output
-  const fallback = await extractFindingsWithLLM(result.result, apiKey);
+  const fallback = await extractFindingsWithLLM(result.result, apiKey, auxiliaryMaxRetries);
 
   if (fallback.success) {
     return { findings: validateFindings(fallback.findings, filename), extractionFailed: false, extractionMethod: 'llm', extractionUsage: fallback.usage };
@@ -455,7 +456,7 @@ async function analyzeHunk(
             };
           }
 
-          const parseResult = await parseHunkOutput(resultMessage, hunkCtx.filename, apiKey);
+          const parseResult = await parseHunkOutput(resultMessage, hunkCtx.filename, apiKey, options.auxiliaryMaxRetries);
 
           // Filter findings outside hunk line range (defense-in-depth)
           const hunkRange = getHunkLineRange(hunkCtx.hunk);
@@ -895,6 +896,7 @@ export async function runSkill(
   const mergeResult = await mergeCrossLocationFindings(uniqueFindings, {
     apiKey: options.apiKey,
     repoPath: context.repoPath,
+    maxRetries: options.auxiliaryMaxRetries,
   });
   const mergedFindings = mergeResult.findings;
   if (mergeResult.usage) {

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -6,7 +6,7 @@ import { customAlphabet } from 'nanoid';
 import { FindingSchema, compareFindingPriority } from '../types/index.js';
 import type { Finding, Location, UsageStats } from '../types/index.js';
 import { Sentry } from '../sentry.js';
-import { callHaiku, HAIKU_MODEL, setGenAiResponseAttrs } from './haiku.js';
+import { callHaiku, DEFAULT_AUXILIARY_MAX_RETRIES, HAIKU_MODEL, setGenAiResponseAttrs } from './haiku.js';
 import { apiUsageToStats } from './pricing.js';
 
 /** Pattern to match the start of findings JSON (allows whitespace after brace) */
@@ -173,7 +173,8 @@ export function truncateForLLMFallback(rawText: string, maxChars: number): strin
  */
 export async function extractFindingsWithLLM(
   rawText: string,
-  apiKey?: string
+  apiKey?: string,
+  maxRetries?: number
 ): Promise<ExtractFindingsResult> {
   if (!apiKey) {
     return {
@@ -208,7 +209,7 @@ export async function extractFindingsWithLLM(
     },
     async (span) => {
       try {
-        const client = new Anthropic({ apiKey, timeout: LLM_FALLBACK_TIMEOUT_MS });
+        const client = new Anthropic({ apiKey, timeout: LLM_FALLBACK_TIMEOUT_MS, maxRetries: maxRetries ?? DEFAULT_AUXILIARY_MAX_RETRIES });
         const userContent = `Extract the findings JSON from this model output.
 Return ONLY valid JSON in format: {"findings": [...]}
 If no findings exist, return: {"findings": []}
@@ -475,7 +476,7 @@ function readSnippet(repoPath: string, filePath: string, startLine: number, cont
  */
 export async function mergeCrossLocationFindings(
   findings: Finding[],
-  options?: { apiKey?: string; repoPath?: string }
+  options?: { apiKey?: string; repoPath?: string; maxRetries?: number }
 ): Promise<MergeResult> {
   const apiKey = options?.apiKey;
   const repoPath = options?.repoPath ?? '.';
@@ -509,6 +510,7 @@ Singletons should not appear. Return [] if no findings describe the same issue.`
     prompt,
     schema: MergeGroupsSchema,
     maxTokens: 512,
+    maxRetries: options?.maxRetries,
   });
 
   if (!result.success) {

--- a/src/sdk/haiku.ts
+++ b/src/sdk/haiku.ts
@@ -7,6 +7,7 @@ import { apiUsageToStats } from './pricing.js';
 import { aggregateUsage, emptyUsage } from './usage.js';
 
 export const HAIKU_MODEL = 'claude-haiku-4-5';
+export const DEFAULT_AUXILIARY_MAX_RETRIES = 5;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_TOKENS = 4096;
 
@@ -124,6 +125,7 @@ export interface CallHaikuOptions<T> {
   schema: z.ZodType<T>;
   maxTokens?: number;
   timeout?: number;
+  maxRetries?: number;
 }
 
 /**
@@ -142,7 +144,7 @@ function inferPrefill(schema: z.ZodType): string | undefined {
  * Auto-prefills based on Zod schema type, extracts JSON, validates with Zod.
  */
 export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuResult<T>> {
-  const { apiKey, prompt, schema, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS } = options;
+  const { apiKey, prompt, schema, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES } = options;
 
   return Sentry.startSpan(
     {
@@ -156,7 +158,7 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
       },
     },
     async (span) => {
-      const client = new Anthropic({ apiKey, timeout });
+      const client = new Anthropic({ apiKey, timeout, maxRetries });
       const prefill = inferPrefill(schema);
 
       const messages: Anthropic.MessageParam[] = [
@@ -221,6 +223,7 @@ export interface CallHaikuWithToolsOptions<T> {
   maxTokens?: number;
   maxIterations?: number;
   timeout?: number;
+  maxRetries?: number;
 }
 
 /**
@@ -238,6 +241,7 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
     maxTokens = DEFAULT_MAX_TOKENS,
     maxIterations = 5,
     timeout = DEFAULT_TIMEOUT_MS,
+    maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES,
   } = options;
 
   return Sentry.startSpan(
@@ -252,7 +256,7 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
       },
     },
     async (span) => {
-      const client = new Anthropic({ apiKey, timeout });
+      const client = new Anthropic({ apiKey, timeout, maxRetries });
 
       // No prefill for tool-use loops: prefill biases the model to output JSON
       // immediately instead of calling tools to gather information first.

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -79,6 +79,8 @@ export interface SkillRunnerOptions {
   verbose?: boolean;
   /** Max number of "other files" to list in hunk prompts for PR context (default: 50, 0 disables) */
   maxContextFiles?: number;
+  /** Max retries for auxiliary Haiku calls (extraction repair, merging, dedup, fix evaluation). Default: 5 */
+  auxiliaryMaxRetries?: number;
 }
 
 /**


### PR DESCRIPTION
Make the retry count for auxiliary Haiku calls configurable through `defaults.auxiliaryMaxRetries` in `warden.toml`.

Auxiliary calls (extraction repair, cross-location merging, dedup, fix evaluation) used a hardcoded retry count of 2 (Anthropic SDK default). During sustained overload (529 responses), findings from expensive SDK queries were permanently lost because a cheap auxiliary call gave up too early.

This adds `auxiliaryMaxRetries` as a global config option (like `batchDelayMs`) and threads it through all auxiliary call sites. The hardcoded constant is renamed from `HAIKU_MAX_RETRIES` to `DEFAULT_AUXILIARY_MAX_RETRIES` (5), so existing behavior is unchanged without config.

Example config:
```toml
[defaults]
auxiliaryMaxRetries = 10
```