### PR TITLE
ref(sweep): Clean up warden-sweep skill per skill-creator review

### DIFF
--- a/skills/warden-sweep/SKILL.md
+++ b/skills/warden-sweep/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: warden-sweep
 description: Full-repository code sweep. Scans every file with warden, verifies findings via deep tracing, creates draft PRs for validated issues. Use when asked to "sweep the repo", "scan everything", "find all bugs", "full codebase review", "batch code analysis", or run warden across the entire repository.
+disable-model-invocation: true
 ---
 
 # Warden Sweep
@@ -123,33 +124,7 @@ Launch a Task subagent (`subagent_type: "general-purpose"`) for each finding. Pr
 
 **Task prompt for each finding:**
 
-```
-Verify a code analysis finding. Determine if this is a TRUE issue or a FALSE POSITIVE.
-Do NOT write or edit any files. Research only.
-
-## Finding
-- Title: ${TITLE}
-- Severity: ${SEVERITY} | Confidence: ${CONFIDENCE}
-- Skill: ${SKILL}
-- Location: ${FILE_PATH}:${START_LINE}-${END_LINE}
-- Description: ${DESCRIPTION}
-- Verification hint: ${VERIFICATION}
-
-## Instructions
-1. Read the file at the reported location. Examine at least 50 lines of surrounding context.
-2. Trace data flow to/from the flagged code using Grep/Glob.
-3. Check if the issue is mitigated elsewhere (guards, validation, try/catch upstream).
-4. Check if the issue is actually reachable in practice.
-
-Return your verdict as JSON:
-{
-  "findingId": "${FINDING_ID}",
-  "verdict": "verified" or "rejected",
-  "confidence": "high" or "medium" or "low",
-  "reasoning": "2-3 sentence explanation",
-  "traceNotes": "What code paths you examined"
-}
-```
+Read `${CLAUDE_SKILL_ROOT}/references/verify-prompt.md` for the prompt template. Substitute the finding's values into the `${...}` placeholders.
 
 **Process results:**
 
@@ -272,82 +247,7 @@ Each finding branches from the repo's default branch so PRs contain only the fix
 
 **Step 2: Generate fix**
 
-Launch a Task subagent (`subagent_type: "general-purpose"`) to apply the fix in the worktree:
-
-````
-Fix a verified code issue. You are working in a git worktree at: ${WORKTREE}
-
-## Finding
-- Title: ${TITLE}
-- File: ${FILE_PATH}:${START_LINE}
-- Description: ${DESCRIPTION}
-- Verification: ${REASONING}
-- Suggested Fix: ${FIX_DESCRIPTION}
-```diff
-${FIX_DIFF}
-```
-
-## Instructions
-
-### Step 1: Understand the code
-Read the file at ${WORKTREE}/${FILE_PATH}. Read at least 50 lines above and below the reported location. Trace callers and callees of the affected code using Grep/Glob to understand how it is used. Do NOT skip this step.
-
-### Step 2: Apply a minimal fix
-Apply the smallest change that addresses the finding. If the suggested diff doesn't apply cleanly, adapt it while preserving intent. Do NOT refactor surrounding code, rename variables, add comments, or make any change beyond what the finding requires.
-
-### Step 3: Write tests
-Write or update tests that verify the fix:
-- Follow existing test patterns (co-located files, same framework)
-- At minimum, write a test that would have caught the original bug
-- Test the specific edge case, not just the happy path
-
-Only modify the fix target and its test file.
-
-### Step 4: Self-review
-Before staging, run `git diff` in the worktree and review every changed line. Verify:
-1. The change addresses the specific finding described, not something else
-2. No unrelated code was modified (no drive-by cleanups, no formatting changes)
-3. Trace through changed code paths: does the fix introduce any new bug, null reference, type error, or broken import?
-4. Tests exercise the fix (the failure case), not just that the code runs
-
-If ANY check fails, fix the problem before proceeding. If the suggested fix is wrong or would introduce a regression you cannot resolve, do NOT commit. Instead, skip to the output step and report why.
-
-### Step 5: Commit
-Do NOT run tests locally. CI will validate the changes.
-
-Stage and commit with this exact message:
-
-fix: ${TITLE}
-
-Warden finding ${FINDING_ID}
-Severity: ${SEVERITY}
-
-Co-Authored-By: Warden <noreply@getsentry.com>
-
-### Step 6: Output
-Return ONLY valid JSON (no surrounding text). Use `"status": "applied"` if you committed a fix, or `"status": "skipped"` if you did not.
-
-```json
-{
-  "status": "applied",
-  "filesChanged": ["src/example.ts"],
-  "testFilesChanged": ["src/example.test.ts"],
-  "selfReview": "Verified the fix addresses the null check and test covers the failure case",
-  "skipReason": null
-}
-```
-
-When skipping:
-```json
-{
-  "status": "skipped",
-  "filesChanged": [],
-  "testFilesChanged": [],
-  "selfReview": null,
-  "skipReason": "The suggested fix would introduce a regression in the error handling path"
-}
-```
-````
+Launch a Task subagent (`subagent_type: "general-purpose"`) to apply the fix in the worktree. Read `${CLAUDE_SKILL_ROOT}/references/patch-prompt.md` for the prompt template. Substitute the finding's values and worktree path into the `${...}` placeholders.
 
 **Step 2b: Handle skipped findings**
 

