### PR TITLE
feat(telemetry): Add namespaced fix-eval feedback metrics

### DIFF
--- a/src/action/fix-evaluation/fix-evaluation.test.ts
+++ b/src/action/fix-evaluation/fix-evaluation.test.ts
@@ -82,6 +82,9 @@ describe('evaluateFixAttempts', () => {
     expect(result.toResolve).toHaveLength(0);
     expect(result.toReply).toHaveLength(0);
     expect(result.evaluations).toHaveLength(0);
+    expect(result.uniqueFindingsEvaluated).toBe(0);
+    expect(result.uniqueFindingsCodeChanged).toBe(0);
+    expect(result.uniqueFindingsResolved).toBe(0);
   });
 
   it('skips resolved comments', async () => {
@@ -131,6 +134,9 @@ describe('evaluateFixAttempts', () => {
       verdict: 'resolved',
       usedFallback: false,
     });
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(1);
   });
 
   it('categorizes attempted_failed verdicts into toReply', async () => {
@@ -152,6 +158,9 @@ describe('evaluateFixAttempts', () => {
       verdict: 'attempted_failed',
       reasoning: 'Only partial fix',
     });
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(0);
   });
 
   it('skips not_attempted verdicts', async () => {
@@ -171,6 +180,9 @@ describe('evaluateFixAttempts', () => {
     expect(result.evaluations[0]).toMatchObject({
       verdict: 'not_attempted',
     });
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(0);
+    expect(result.uniqueFindingsResolved).toBe(0);
   });
 
   it('overrides resolved verdict when issue is re-detected', async () => {
@@ -198,6 +210,9 @@ describe('evaluateFixAttempts', () => {
     expect(result.evaluations[0]).toMatchObject({
       verdict: 're_detected',
     });
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(0);
   });
 
   it('limits evaluation to MAX_EVALUATIONS (20)', async () => {
@@ -351,5 +366,42 @@ describe('evaluateFixAttempts', () => {
     expect(result.toResolve).toHaveLength(1);
     expect(result.toReply).toHaveLength(1);
     expect(result.failedEvaluations).toBe(0);
+    expect(result.uniqueFindingsEvaluated).toBe(3);
+    expect(result.uniqueFindingsCodeChanged).toBe(2);
+    expect(result.uniqueFindingsResolved).toBe(1);
+  });
+
+  it('counts unique findings by thread id', async () => {
+    const comments = [
+      createComment({ id: 1, threadId: 'thread-1', path: 'src/a.ts' }),
+      createComment({ id: 2, threadId: 'thread-1', path: 'src/b.ts' }),
+    ];
+
+    mockFetchFollowUpChanges.mockResolvedValue({
+      patches: new Map([
+        ['src/a.ts', 'patch-a'],
+        ['src/b.ts', 'patch-b'],
+      ]),
+      commitMessages: ['Fix issue'],
+    });
+
+    mockEvaluateFix
+      .mockResolvedValueOnce({
+        verdict: { status: 'attempted_failed', reasoning: 'Partial fix' },
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.001 },
+        usedFallback: false,
+      })
+      .mockResolvedValueOnce({
+        verdict: { status: 'resolved', reasoning: 'Fixed' },
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.001 },
+        usedFallback: false,
+      });
+
+    const result = await evaluateFixAttempts(mockOctokit, comments, defaultContext, [], 'api-key');
+
+    expect(result.evaluated).toBe(2);
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(1);
   });
 });

--- a/src/action/fix-evaluation/index.ts
+++ b/src/action/fix-evaluation/index.ts
@@ -92,7 +92,7 @@ export async function evaluateFixAttempts(
       op: 'fix_eval.run',
       name: 'evaluate fix attempts',
       attributes: {
-        'fix_eval.comment_count': comments.length,
+        'warden.fix_eval.comment_count': comments.length,
       },
     },
     async (outerSpan) => {
@@ -102,6 +102,9 @@ export async function evaluateFixAttempts(
         skipped: 0,
         evaluated: 0,
         failedEvaluations: 0,
+        uniqueFindingsEvaluated: 0,
+        uniqueFindingsCodeChanged: 0,
+        uniqueFindingsResolved: 0,
         usage: emptyUsage(),
         evaluations: [],
       };
@@ -144,6 +147,9 @@ export async function evaluateFixAttempts(
 
       const changedFiles = [...patches.keys()];
       const usages: UsageStats[] = [];
+      const uniqueEvaluatedThreadIds = new Set<string>();
+      const uniqueCodeChangedThreadIds = new Set<string>();
+      const uniqueResolvedThreadIds = new Set<string>();
 
       for (const comment of commentsToEvaluate) {
         const findingId = extractFindingId(comment.title);
@@ -165,6 +171,9 @@ export async function evaluateFixAttempts(
         }
 
         result.evaluated++;
+        if (comment.threadId) {
+          uniqueEvaluatedThreadIds.add(comment.threadId);
+        }
 
         // Fetch code after fix (optional, reduces tool calls)
         let codeAfterFix: string | undefined;
@@ -187,7 +196,7 @@ export async function evaluateFixAttempts(
             attributes: {
               'code.filepath': comment.path,
               'code.line': comment.line,
-              'fix_eval.finding_id': findingId ?? 'unknown',
+              'warden.fix_eval.finding_id': findingId ?? 'unknown',
             },
           },
           async (evalSpan) => {
@@ -200,8 +209,8 @@ export async function evaluateFixAttempts(
             );
             const durationMs = performance.now() - startTime;
 
-            evalSpan.setAttribute('fix_eval.verdict', evalResult.verdict.status);
-            evalSpan.setAttribute('fix_eval.used_fallback', evalResult.usedFallback);
+            evalSpan.setAttribute('warden.fix_eval.verdict', evalResult.verdict.status);
+            evalSpan.setAttribute('warden.fix_eval.used_fallback', evalResult.usedFallback);
 
             return { evalResult, durationMs };
           },
@@ -247,6 +256,9 @@ export async function evaluateFixAttempts(
 
         if (reDetected) {
           finalVerdict = 're_detected';
+          if (comment.threadId) {
+            uniqueCodeChangedThreadIds.add(comment.threadId);
+          }
           result.toReply.push({
             comment,
             replyBody: formatFailedFixReply(
@@ -256,8 +268,15 @@ export async function evaluateFixAttempts(
             commitSha: context.headSha,
           });
         } else if (evalResult.verdict.status === 'resolved') {
+          if (comment.threadId) {
+            uniqueCodeChangedThreadIds.add(comment.threadId);
+            uniqueResolvedThreadIds.add(comment.threadId);
+          }
           result.toResolve.push(comment);
         } else {
+          if (evalResult.verdict.status === 'attempted_failed' && comment.threadId) {
+            uniqueCodeChangedThreadIds.add(comment.threadId);
+          }
           result.toReply.push({
             comment,
             replyBody: formatFailedFixReply(context.headSha, evalResult.verdict.reasoning),
@@ -279,13 +298,32 @@ export async function evaluateFixAttempts(
       }
 
       result.usage = usages.length > 0 ? aggregateUsage(usages) : emptyUsage();
+      result.uniqueFindingsEvaluated = uniqueEvaluatedThreadIds.size;
+      result.uniqueFindingsCodeChanged = uniqueCodeChangedThreadIds.size;
+      result.uniqueFindingsResolved = uniqueResolvedThreadIds.size;
+      const codeChangeRate =
+        result.uniqueFindingsEvaluated > 0
+          ? result.uniqueFindingsCodeChanged / result.uniqueFindingsEvaluated
+          : 0;
 
       // Set summary attributes and emit metrics
-      outerSpan.setAttribute('fix_eval.evaluated', result.evaluated);
-      outerSpan.setAttribute('fix_eval.resolved', result.toResolve.length);
-      outerSpan.setAttribute('fix_eval.failed', result.failedEvaluations);
-      outerSpan.setAttribute('fix_eval.skipped', result.skipped);
-      emitFixEvalMetrics(result.evaluated, result.toResolve.length, result.failedEvaluations, result.skipped);
+      outerSpan.setAttribute('warden.fix_eval.evaluated', result.evaluated);
+      outerSpan.setAttribute('warden.fix_eval.resolved', result.toResolve.length);
+      outerSpan.setAttribute('warden.fix_eval.failed', result.failedEvaluations);
+      outerSpan.setAttribute('warden.fix_eval.skipped', result.skipped);
+      outerSpan.setAttribute('warden.fix_eval.unique_findings.evaluated', result.uniqueFindingsEvaluated);
+      outerSpan.setAttribute('warden.fix_eval.unique_findings.code_changed', result.uniqueFindingsCodeChanged);
+      outerSpan.setAttribute('warden.fix_eval.unique_findings.resolved', result.uniqueFindingsResolved);
+      outerSpan.setAttribute('warden.fix_eval.unique_findings.code_change_rate', codeChangeRate);
+      emitFixEvalMetrics(
+        result.evaluated,
+        result.toResolve.length,
+        result.failedEvaluations,
+        result.skipped,
+        result.uniqueFindingsEvaluated,
+        result.uniqueFindingsCodeChanged,
+        result.uniqueFindingsResolved
+      );
 
       return result;
     },

--- a/src/action/fix-evaluation/types.ts
+++ b/src/action/fix-evaluation/types.ts
@@ -42,6 +42,12 @@ export interface EvaluateFixAttemptsResult {
   evaluated: number;
   /** Evaluations that failed and used fallback (API errors, invalid responses) */
   failedEvaluations: number;
+  /** Unique finding threads evaluated in this run */
+  uniqueFindingsEvaluated: number;
+  /** Unique finding threads with evidence of code-change action */
+  uniqueFindingsCodeChanged: number;
+  /** Unique finding threads judged resolved */
+  uniqueFindingsResolved: number;
   /** Accumulated usage stats from all fix evaluations */
   usage: UsageStats;
   /** Per-comment evaluation details for logging/reporting */

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -52,6 +52,9 @@ vi.mock('../fix-evaluation/index.js', () => ({
       skipped: 0,
       evaluated: 0,
       failedEvaluations: 0,
+      uniqueFindingsEvaluated: 0,
+      uniqueFindingsCodeChanged: 0,
+      uniqueFindingsResolved: 0,
       usage: { inputTokens: 0, outputTokens: 0, costUSD: 0 },
     })
   ),
@@ -702,6 +705,9 @@ describe('runPRWorkflow', () => {
         skipped: 0,
         evaluated: 1,
         failedEvaluations: 0,
+        uniqueFindingsEvaluated: 1,
+        uniqueFindingsCodeChanged: 1,
+        uniqueFindingsResolved: 1,
         usage: { inputTokens: 0, outputTokens: 0, costUSD: 0 },
       });
 
@@ -765,6 +771,9 @@ describe('runPRWorkflow', () => {
         skipped: 0,
         evaluated: 1,
         failedEvaluations: 0,
+        uniqueFindingsEvaluated: 1,
+        uniqueFindingsCodeChanged: 0,
+        uniqueFindingsResolved: 0,
         usage: { inputTokens: 0, outputTokens: 0, costUSD: 0 },
       });
 

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -353,7 +353,11 @@ async function evaluateFixesAndResolveStale(
   canResolveStale: boolean,
   anthropicApiKey: string,
   auxiliaryMaxRetries?: number
-): Promise<{ allResolved: boolean }> {
+): Promise<{
+  allResolved: boolean;
+  autoResolvedByFixEvaluation: number;
+  autoResolvedByStaleCheck: number;
+}> {
   const wardenComments = fetchedComments.filter((c) => c.isWarden);
   const commentsResolvedByFixEval = new Set<number>();
   const commentsEvaluatedByFixEval = new Set<number>();
@@ -467,7 +471,11 @@ async function evaluateFixesAndResolveStale(
     (c) => commentsResolvedByFixEval.has(c.id) || commentsResolvedByStale.has(c.id)
   );
 
-  return { allResolved };
+  return {
+    allResolved,
+    autoResolvedByFixEvaluation: commentsResolvedByFixEval.size,
+    autoResolvedByStaleCheck: commentsResolvedByStale.size,
+  };
 }
 
 /**
@@ -579,9 +587,13 @@ async function cleanupOrphanedComments(
 
   logAction(`No triggers matched, but found ${wardenComments.length} existing Warden comments. Running cleanup.`);
 
-  const { allResolved } = await evaluateFixesAndResolveStale(
+  const { allResolved, autoResolvedByFixEvaluation, autoResolvedByStaleCheck } =
+    await evaluateFixesAndResolveStale(
     octokit, context, existingComments, [], true, anthropicApiKey, auxiliaryMaxRetries
-  );
+    );
+  const activeSpan = Sentry.getActiveSpan();
+  activeSpan?.setAttribute('warden.feedback.auto_resolve.fix_eval_count', autoResolvedByFixEvaluation);
+  activeSpan?.setAttribute('warden.feedback.auto_resolve.stale_count', autoResolvedByStaleCheck);
 
   // Dismiss CHANGES_REQUESTED only if every unresolved comment was resolved
   if (allResolved) {
@@ -680,12 +692,21 @@ export async function runPRWorkflow(
 
       await Sentry.startSpan(
         { op: 'workflow.resolve', name: 'resolve stale comments' },
-        () =>
-          evaluateFixesAndResolveStale(
+        async (resolveSpan) => {
+          const resolutionResult = await evaluateFixesAndResolveStale(
             octokit, context, reviewPhase.fetchedComments,
             allFindings, canResolveStale, inputs.anthropicApiKey,
             config.defaults?.auxiliaryMaxRetries,
-          ),
+          );
+          resolveSpan.setAttribute(
+            'warden.feedback.auto_resolve.fix_eval_count',
+            resolutionResult.autoResolvedByFixEvaluation
+          );
+          resolveSpan.setAttribute(
+            'warden.feedback.auto_resolve.stale_count',
+            resolutionResult.autoResolvedByStaleCheck
+          );
+        },
       );
 
       await finalizeWorkflow(

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -126,12 +126,23 @@ export function emitExtractionMetrics(skill: string, method: 'regex' | 'llm' | '
   });
 }
 
-export function emitFixEvalMetrics(evaluated: number, resolved: number, failed: number, skipped: number): void {
+export function emitFixEvalMetrics(
+  evaluated: number,
+  resolved: number,
+  failed: number,
+  skipped: number,
+  uniqueFindingsEvaluated: number,
+  uniqueFindingsCodeChanged: number,
+  uniqueFindingsResolved: number
+): void {
   safeEmit(() => {
-    Sentry.metrics.count('fix_eval.evaluated', evaluated);
-    Sentry.metrics.count('fix_eval.resolved', resolved);
-    Sentry.metrics.count('fix_eval.failed', failed);
-    Sentry.metrics.count('fix_eval.skipped', skipped);
+    Sentry.metrics.count('warden.fix_eval.evaluated', evaluated);
+    Sentry.metrics.count('warden.fix_eval.resolved', resolved);
+    Sentry.metrics.count('warden.fix_eval.failed', failed);
+    Sentry.metrics.count('warden.fix_eval.skipped', skipped);
+    Sentry.metrics.count('warden.fix_eval.unique_findings.evaluated', uniqueFindingsEvaluated);
+    Sentry.metrics.count('warden.fix_eval.unique_findings.code_changed', uniqueFindingsCodeChanged);
+    Sentry.metrics.count('warden.fix_eval.unique_findings.resolved', uniqueFindingsResolved);
   });
 }
 
@@ -167,7 +178,7 @@ export function emitDedupMetrics(total: number, unique: number): void {
 
 export function emitStaleResolutionMetric(count: number): void {
   safeEmit(() => {
-    Sentry.metrics.count('stale.resolved', count);
+    Sentry.metrics.count('warden.stale.resolved', count);
   });
 }
 


### PR DESCRIPTION
Add namespaced telemetry for fix evaluation outcomes so we can measure how often feedback leads to code changes at the unique-finding level.

This threads unique finding counters (by review thread ID) through fix evaluation and emits both span attributes and metrics under the warden namespace. It also records auto-resolution attribution on workflow spans so we can distinguish fix-eval-driven resolution from stale resolution.

The previous telemetry mixed concerns and did not provide a direct signal for unique findings that drove code-change action. With these counters, we can query percentage of unique findings that led to code changes directly from metrics.