### PR TITLE
fix: Respect ignorePaths in all code paths

### DIFF
--- a/skills/warden-sweep/scripts/scan.py
+++ b/skills/warden-sweep/scripts/scan.py
@@ -246,7 +246,7 @@ def enumerate_files(
 ) -> list[str]:
     """Enumerate files to scan using git ls-files, filtered by extension."""
     if specific_files:
-        return specific_files
+        return [f for f in specific_files if not should_ignore(f, ignore_patterns)]
 
     result = run_cmd(["git", "ls-files"])
     if result.returncode != 0:

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -347,7 +347,12 @@ async function runSkills(
     const match = config
       ? resolveSkillConfigs(config, options.model).find((t) => t.skill === options.skill)
       : undefined;
-    skillsToRun = [{ skill: options.skill, remote: match?.remote, filters: match?.filters ?? {} }];
+    // Fall back to global defaults when the skill isn't in the config
+    const defaultIgnorePaths = config?.defaults?.ignorePaths;
+    const fallbackFilters = defaultIgnorePaths?.length
+      ? { ignorePaths: defaultIgnorePaths }
+      : {};
+    skillsToRun = [{ skill: options.skill, remote: match?.remote, filters: match?.filters ?? fallbackFilters }];
   } else if (config) {
     // Get skills from matched triggers, preserving remote property and filters
     const resolvedTriggers = resolveSkillConfigs(config, options.model);


### PR DESCRIPTION
Two places silently dropped `defaults.ignorePaths` from `warden.toml`:

1. **warden-sweep `scan.py`**: When specific files were passed as arguments
   (`uv run scan.py evals/fixtures/foo.ts`), `enumerate_files()` returned
   them directly without checking ignore patterns. Now filters them through
   `should_ignore()`.

2. **CLI `--skill` flag**: When `warden <target> --skill <name>` referenced
   a skill not defined in `warden.toml`, the fallback filters were `{}`,
   losing global ignores like `dist/**` and `evals/**`. Now falls back to
   `defaults.ignorePaths` instead of empty filters.