--- a/skills/warden-sweep/references/patch-prompt.md
+++ b/skills/warden-sweep/references/patch-prompt.md
@@ -1,0 +1,72 @@
+Fix a verified code issue. You are working in a git worktree at: ${WORKTREE}
+
+## Finding
+- Title: ${TITLE}
+- File: ${FILE_PATH}:${START_LINE}
+- Description: ${DESCRIPTION}
+- Verification: ${REASONING}
+- Suggested Fix: ${FIX_DESCRIPTION}
+```diff
+${FIX_DIFF}
+```
+
+## Instructions
+
+### Step 1: Understand the code
+Read the file at ${WORKTREE}/${FILE_PATH}. Read at least 50 lines above and below the reported location. Trace callers and callees of the affected code using Grep/Glob to understand how it is used. Do NOT skip this step.
+
+### Step 2: Apply a minimal fix
+Apply the smallest change that addresses the finding. If the suggested diff doesn't apply cleanly, adapt it while preserving intent. Do NOT refactor surrounding code, rename variables, add comments, or make any change beyond what the finding requires.
+
+### Step 3: Write tests
+Write or update tests that verify the fix:
+- Follow existing test patterns (co-located files, same framework)
+- At minimum, write a test that would have caught the original bug
+- Test the specific edge case, not just the happy path
+
+Only modify the fix target and its test file.
+
+### Step 4: Self-review
+Before staging, run `git diff` in the worktree and review every changed line. Verify:
+1. The change addresses the specific finding described, not something else
+2. No unrelated code was modified (no drive-by cleanups, no formatting changes)
+3. Trace through changed code paths: does the fix introduce any new bug, null reference, type error, or broken import?
+4. Tests exercise the fix (the failure case), not just that the code runs
+
+If ANY check fails, fix the problem before proceeding. If the suggested fix is wrong or would introduce a regression you cannot resolve, do NOT commit. Instead, skip to the output step and report why.
+
+### Step 5: Commit
+Do NOT run tests locally. CI will validate the changes.
+
+Stage and commit with this exact message:
+
+fix: ${TITLE}
+
+Warden finding ${FINDING_ID}
+Severity: ${SEVERITY}
+
+Co-Authored-By: Warden <noreply@getsentry.com>
+
+### Step 6: Output
+Return ONLY valid JSON (no surrounding text). Use `"status": "applied"` if you committed a fix, or `"status": "skipped"` if you did not.
+
+```json
+{
+  "status": "applied",
+  "filesChanged": ["src/example.ts"],
+  "testFilesChanged": ["src/example.test.ts"],
+  "selfReview": "Verified the fix addresses the null check and test covers the failure case",
+  "skipReason": null
+}
+```
+
+When skipping:
+```json
+{
+  "status": "skipped",
+  "filesChanged": [],
+  "testFilesChanged": [],
+  "selfReview": null,
+  "skipReason": "The suggested fix would introduce a regression in the error handling path"
+}
+```

--- a/skills/warden-sweep/references/verify-prompt.md
+++ b/skills/warden-sweep/references/verify-prompt.md
@@ -1,0 +1,25 @@
+Verify a code analysis finding. Determine if this is a TRUE issue or a FALSE POSITIVE.
+Do NOT write or edit any files. Research only.
+
+## Finding
+- Title: ${TITLE}
+- Severity: ${SEVERITY} | Confidence: ${CONFIDENCE}
+- Skill: ${SKILL}
+- Location: ${FILE_PATH}:${START_LINE}-${END_LINE}
+- Description: ${DESCRIPTION}
+- Verification hint: ${VERIFICATION}
+
+## Instructions
+1. Read the file at the reported location. Examine at least 50 lines of surrounding context.
+2. Trace data flow to/from the flagged code using Grep/Glob.
+3. Check if the issue is mitigated elsewhere (guards, validation, try/catch upstream).
+4. Check if the issue is actually reachable in practice.
+
+Return your verdict as JSON:
+{
+  "findingId": "${FINDING_ID}",
+  "verdict": "verified" or "rejected",
+  "confidence": "high" or "medium" or "low",
+  "reasoning": "2-3 sentence explanation",
+  "traceNotes": "What code paths you examined"
+}

--- a/skills/warden-sweep/scripts/_utils.py
+++ b/skills/warden-sweep/scripts/_utils.py
@@ -20,6 +20,17 @@ def run_cmd(
     )
 
 
