### PR TITLE
fix(types): Move FixStatusSchema to shared types to fix npm install

### DIFF
--- a/src/action/fix-evaluation/types.ts
+++ b/src/action/fix-evaluation/types.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
-import type { UsageStats } from '../../types/index.js';
+import { FixStatusSchema } from '../../types/index.js';
+import type { UsageStats, FixStatus } from '../../types/index.js';
 import type { ExistingComment } from '../../output/dedup.js';
 
-export const FixStatusSchema = z.enum(['not_attempted', 'attempted_failed', 'resolved']);
-export type FixStatus = z.infer<typeof FixStatusSchema>;
+export { FixStatusSchema };
+export type { FixStatus };
 
 export const FixJudgeVerdictSchema = z.object({
   status: FixStatusSchema,

--- a/src/cli/output/jsonl.ts
+++ b/src/cli/output/jsonl.ts
@@ -8,9 +8,9 @@ import {
   SkippedFileSchema,
   AuxiliaryUsageMapSchema,
   SeveritySchema,
+  FixStatusSchema,
 } from '../../types/index.js';
 import type { SkillReport, UsageStats, AuxiliaryUsageMap } from '../../types/index.js';
-import { FixStatusSchema } from '../../action/fix-evaluation/types.js';
 import { mergeAuxiliaryUsage } from '../../sdk/usage.js';
 import { countBySeverity } from './formatters.js';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -239,3 +239,7 @@ export const RetryConfigSchema = z.object({
   maxDelayMs: z.number().int().positive().default(30000),
 });
 export type RetryConfig = z.infer<typeof RetryConfigSchema>;
+
+// Fix evaluation status
+export const FixStatusSchema = z.enum(['not_attempted', 'attempted_failed', 'resolved']);
+export type FixStatus = z.infer<typeof FixStatusSchema>;


### PR DESCRIPTION
The CLI imports `FixStatusSchema` but it lived under `src/action/`, which is excluded from the npm package via `.npmignore`. This caused ERR_MODULE_NOT_FOUND at runtime after installation via npm, etc.

This got me unblocked locally. Not sure if I did the PR process right, but figured I'd at least give it a shot. Other option would be to not ignore the file in `/action`, but assumed that was getting ignored for a reason. 

Fixes #183 