### PR TITLE
fix(review): Preserve active Warden threads

### DIFF
--- a/src/action/review/poster.test.ts
+++ b/src/action/review/poster.test.ts
@@ -230,6 +230,7 @@ describe('postTriggerReview', () => {
     );
     // Since all findings were duplicates and failOn not triggered, nothing new to post
     expect(postResult.posted).toBe(false);
+    expect(postResult.activeWardenCommentIds.size).toBe(0);
   });
 
   it('posts REQUEST_CHANGES when all findings deduplicated but failOn threshold met', async () => {
@@ -293,6 +294,7 @@ describe('postTriggerReview', () => {
     );
     // Even though all findings were deduplicated, REQUEST_CHANGES should still be posted
     expect(postResult.posted).toBe(true);
+    expect([...postResult.activeWardenCommentIds]).toEqual([1]);
     expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'REQUEST_CHANGES',

--- a/src/action/review/poster.ts
+++ b/src/action/review/poster.ts
@@ -44,6 +44,8 @@ export interface ReviewPostResult {
   posted: boolean;
   /** New comments that were posted (for cross-trigger deduplication) */
   newComments: ExistingComment[];
+  /** Existing Warden comment IDs matched by current findings */
+  activeWardenCommentIds: Set<number>;
   /** Whether this trigger should cause the action to fail */
   shouldFail: boolean;
   /** Reason for failure, if any */
@@ -159,9 +161,10 @@ export async function postTriggerReview(
   const { octokit, context } = deps;
 
   const newComments: ExistingComment[] = [];
+  const activeWardenCommentIds = new Set<number>();
 
   if (!result.report) {
-    return { posted: false, newComments, shouldFail: false };
+    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
   }
 
   // Filter findings by reportOn threshold and confidence
@@ -170,7 +173,7 @@ export async function postTriggerReview(
 
   // Skip if nothing to post
   if (!result.renderResult || (filteredFindings.length === 0 && !reportOnSuccess)) {
-    return { posted: false, newComments, shouldFail: false };
+    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
   }
 
   try {
@@ -219,6 +222,12 @@ export async function postTriggerReview(
         logAction(
           `Found ${dedupResult.duplicateActions.length} duplicate findings for ${result.triggerName}`
         );
+      }
+
+      for (const action of dedupResult.duplicateActions) {
+        if (action.existingComment.isWarden && action.existingComment.id > 0) {
+          activeWardenCommentIds.add(action.existingComment.id);
+        }
       }
     }
 
@@ -292,12 +301,12 @@ export async function postTriggerReview(
         }
       }
 
-      return { posted: true, newComments, shouldFail: false };
+      return { posted: true, newComments, activeWardenCommentIds, shouldFail: false };
     }
 
-    return { posted: false, newComments, shouldFail: false };
+    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
   } catch (error) {
     warnAction(`Failed to post review for ${result.triggerName}: ${error}`);
-    return { posted: false, newComments, shouldFail: false };
+    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
   }
 }

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import type { Octokit } from '@octokit/rest';
 import type { ActionInputs } from '../inputs.js';
 import type { SkillReport, Finding } from '../../types/index.js';
+import type { ExistingComment } from '../../output/dedup.js';
 
 // -----------------------------------------------------------------------------
 // Fixtures Directory
@@ -638,6 +639,54 @@ describe('runPRWorkflow', () => {
       await runPRWorkflow(mockOctokit, createDefaultInputs(), 'pull_request', EVENT_PAYLOAD_PATH, FIXTURES_DIR);
 
       expect(mockEvaluateFixAttempts).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-resolve comments matched by current-run deduplication', async () => {
+      const existingComment: ExistingComment = {
+        id: 1,
+        path: 'src/test.ts',
+        line: 10,
+        title: 'Old warning wording',
+        description: 'Old description',
+        contentHash: 'oldhash',
+        isWarden: true,
+        isResolved: false,
+        threadId: 'thread-1',
+      };
+      const finding = createFinding({
+        severity: 'high',
+        title: 'Current warning wording',
+        description: 'Current description',
+        location: { path: 'src/test.ts', startLine: 10 },
+      });
+
+      mockFetchExistingComments.mockResolvedValue([existingComment]);
+      mockRunSkillTask.mockResolvedValue({
+        name: 'test-trigger',
+        report: createSkillReport({ findings: [finding] }),
+      });
+      mockDeduplicateFindings.mockResolvedValue({
+        newFindings: [],
+        duplicateActions: [
+          {
+            type: 'update_warden',
+            finding,
+            existingComment,
+            matchType: 'semantic',
+          },
+        ],
+      });
+
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs({ failOn: 'high', requestChanges: true }),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        FIXTURES_DIR
+      );
+
+      expect(mockEvaluateFixAttempts).not.toHaveBeenCalled();
+      expect(mockOctokit.graphql).not.toHaveBeenCalled();
     });
   });
 

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -69,6 +69,7 @@ interface ReviewPhaseResult {
   reports: SkillReport[];
   fetchedComments: ExistingComment[];
   existingComments: ExistingComment[];
+  activeWardenCommentIds: Set<number>;
   shouldFailAction: boolean;
   failureReasons: string[];
 }
