### PR TITLE
ref(cli): Use git ls-files for .gitignore discovery

### DIFF
--- a/src/cli/files.ts
+++ b/src/cli/files.ts
@@ -112,8 +112,11 @@ function loadGitignoreRules(gitRoot: string): Ignore {
     });
   }
 
-  // Sort by path depth (root first, then nested)
-  gitignoreFiles.sort((a, b) => a.split('/').length - b.split('/').length);
+  // Sort by path depth (root first, then nested).
+  // Normalize to forward slashes so depth counting works on Windows too.
+  gitignoreFiles.sort(
+    (a, b) => normalizePath(a).split('/').length - normalizePath(b).split('/').length
+  );
 
   // Process gitignore files from root down (parent rules apply first)
   for (const gitignorePath of gitignoreFiles) {


### PR DESCRIPTION
Use `git ls-files --exclude-standard` to discover `.gitignore` files instead
of crawling the filesystem with fast-glob.

The previous approach used fast-glob with `**/.gitignore` and required a
hardcoded exclusion list (`node_modules`, `.git`). Any other large ignored
directory (`.venv`, `vendor`, `build`, etc.) would cause the same 30+ second
hang that node_modules did (#220). This is a whack-a-mole problem.

`git ls-files` already knows what's ignored and skips those directories
entirely, returning results in ~2ms with no exclusion list needed. Falls back
to fast-glob for non-git directories (test fixtures with fake `.git` dirs).

Supersedes #220 with a more robust approach.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>