### PR TITLE
chore(config): Exclude evals directory from warden analysis

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -6,7 +6,7 @@ failOn = "high"
 # Show annotations for medium+ severity findings
 reportOn = "medium"
 # Exclude build output from all skills
-ignorePaths = ["dist/**"]
+ignorePaths = ["dist/**", "evals/**"]
 
 [[skills]]
 name = "find-warden-bugs"


### PR DESCRIPTION
Eval fixtures contain intentionally buggy code that warden flags as real
issues. Adding `evals/**` to the global `ignorePaths` prevents noise during
sweeps and CI runs.