+def run_cmd_stdout(
+    args: list[str], timeout: int = 30, cwd: str | None = None
+) -> str | None:
+    """Run a command and return stripped stdout, or None on failure."""
+    try:
+        result = run_cmd(args, timeout=timeout, cwd=cwd)
+        return result.stdout.strip() if result.returncode == 0 else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
 def read_json(path: str) -> dict[str, Any] | None:
     """Read a JSON file and return parsed object, or None on failure."""
     if not os.path.exists(path):

--- a/skills/warden-sweep/scripts/find_reviewers.py
+++ b/skills/warden-sweep/scripts/find_reviewers.py
@@ -20,22 +20,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
+import os
 import sys
 
-
-def run_cmd(args: list[str], timeout: int = 30) -> str | None:
-    """Run a command and return stdout, or None on failure."""
-    try:
-        result = subprocess.run(
-            args,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        return result.stdout.strip() if result.returncode == 0 else None
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _utils import run_cmd_stdout as run_cmd  # noqa: E402
 
 
 def get_top_authors(file_path: str, count: int = 2) -> list[str]:

--- a/skills/warden-sweep/scripts/scan.py
+++ b/skills/warden-sweep/scripts/scan.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.9"
+# dependencies = ["tomli; python_version < '3.11'"]
 # ///
 """
 Warden Sweep: Scan phase.
@@ -33,6 +34,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redefine]
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _utils import ensure_github_label, run_cmd  # noqa: E402
@@ -99,84 +105,16 @@ def write_manifest(sweep_dir: str, run_id: str) -> None:
         f.write("\n")
 
 
-def _strip_toml_inline_comment(line: str) -> str:
-    """Strip inline TOML comments (# outside of quoted strings)."""
-    in_quote = False
-    quote_char = ""
-    for i, ch in enumerate(line):
-        if in_quote:
-            if ch == quote_char:
-                in_quote = False
-        elif ch in ('"', "'"):
-            in_quote = True
-            quote_char = ch
-        elif ch == "#":
-            return line[:i].rstrip()
-    return line
-
-
-def _toml_array_to_json(value: str) -> str:
-    """Convert a TOML array string to JSON-compatible format.
-
-    Handles TOML single-quoted strings and trailing commas.
-    Inline comments should be stripped before calling this function.
-    """
-    import re
-    # Replace single-quoted strings with double-quoted (TOML literal strings)
-    value = re.sub(r"'([^']*)'", r'"\1"', value)
-    # Strip trailing comma before closing bracket
-    value = re.sub(r",\s*]", "]", value)
-    return value
-
-
 def load_ignore_paths() -> list[str]:
     """Load ignorePaths from warden.toml defaults if present."""
-    try:
-        # Try to parse warden.toml for defaults.ignorePaths
-        toml_path = "warden.toml"
-        if not os.path.exists(toml_path):
-            return []
-
-        with open(toml_path) as f:
-            content = f.read()
-
-        # Simple TOML parsing for ignorePaths in [defaults] section
-        in_defaults = False
-        collecting_value = False
-        value_parts: list[str] = []
-        for line in content.splitlines():
-            stripped = line.strip()
-            if collecting_value:
-                # Skip TOML comment lines inside multiline arrays
-                if stripped.startswith("#"):
-                    continue
-                # Strip inline comments before accumulating
-                stripped = _strip_toml_inline_comment(stripped)
-                value_parts.append(stripped)
-                combined = "".join(value_parts)
-                if combined.count("[") <= combined.count("]"):
-                    try:
-                        return json.loads(_toml_array_to_json(combined))
-                    except json.JSONDecodeError:
-                        return []
-                continue
-            if stripped == "[defaults]":
-                in_defaults = True
-                continue
-            if stripped.startswith("[") and stripped != "[defaults]":
-                in_defaults = False
-                continue
-            if in_defaults and stripped.startswith("ignorePaths"):
-                _, _, value = stripped.partition("=")
-                value = _strip_toml_inline_comment(value.strip())
-                if not value:
-                    continue
-                try:
-                    return json.loads(_toml_array_to_json(value))
-                except json.JSONDecodeError:
-                    value_parts = [value]
-                    collecting_value = True
+    toml_path = "warden.toml"
+    if not os.path.exists(toml_path):
         return []
+    try:
+        with open(toml_path, "rb") as f:
+            config = tomllib.load(f)
+        paths = config.get("defaults", {}).get("ignorePaths", [])
+        return paths if isinstance(paths, list) else []
     except Exception:
         return []
 


### PR DESCRIPTION
Reviewed the warden-sweep skill against skill-creator guidelines and applied several cleanups:

- Add `disable-model-invocation: true` to frontmatter, preventing auto-invocation of this side-effect-heavy skill
- Extract verify and patch subagent prompts to `references/` for progressive disclosure (SKILL.md drops from 500 to 400 lines)
- Deduplicate `run_cmd` in `find_reviewers.py` by importing shared `run_cmd_stdout` from `_utils.py`
- Replace hand-rolled TOML parser in `scan.py` with `tomllib`/`tomli`, eliminating ~80 lines of fragile regex-based parsing