### PR TITLE
fix(output): Use backticks instead of brackets in attribution footer

### DIFF
--- a/specs/github-comments.md
+++ b/specs/github-comments.md
@@ -18,13 +18,13 @@ How Warden formats and manages PR comments: format conventions, deduplication, a
 
 </details>
 
-<sub>Identified by Warden [skill-name] · FINDING-ID</sub>
+Identified by Warden `skill-name` · `FINDING-ID`
 <!-- warden:v1:path:line:hash -->
 ```
 
 - Title: bold, no emoji, no ID, no confidence, no severity
 - Severity is communicated via GitHub check annotation level (failure/warning/notice)
-- Footer: skill name in brackets, finding ID after separator
+- Footer: skill name and finding ID in backticks
 - Additional locations in collapsible details block
 
 ### Summary Comment Finding Item
@@ -51,18 +51,19 @@ Capitalize severity labels, no emoji.
 
 Description
 
-<sub>Identified by Warden [skill-name]</sub>
+Identified by Warden `skill-name`
 ```
 
 ### Attribution Formats
 
 Current format:
 ```
-<sub>Identified by Warden [skill1], [skill2] · FINDING-ID</sub>
+Identified by Warden `skill1`, `skill2` · `FINDING-ID`
 ```
 
 Legacy formats (still parsed for backward compat):
 ```
+<sub>Identified by Warden [skill1], [skill2] · FINDING-ID</sub>
 <sub>Identified by Warden via `skill1`, `skill2` · severity, confidence</sub>
 <sub>warden: skill1, skill2</sub>
 ```
@@ -137,8 +138,8 @@ When Warden detects an issue it already posted about:
 
 **Attribution update example**:
 ```
-Before: <sub>Identified by Warden [security-review] · ABC-123</sub>
-After:  <sub>Identified by Warden [security-review], [code-quality] · ABC-123</sub>
+Before: Identified by Warden `security-review` · `ABC-123`
+After:  Identified by Warden `security-review`, `code-quality` · `ABC-123`
 ```
 
 ### Same Finding from Others
@@ -255,7 +256,7 @@ Run 2: code-quality also detects it
 
 Result:
 - One comment at db.ts:42
-- Attribution: "Identified by Warden [security-review], [code-quality] · SQL-001"
+- Attribution: "Identified by Warden `security-review`, `code-quality` · `SQL-001`"
 ```
 
 ### Human Found It First

--- a/specs/github-pr-review.md
+++ b/specs/github-pr-review.md
@@ -90,7 +90,7 @@ Each inline comment includes:
 2. Description
 3. Suggested fix (if available, as GitHub suggestion block)
 4. Additional locations (collapsible, if any)
-5. Attribution footnote (`Identified by Warden [skill-name] · finding-id`)
+5. Attribution footnote (`Identified by Warden \`skill-name\` · \`finding-id\``)
 6. Hidden deduplication marker
 
 ### Multi-line Findings

--- a/src/output/dedup.test.ts
+++ b/src/output/dedup.test.ts
@@ -161,6 +161,11 @@ describe('isWardenComment', () => {
     expect(isWardenComment(body)).toBe(true);
   });
 
