### PR TITLE
fix(ci): Enable auto-generated changelogs for GitHub releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,5 @@
-changelogPolicy: none
+changelog:
+  policy: auto
 preReleaseCommand: bash bin/bump-version.sh
 targets:
   - name: github


### PR DESCRIPTION
Enable auto-generated changelogs for GitHub releases

All GitHub releases from v0.8.0 through v0.17.0 have empty bodies because
`changelogPolicy` was set to `none` when Craft was first adopted and never
updated. This switches to `auto` so Craft generates changelog entries from
commits and PRs between version tags.


Agent transcript: https://claudescope.sentry.dev/share/fsezNdUwUEZ-A0lxmQED2TIcf8IL6DZitaVuvGW5GIQ