### PR TITLE
fix(sweep): Add self-validation to fix subagent prompt

### DIFF
--- a/skills/warden-sweep/SKILL.md
+++ b/skills/warden-sweep/SKILL.md
@@ -318,14 +318,28 @@ Severity: ${SEVERITY}
 Co-Authored-By: Warden <noreply@getsentry.com>
 
 ### Step 6: Output
-Return ONLY this JSON (no surrounding text):
+Return ONLY valid JSON (no surrounding text). Use `"status": "applied"` if you committed a fix, or `"status": "skipped"` if you did not.
+
+```json
 {
-  "status": "applied" or "skipped",
-  "filesChanged": ["list of files modified"],
-  "testFilesChanged": ["list of test files added/updated"],
-  "selfReview": "1-2 sentence summary of what you verified in your diff review",
-  "skipReason": "If status is skipped: why the fix was not applied"
+  "status": "applied",
+  "filesChanged": ["src/example.ts"],
+  "testFilesChanged": ["src/example.test.ts"],
+  "selfReview": "Verified the fix addresses the null check and test covers the failure case",
+  "skipReason": null
 }
+```
+
+When skipping:
+```json
+{
+  "status": "skipped",
+  "filesChanged": [],
+  "testFilesChanged": [],
+  "selfReview": null,
+  "skipReason": "The suggested fix would introduce a regression in the error handling path"
+}
+```
 ````
 
 **Step 2b: Handle skipped findings**


### PR DESCRIPTION
Several sweep PRs contained bugs introduced by the fix subagent. The
prompt was too permissive: apply fix, write tests, commit, done. No
self-review, no validation checklist, no way to bail out of a bad fix.

Rewrites the Phase 4 Step 2 fix subagent prompt with:

- **Understand before fixing**: Read 50+ lines of context, trace callers/callees before touching code
- **Minimal fix principle**: Smallest change only, no drive-by refactoring
- **Pre-commit self-review**: Agent must `git diff` and verify 4 criteria before staging
- **Explicit failure mode**: Agent can skip the commit and report why instead of forcing a bad fix
- **Structured JSON output**: Parseable response with status, files changed, and self-assessment