### PR TITLE
fix: Exclude dev files and secrets from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,10 @@ action.yml
 **/*.test.*
 vitest*.config.ts
 
+# Environment and secrets (.npmignore overrides .gitignore)
+.env
+.env.*
+
 # Development/CI files
 .github/
 .agents/
@@ -23,6 +27,17 @@ tsconfig.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
 
+# Evals and dev scripts
+evals/
+scripts/
+
+# Plugin/agent config (not needed by npm consumers)
+plugins/
+.claude-plugin/
+.mcp.json
+agents.toml
+conductor.json
+
 # Release tooling
 .craft.yml
 bin/
@@ -32,6 +47,7 @@ AGENTS.md
 CLAUDE.md
 CONTRIBUTING.md
 SPEC.md
+docs/
 packages/
 assets/
 specs/


### PR DESCRIPTION
The `.npmignore` was missing exclusions for several file categories, causing
them to ship in the npm package unnecessarily. Since `.npmignore` overrides
`.gitignore` entirely, the `.env` patterns were particularly important as
they could leak secrets during `npm publish`.

Added exclusions for:
- `.env` / `.env.*` (secrets -- critical since `.npmignore` overrides `.gitignore`)
- `evals/` (test fixtures and eval specs)
- `scripts/` (dev scripts like `update-pricing.ts`)
- `plugins/`, `.claude-plugin/`, `.mcp.json`, `agents.toml`, `conductor.json` (agent/plugin config)
- `docs/` (docs site, could pull in `node_modules/` if present locally)

Package size drops from ~20k files to 300 files.