### PR TITLE
chore: Add .serena to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /.dex/*
 !/.dex/config.toml
 
+# AI tooling
+.serena/
+
 # Dependencies
 node_modules/
 


### PR DESCRIPTION
Add Serena AI tooling directory to gitignore

Serena generates local project configuration and memory files under `.serena/` that are specific to each developer's environment and should not be tracked in version control.