### PR TITLE
feat(init): Add section-based output and interactive skill prompt

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -214,7 +214,7 @@ describe('init command', () => {
       expect(existsSync(join(tempDir, '.claude', 'skills'))).toBe(false);
     });
 
-    it('skips symlink if .claude/skills already exists without --force', async () => {
+    it('replaces existing .claude/skills directory with symlink using --force', async () => {
       mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
 
       const reporter = createMockReporter();

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -332,11 +332,11 @@ export async function runInit(options: CLIOptions, reporter: Reporter): Promise<
     `Bundled skills for AI agents (${skillNames.join(', ')})`,
   );
   if (allSkillsInstalled(repoRoot) && !options.force) {
-    ensureClaudeSymlink(repoRoot, false, reporter);
+    if (ensureClaudeSymlink(repoRoot, false, reporter)) filesCreated++;
     renderSkipped(reporter, 'already installed');
   } else if (options.force) {
     const count = installBundledSkills(repoRoot, true, reporter);
-    ensureClaudeSymlink(repoRoot, true, reporter);
+    if (ensureClaudeSymlink(repoRoot, true, reporter)) filesCreated++;
     renderCreated(reporter);
     filesCreated += count;
   } else if (reporter.mode.isTTY && process.stdin.isTTY) {
@@ -347,7 +347,7 @@ export async function runInit(options: CLIOptions, reporter: Reporter): Promise<
 
     if (key.toLowerCase() !== 'n') {
       const count = installBundledSkills(repoRoot, false, reporter);
-      ensureClaudeSymlink(repoRoot, false, reporter);
+      if (ensureClaudeSymlink(repoRoot, false, reporter)) filesCreated++;
       renderCreated(reporter);
       filesCreated += count;
     } else {


### PR DESCRIPTION
Restructure `warden init` output into clearly labeled CONFIG / WORKFLOW / SKILLS
sections with headings, descriptions, and status indicators. Skill installation
now prompts interactively in TTY mode instead of installing silently, skips in
non-TTY mode, and always installs with `--force`.