### PR TITLE
feat(cli): Add --staged flag and default to HEAD for uncommitted changes

### DIFF
--- a/packages/docs/src/pages/guide.astro
+++ b/packages/docs/src/pages/guide.astro
@@ -97,7 +97,21 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...`}
     />
   </Terminal>
 
-  <p>Warden analyzes staged and unstaged changes, running any skills that match via your configured triggers.</p>
+  <p>Warden analyzes all uncommitted changes (staged and unstaged) against HEAD, running any skills that match via your configured triggers.</p>
+
+  <h3>Review Only Staged Changes</h3>
+
+  <p>For pre-commit workflows, analyze only what you're about to commit:</p>
+
+  <Terminal showCopy={true}>
+    <Code
+      code={`warden --staged`}
+      lang="bash"
+      theme="vitesse-black"
+    />
+  </Terminal>
+
+  <p>This uses <code>git diff --cached</code> so only staged files are analyzed.</p>
 
   <h3>Review Before Pushing</h3>
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -37,6 +37,8 @@ export const CLIOptionsSchema = z.object({
   list: z.boolean().default(false),
   /** Force interpretation of ambiguous targets as git refs */
   git: z.boolean().default(false),
+  /** Analyze only staged changes (git diff --cached) */
+  staged: z.boolean().default(false),
   /** Remote repository reference for skills (e.g., "owner/repo" or "owner/repo@sha") */
   remote: z.string().optional(),
   /** Skip network operations - only use cached remote skills */
@@ -109,6 +111,7 @@ Options:
   --fix                Automatically apply all suggested fixes
   --parallel <n>       Max concurrent trigger/skill executions (default: 4)
   -x, --fail-fast      Stop after first finding
+  --staged             Analyze only staged changes
   --git                Force ambiguous targets to be treated as git refs
   --quiet              Errors and final summary only
   -v, --verbose        Show real-time findings and hunk details
@@ -291,6 +294,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       'fail-fast': { type: 'boolean', short: 'x', default: false },
       parallel: { type: 'string' },
       git: { type: 'boolean', default: false },
+      staged: { type: 'boolean', default: false },
       log: { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'V', default: false },
@@ -465,6 +469,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
     force: values.force,
     parallel: values.parallel ? parseInt(values.parallel, 10) : undefined,
     git: values.git,
+    staged: values.staged,
     log: values.log,
     offline: values.offline,
     failFast: values['fail-fast'],

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -26,6 +26,7 @@ function createOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
     force: false,
     list: false,
     git: false,
+    staged: false,
     offline: false,
     failFast: false,
     ...overrides,

--- a/src/cli/commands/logs.test.ts
+++ b/src/cli/commands/logs.test.ts
@@ -27,6 +27,7 @@ function createDefaultOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
     force: false,
     list: false,
     git: false,
+    staged: false,
     offline: false,
     failFast: false,
     log: false,

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -34,6 +34,8 @@ export interface LocalContextOptions {
   cwd?: string;
   /** Override auto-detected default branch (from config) */
   defaultBranch?: string;
+  /** Analyze only staged changes (git diff --cached) */
+  staged?: boolean;
 }
 
 /**
@@ -49,12 +51,14 @@ export function buildLocalEventContext(options: LocalContextOptions = {}): Event
   const { owner, name } = getRepoName(cwd);
   const defaultBranch = options.defaultBranch ?? getDefaultBranch(cwd);
 
-  const base = options.base ?? defaultBranch;
+  // When staged, always diff against HEAD (index vs HEAD)
+  const staged = options.staged ?? false;
+  const base = staged ? 'HEAD' : (options.base ?? defaultBranch);
   const head = options.head; // undefined means working tree
   const currentBranch = getCurrentBranch(cwd);
   const headSha = head ? head : getHeadSha(cwd);
 
-  const changedFiles = getChangedFilesWithPatches(base, head, cwd);
+  const changedFiles = getChangedFilesWithPatches(base, head, cwd, { staged });
   const files = changedFiles.map(toFileChange);
 
   // Use actual commit message when analyzing a specific commit
@@ -64,9 +68,12 @@ export function buildLocalEventContext(options: LocalContextOptions = {}): Event
     const commitMsg = getCommitMessage(head, cwd);
     title = commitMsg.subject || `Commit ${head}`;
     body = commitMsg.body || `Analyzing changes in ${head}`;
+  } else if (staged) {
+    title = `Staged changes: ${currentBranch}`;
+    body = `Analyzing staged changes`;
   } else {
     title = `Local changes: ${currentBranch}`;
-    body = `Analyzing local changes from ${base} to working tree`;
+    body = `Analyzing uncommitted changes from HEAD`;
   }
 
   return {

--- a/src/cli/git.ts
+++ b/src/cli/git.ts
@@ -170,18 +170,36 @@ function mapStatus(status: string): GitFileChange['status'] {
   }
 }
 
+export interface DiffOptions {
+  /** Use --cached to diff only staged changes against HEAD */
+  staged?: boolean;
+}
+
+/**
+ * Build the git diff arguments for a given base/head/staged configuration.
+ */
+function buildDiffArgs(base: string, head: string | undefined, options?: DiffOptions): string[] {
+  if (options?.staged) {
+    return ['diff', '--cached'];
+  }
+  const diffRef = head ? `${base}...${head}` : base;
+  return ['diff', diffRef];
+}
+
 /**
  * Get list of changed files between two refs.
  * If head is undefined, compares against the working tree.
+ * If options.staged is true, compares only staged changes against HEAD.
  */
 export function getChangedFiles(
   base: string,
   head?: string,
-  cwd: string = process.cwd()
+  cwd: string = process.cwd(),
+  options?: DiffOptions
 ): GitFileChange[] {
   // Get file statuses
-  const diffRef = head ? `${base}...${head}` : base;
-  const nameStatusOutput = git(['diff', '--name-status', diffRef], cwd);
+  const baseArgs = buildDiffArgs(base, head, options);
+  const nameStatusOutput = git([...baseArgs, '--name-status'], cwd);
 
   if (!nameStatusOutput) {
     return [];
@@ -207,7 +225,7 @@ export function getChangedFiles(
   }
 
   // Get numstat for additions/deletions
-  const numstatOutput = git(['diff', '--numstat', diffRef], cwd);
+  const numstatOutput = git([...baseArgs, '--numstat'], cwd);
   if (numstatOutput) {
     for (const line of numstatOutput.split('\n')) {
       if (!line.trim()) continue;
@@ -233,11 +251,12 @@ export function getFilePatch(
   base: string,
   head: string | undefined,
   filename: string,
-  cwd: string = process.cwd()
+  cwd: string = process.cwd(),
+  options?: DiffOptions
 ): string | undefined {
   try {
-    const diffRef = head ? `${base}...${head}` : base;
-    return git(['diff', diffRef, '--', filename], cwd);
+    const baseArgs = buildDiffArgs(base, head, options);
+    return git([...baseArgs, '--', filename], cwd);
   } catch {
     return undefined;
   }
@@ -276,9 +295,10 @@ function parseCombinedDiff(diffOutput: string): Map<string, string> {
 export function getChangedFilesWithPatches(
   base: string,
   head?: string,
-  cwd: string = process.cwd()
+  cwd: string = process.cwd(),
+  options?: DiffOptions
 ): GitFileChange[] {
-  const files = getChangedFiles(base, head, cwd);
+  const files = getChangedFiles(base, head, cwd, options);
 
   if (files.length === 0) {
     return files;
@@ -286,8 +306,8 @@ export function getChangedFilesWithPatches(
 
   // Get all patches in a single git diff command
   try {
-    const diffRef = head ? `${base}...${head}` : base;
-    const combinedDiff = git(['diff', diffRef], cwd);
+    const baseArgs = buildDiffArgs(base, head, options);
+    const combinedDiff = git(baseArgs, cwd);
     const patches = parseCombinedDiff(combinedDiff);
 
     for (const file of files) {
@@ -297,7 +317,7 @@ export function getChangedFilesWithPatches(
   } catch {
     // Fall back to per-file patches if combined diff fails
     for (const file of files) {
-      file.patch = getFilePatch(base, head, file.filename, cwd);
+      file.patch = getFilePatch(base, head, file.filename, cwd, options);
       file.chunks = countPatchChunks(file.patch);
     }
   }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -582,11 +582,14 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
   // Load config
   const config = loadWardenConfig(dirname(configPath));
 
-  // Build context from local git
-  reporter.startContext('Analyzing uncommitted changes...');
+  // Build context from local git — default to HEAD so only uncommitted changes are analyzed
+  const statusMessage = options.staged ? 'Analyzing staged changes...' : 'Analyzing uncommitted changes...';
+  reporter.startContext(statusMessage);
   const context = buildLocalEventContext({
+    base: 'HEAD',
     cwd: repoPath,
     defaultBranch: config.defaults?.defaultBranch,
+    staged: options.staged,
   });
 
   const pullRequest = context.pullRequest;
@@ -601,10 +604,14 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
       process.stdout.write(content);
     } else {
       writeEmptyRunLog(repoPath, { traceId: getTraceId(), outputPath: options.output });
-      const tip = !hasUncommittedChanges(repoPath)
-        ? 'Specify a git ref: warden HEAD~3 --skill <name>'
-        : undefined;
-      reporter.renderEmptyState('No changes found', tip);
+      if (options.staged) {
+        reporter.renderEmptyState('No staged changes found');
+      } else {
+        const tip = !hasUncommittedChanges(repoPath)
+          ? 'Specify a git ref: warden HEAD~3 --skill <name>'
+          : undefined;
+        reporter.renderEmptyState('No uncommitted changes found', tip);
+      }
       reporter.blank();
     }
     return 0;
@@ -736,11 +743,13 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
   const config = existsSync(configPath) ? loadWardenConfig(dirname(configPath)) : null;
 
   // Build context from local git - compare against HEAD for true uncommitted changes
-  reporter.startContext('Analyzing uncommitted changes...');
+  const statusMessage = options.staged ? 'Analyzing staged changes...' : 'Analyzing uncommitted changes...';
+  reporter.startContext(statusMessage);
   const context = buildLocalEventContext({
     base: 'HEAD',
     cwd: repoPath,
     defaultBranch: config?.defaults?.defaultBranch,
+    staged: options.staged,
   });
 
   const pullRequest = context.pullRequest;
@@ -755,8 +764,12 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
       process.stdout.write(content);
     } else {
       writeEmptyRunLog(repoPath, { traceId: getTraceId(), outputPath: options.output });
-      const tip = 'Specify a git ref to analyze committed changes: warden main --skill <name>';
-      reporter.renderEmptyState('No uncommitted changes found', tip);
+      if (options.staged) {
+        reporter.renderEmptyState('No staged changes found');
+      } else {
+        const tip = 'Specify a git ref to analyze committed changes: warden main --skill <name>';
+        reporter.renderEmptyState('No uncommitted changes found', tip);
+      }
       reporter.blank();
     }
     return 0;
@@ -769,6 +782,11 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
 
 async function runCommand(options: CLIOptions, reporter: Reporter): Promise<number> {
   const targets = options.targets ?? [];
+
+  // --staged is only meaningful without explicit targets
+  if (options.staged && targets.length > 0) {
+    reporter.warning('--staged is ignored when targets are specified');
+  }
 
   // No targets with --skill → run skill directly on uncommitted changes
   if (targets.length === 0 && options.skill) {


### PR DESCRIPTION
Two issues with how Warden handles local changes:

1. Config mode (`warden` with no args) diffed against the default branch (e.g. `main`), which included all committed branch changes alongside uncommitted ones. The status message said "Analyzing uncommitted changes..." but it was actually analyzing the full branch diff.

2. There was no way to analyze only staged changes. For pre-commit workflows, if you stage 2 files but have 3 WIP files unstaged, Warden would analyze all 5.

This PR fixes both:

- **Config mode now diffs against HEAD**, matching the behavior of direct skill mode. `warden` with no args analyzes only uncommitted changes (staged + unstaged). Users can still get the full branch diff with `warden main`.
- **New `--staged` flag** uses `git diff --cached` to analyze only staged changes. This threads through `git.ts` (new `DiffOptions` interface and `buildDiffArgs` helper), `context.ts`, and both CLI run modes. Status and empty-state messages adapt accordingly.
- Docs updated to describe the corrected default behavior and document `--staged` for pre-commit workflows.

`--staged` with explicit targets warns and is ignored, since targets already define what to analyze.