### PR TITLE
fix(cli): Exclude node_modules from gitignore file discovery

### DIFF
--- a/src/cli/files.ts
+++ b/src/cli/files.ts
@@ -96,7 +96,7 @@ async function loadGitignoreRules(gitRoot: string, cwd: string): Promise<Ignore>
     cwd: gitRoot,
     absolute: true,
     dot: true,
-    ignore: ['**/.git/**'],
+    ignore: ['**/.git/**', '**/node_modules/**'],
   });
 
   // Also check from cwd up to git root for any .gitignore files


### PR DESCRIPTION
- `loadGitignoreRules` in `src/cli/files.ts` uses `fast-glob` to find `.gitignore` files but only excluded `.git/**`, not `node_modules/**`
- The 827MB `node_modules` directory was being traversed on every warden invocation, causing 30+ second hangs
- Adding `**/node_modules/**` to the ignore list reduces the glob from ~30s to ~36ms

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>