@@ -314,6 +315,7 @@ async function postReviewsAndTrackFailures(
 
   // Post reviews to GitHub (sequentially to avoid rate limits)
   const reports: SkillReport[] = [];
+  const activeWardenCommentIds = new Set<number>();
   let shouldFailAction = false;
   const failureReasons: string[] = [];
 
@@ -334,6 +336,7 @@ async function postReviewsAndTrackFailures(
 
       // Add newly posted comments to existing comments for cross-trigger deduplication
       existingComments.push(...postResult.newComments);
+      postResult.activeWardenCommentIds.forEach((id) => activeWardenCommentIds.add(id));
 
       // Check if we should fail based on this trigger's config
       // Filter by confidence first so low-confidence findings don't cause failure
@@ -347,7 +350,14 @@ async function postReviewsAndTrackFailures(
     }
   }
 
-  return { reports, fetchedComments, existingComments, shouldFailAction, failureReasons };
+  return {
+    reports,
+    fetchedComments,
+    existingComments,
+    activeWardenCommentIds,
+    shouldFailAction,
+    failureReasons,
+  };
 }
 
 /**
@@ -360,6 +370,7 @@ async function evaluateFixesAndResolveStale(
   context: EventContext,
   fetchedComments: ExistingComment[],
   allFindings: Finding[],
+  activeWardenCommentIds: ReadonlySet<number>,
   canResolveStale: boolean,
   anthropicApiKey: string,
   auxiliaryMaxRetries?: number
@@ -372,24 +383,27 @@ async function evaluateFixesAndResolveStale(
   const commentsResolvedByFixEval = new Set<number>();
   const commentsEvaluatedByFixEval = new Set<number>();
   const commentsResolvedByStale = new Set<number>();
+  const commentsForFixEvaluation = wardenComments.filter(
+    (c) => !activeWardenCommentIds.has(c.id)
+  );
 
   // Evaluate follow-up commit fix attempts
   if (
     context.pullRequest &&
-    wardenComments.length > 0 &&
+    commentsForFixEvaluation.length > 0 &&
     canResolveStale &&
     anthropicApiKey
   ) {
     try {
       logGroup('Fix evaluation');
-      const unresolvedCount = wardenComments.filter((c) => !c.isResolved && c.threadId).length;
+      const unresolvedCount = commentsForFixEvaluation.filter((c) => !c.isResolved && c.threadId).length;
       if (unresolvedCount > 0) {
         logAction(`Fix evaluation: evaluating ${unresolvedCount} unresolved comments`);
       }
 
       const fixEvaluation = await evaluateFixAttempts(
         octokit,
-        wardenComments,
+        commentsForFixEvaluation,
         {
           owner: context.repository.owner,
           repo: context.repository.name,
@@ -455,7 +469,10 @@ async function evaluateFixesAndResolveStale(
     try {
       const scope = buildAnalyzedScope(context.pullRequest.files);
       const commentsForStaleCheck = wardenComments.filter(
-        (c) => !commentsResolvedByFixEval.has(c.id) && !commentsEvaluatedByFixEval.has(c.id)
+        (c) =>
+          !activeWardenCommentIds.has(c.id) &&
+          !commentsResolvedByFixEval.has(c.id) &&
+          !commentsEvaluatedByFixEval.has(c.id)
       );
       const staleComments = findStaleComments(commentsForStaleCheck, allFindings, scope);
 
@@ -619,7 +636,7 @@ async function cleanupOrphanedComments(
 
   const { allResolved, autoResolvedByFixEvaluation, autoResolvedByStaleCheck } =
     await evaluateFixesAndResolveStale(
-    octokit, context, existingComments, [], true, anthropicApiKey, auxiliaryMaxRetries
+      octokit, context, existingComments, [], new Set(), true, anthropicApiKey, auxiliaryMaxRetries
     );
   const activeSpan = Sentry.getActiveSpan();
   activeSpan?.setAttribute('warden.feedback.auto_resolve.fix_eval_count', autoResolvedByFixEvaluation);
@@ -745,7 +762,8 @@ export async function runPRWorkflow(
         async (resolveSpan) => {
           const resolutionResult = await evaluateFixesAndResolveStale(
             octokit, context, reviewPhase.fetchedComments,
-            allFindings, canResolveStale, inputs.anthropicApiKey,
+            allFindings, reviewPhase.activeWardenCommentIds,
+            canResolveStale, inputs.anthropicApiKey,
             config.defaults?.auxiliaryMaxRetries,
           );
           resolveSpan.setAttribute(


### PR DESCRIPTION
Prevent stale cleanup from resolving Warden review threads that are still active in the current run.

Current-run deduplication can map a fresh finding to an existing Warden comment, suppressing a duplicate inline comment while still requiring review. The stale-resolution pass previously did not know about that dedup match, so it could resolve the existing thread even though the warning still blocked the PR.

This carries matched Warden comment IDs from review posting into stale cleanup and excludes them from fix evaluation and stale resolution. The regression test covers the behavior by simulating a current finding that dedups to an unresolved Warden thread and verifying no GraphQL resolution is attempted.

Validated locally with focused workflow/review tests, typecheck, lint, build, and the full test suite with NO_COLOR unset.

Fixes #271