### PR TITLE
feat(sweep): Add --skill flag to scan.py

### DIFF
--- a/skills/warden-sweep/scripts/scan.py
+++ b/skills/warden-sweep/scripts/scan.py
@@ -340,9 +340,9 @@ def scan_file(
                     record = json.loads(line)
                     if record.get("type") == "summary":
                         continue
-                    skill = record.get("skill", "")
-                    if skill:
-                        skills.add(skill)
+                    record_skill = record.get("skill", "")
+                    if record_skill:
+                        skills.add(record_skill)
                     findings = record.get("findings", [])
                     finding_count += len(findings)
                 except json.JSONDecodeError:


### PR DESCRIPTION
Add a `--skill` argument to the sweep scan script that passes through to
each `warden` invocation. This allows scoping a sweep to a single skill
(e.g. `--skill find-warden-bugs`) instead of running all skills on every file.