+  it('returns true for current backtick format attribution', () => {
+    const body = `**Issue**\n\nDescription\n\nIdentified by Warden \`skill\` · ABC-123`;
+    expect(isWardenComment(body)).toBe(true);
+  });
+
   it('returns false for regular comment', () => {
     const body = 'This is a regular comment.';
     expect(isWardenComment(body)).toBe(false);
@@ -429,6 +434,21 @@ describe('parseWardenSkills', () => {
     const body = `<sub>Identified by Warden [skill1], [skill2], [skill3] · XYZ-789</sub>`;
     expect(parseWardenSkills(body)).toEqual(['skill1', 'skill2', 'skill3']);
   });
+
+  it('parses single skill from current backtick format', () => {
+    const body = `Identified by Warden \`notseer\` · ABC-123`;
+    expect(parseWardenSkills(body)).toEqual(['notseer']);
+  });
+
+  it('parses multiple skills from current backtick format', () => {
+    const body = `Identified by Warden \`skill1\`, \`skill2\` · ABC-123`;
+    expect(parseWardenSkills(body)).toEqual(['skill1', 'skill2']);
+  });
+
+  it('parses current backtick format with three skills', () => {
+    const body = `Identified by Warden \`skill1\`, \`skill2\`, \`skill3\` · XYZ-789`;
+    expect(parseWardenSkills(body)).toEqual(['skill1', 'skill2', 'skill3']);
+  });
 });
 
 describe('updateWardenCommentBody', () => {
@@ -501,6 +521,30 @@ describe('updateWardenCommentBody', () => {
     const body = `<sub>Identified by Warden [skill1], [skill2] · ABC-123</sub>`;
     const result = updateWardenCommentBody(body, 'skill3');
     expect(result).toContain('<sub>Identified by Warden [skill1], [skill2], [skill3] · ABC-123</sub>');
+  });
+
+  it('adds new skill to current backtick format attribution', () => {
+    const body = `**Issue**\n\nDescription\n\nIdentified by Warden \`skill1\` · ABC-123`;
+    const result = updateWardenCommentBody(body, 'skill2');
+    expect(result).toContain('Identified by Warden `skill1`, `skill2` · ABC-123');
+  });
+
+  it('returns null if skill already listed in current backtick format', () => {
+    const body = `Identified by Warden \`skill1\` · ABC-123`;
+    const result = updateWardenCommentBody(body, 'skill1');
+    expect(result).toBeNull();
+  });
+
+  it('preserves finding ID in current backtick format', () => {
+    const body = `**Issue**\n\nDescription\n\nIdentified by Warden \`notseer\` · 2K5-29B`;
+    const result = updateWardenCommentBody(body, 'security-review');
+    expect(result).toContain('Identified by Warden `notseer`, `security-review` · 2K5-29B');
+  });
+
+  it('adds skill to current backtick format with multiple existing skills', () => {
+    const body = `Identified by Warden \`skill1\`, \`skill2\` · ABC-123`;
+    const result = updateWardenCommentBody(body, 'skill3');
+    expect(result).toContain('Identified by Warden `skill1`, `skill2`, `skill3` · ABC-123');
   });
 });
 

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -138,11 +138,13 @@ export function parseWardenComment(body: string): { title: string; description: 
 
 /**
  * Check if a comment body is a Warden-generated comment.
- * Supports old format (<sub>warden: skill</sub>), via format (<sub>Identified by Warden via `skill`</sub>),
- * and new bracket format (<sub>Identified by Warden [skill]</sub>).
+ * Supports current format (Identified by Warden `skill`), and legacy formats:
+ * bracket (<sub>Identified by Warden [skill]</sub>), via (<sub>Identified by Warden via `skill`</sub>),
+ * old (<sub>warden: skill</sub>).
  */
 export function isWardenComment(body: string): boolean {
   return (
+    body.includes('Identified by Warden `') ||
     body.includes('<sub>warden:') ||
     body.includes('<sub>Identified by Warden via') ||
     body.includes('<sub>Identified by Warden [') ||
@@ -152,13 +154,23 @@ export function isWardenComment(body: string): boolean {
 
 /**
  * Parse skill names from a Warden comment's attribution line.
- * Supports three formats:
- * - Old: "<sub>warden: skill1, skill2</sub>"
- * - Via: "<sub>Identified by Warden via `skill1`, `skill2` · severity</sub>"
- * - Bracket: "<sub>Identified by Warden [skill1], [skill2] · id</sub>"
+ * Supports four formats:
+ * - Current: "Identified by Warden `skill1`, `skill2` · id"
+ * - Legacy bracket: "<sub>Identified by Warden [skill1], [skill2] · id</sub>"
+ * - Legacy via: "<sub>Identified by Warden via `skill1`, `skill2` · severity</sub>"
+ * - Legacy old: "<sub>warden: skill1, skill2</sub>"
  */
 export function parseWardenSkills(body: string): string[] {
-  // Try bracket format: <sub>Identified by Warden [skill1], [skill2] · id</sub>
+  // Try current backtick format (no "via"): Identified by Warden `skill1`, `skill2` · id
+  const backtickMatch = body.match(/Identified by Warden ((?:`[^`]+`(?:, )?)+)/);
+  if (backtickMatch?.[1]) {
+    const skills = [...backtickMatch[1].matchAll(/`([^`]+)`/g)]
+      .map((m) => m[1])
+      .filter((s): s is string => s !== undefined);
+    if (skills.length > 0) return skills;
+  }
+
+  // Try legacy bracket format: <sub>Identified by Warden [skill1], [skill2] · id</sub>
   const bracketMatch = body.match(/<sub>Identified by Warden ((?:\[[^\]]+\](?:, )?)+)/);
   if (bracketMatch?.[1]) {
     const skills = [...bracketMatch[1].matchAll(/\[([^\]]+)\]/g)]
@@ -167,7 +179,7 @@ export function parseWardenSkills(body: string): string[] {
     if (skills.length > 0) return skills;
   }
 
-  // Try via format: <sub>Identified by Warden via `skill1`, `skill2` · severity</sub>
+  // Try legacy via format: <sub>Identified by Warden via `skill1`, `skill2` · severity</sub>
   const viaMatch = body.match(/<sub>Identified by Warden via ([^·<]+)/);
   if (viaMatch?.[1]) {
     const skills = [...viaMatch[1].matchAll(/`([^`]+)`/g)]
@@ -176,7 +188,7 @@ export function parseWardenSkills(body: string): string[] {
     if (skills.length > 0) return skills;
   }
 
-  // Fall back to old format: <sub>warden: skill1, skill2</sub>
+  // Fall back to legacy old format: <sub>warden: skill1, skill2</sub>
   const oldMatch = body.match(/<sub>warden:\s*([^<]+)<\/sub>/);
   if (!oldMatch?.[1]) {
     return [];
@@ -189,11 +201,13 @@ export function parseWardenSkills(body: string): string[] {
 
 /**
  * Update a Warden comment body to add a new skill to the attribution.
- * Old format: Changes "<sub>warden: skill1</sub>" to "<sub>warden: skill1, skill2</sub>"
- * Via format: Changes "<sub>Identified by Warden via `skill1` · severity</sub>"
- *             to "<sub>Identified by Warden via `skill1`, `skill2` · severity</sub>"
- * Bracket format: Changes "<sub>Identified by Warden [skill1] · id</sub>"
+ * Current format: Changes "Identified by Warden `skill1` · id"
+ *                 to "Identified by Warden `skill1`, `skill2` · id"
+ * Legacy bracket: Changes "<sub>Identified by Warden [skill1] · id</sub>"
  *                 to "<sub>Identified by Warden [skill1], [skill2] · id</sub>"
+ * Legacy via: Changes "<sub>Identified by Warden via `skill1` · severity</sub>"
+ *             to "<sub>Identified by Warden via `skill1`, `skill2` · severity</sub>"
+ * Legacy old: Changes "<sub>warden: skill1</sub>" to "<sub>warden: skill1, skill2</sub>"
  * Returns null if skill is already listed or if no attribution tag exists.
  */
 export function updateWardenCommentBody(body: string, newSkill: string): string | null {
@@ -209,7 +223,19 @@ export function updateWardenCommentBody(body: string, newSkill: string): string 
     return null;
   }
 
-  // Check if it's the bracket format: <sub>Identified by Warden [skill] · id</sub>
+  // Check if it's the current backtick format (no <sub>, no "via"): Identified by Warden `skill` · id
+  const backtickFormatMatch = body.match(/Identified by Warden `[^`]+`/) && !body.includes('<sub>Identified by Warden');
+  if (backtickFormatMatch) {
+    const existingSkillsFormatted = existingSkills.map((s) => `\`${s}\``).join(', ');
+    const lineMatch = body.match(/Identified by Warden ((?:`[^`]+`(?:, )?)+)(.*)/);
+    const suffix = lineMatch?.[2] || '';
+    return body.replace(
+      /Identified by Warden (?:`[^`]+`(?:, )?)+.*/,
+      () => `Identified by Warden ${existingSkillsFormatted}, \`${newSkill}\`${suffix}`
+    );
+  }
+
+  // Check if it's the legacy bracket format: <sub>Identified by Warden [skill] · id</sub>
   const bracketFormatMatch = body.match(/<sub>Identified by Warden \[[^\]]+\]/);
   if (bracketFormatMatch) {
     const existingSkillsFormatted = existingSkills.map((s) => `[${s}]`).join(', ');
@@ -221,7 +247,7 @@ export function updateWardenCommentBody(body: string, newSkill: string): string 
     );
   }
 
-  // Check if it's the via format
+  // Check if it's the legacy via format
   const viaFormatMatch = body.match(/<sub>Identified by Warden via `[^`]+`/);
   if (viaFormatMatch) {
     const existingSkillsFormatted = existingSkills.map((s) => `\`${s}\``).join(', ');
@@ -236,7 +262,7 @@ export function updateWardenCommentBody(body: string, newSkill: string): string 
     );
   }
 
-  // Old format: <sub>warden: skill1, skill2</sub>
+  // Legacy old format: <sub>warden: skill1, skill2</sub>
   const allSkills = [...existingSkills, newSkill].join(', ');
   // Use a replacer function to avoid special $ character interpretation in skill names
   return body.replace(/<sub>warden:\s*[^<]+<\/sub>/, () => `<sub>warden: ${allSkills}</sub>`);

--- a/src/output/renderer.test.ts
+++ b/src/output/renderer.test.ts
@@ -69,7 +69,7 @@ describe('renderSkillReport', () => {
     const result = renderSkillReport(report);
 
     expect(result.review).toBeDefined();
-    expect(result.review!.comments[0]!.body).toContain('<sub>Identified by Warden [code-review] · f1</sub>');
+    expect(result.review!.comments[0]!.body).toContain('Identified by Warden `code-review` · `f1`');
   });
 
   it('does not include confidence in attribution footnote', () => {
@@ -95,7 +95,7 @@ describe('renderSkillReport', () => {
 
     expect(result.review).toBeDefined();
     expect(result.review!.comments[0]!.body).toContain(
-      '<sub>Identified by Warden [security-review] · f1</sub>'
+      'Identified by Warden `security-review` · `f1`'
     );
     expect(result.review!.comments[0]!.body).not.toContain('confidence');
   });
@@ -736,7 +736,7 @@ describe('renderSkillReport', () => {
     expect(result.review!.comments).toHaveLength(0);
     expect(result.review!.body).toContain('General Issue');
     expect(result.review!.body).toContain('Applies to whole project');
-    expect(result.review!.body).toContain('Identified by Warden [security-review]');
+    expect(result.review!.body).toContain('Identified by Warden `security-review`');
     expect(result.summaryComment).toContain('General Issue');
     expect(result.summaryComment).toContain('General');
   });
@@ -1278,7 +1278,7 @@ describe('renderFindingsBody', () => {
     expect(body).toContain('**SQL Injection**');
     expect(body).toContain('(`src/db.ts:42`)');
     expect(body).toContain('User input in query');
-    expect(body).toContain('<sub>Identified by Warden [security-review]</sub>');
+    expect(body).toContain('Identified by Warden `security-review`');
   });
 
   it('renders findings without location', () => {

--- a/src/output/renderer.ts
+++ b/src/output/renderer.ts
@@ -92,7 +92,7 @@ function renderReview(
     }
 
     // Add attribution footnote with skill name and finding ID
-    body += `\n\n<sub>Identified by Warden [${report.skill}] · ${finding.id}</sub>`;
+    body += `\n\nIdentified by Warden \`${report.skill}\` · \`${finding.id}\``;
 
     // Add deduplication marker
     const contentHash = generateContentHash(finding.title, finding.description);
@@ -271,7 +271,7 @@ export function renderFindingsBody(findings: Finding[], skill: string): string {
     lines.push(escapeHtml(finding.description));
     lines.push('');
   }
-  lines.push(`<sub>Identified by Warden [${skill}]</sub>`);
+  lines.push(`Identified by Warden \`${skill}\``);
   return lines.join('\n');
 }
 


### PR DESCRIPTION
GitHub's Markdown parser interprets `[skill-name]` inside `<sub>` tags as a link reference, causing skill names to render as clickable elements with no real target.

Switches the attribution footer from `<sub>Identified by Warden [skill] · ID</sub>` to plain `Identified by Warden \`skill\` · \`ID\``. Drops the `<sub>` wrapper entirely for cleaner rendering.

Legacy bracket, via, and old attribution formats are still parsed for backward compatibility with existing PR comments.