### PR TITLE
docs: Use scoped Warden package in npx examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Your code is under new management. Agents that review your code - locally or on 
 
 ```bash
 # Initialize warden in your repository
-npx warden init
+npx @sentry/warden init
 
 # Run on uncommitted changes
 # Uses Claude Code subscription if logged in, or set WARDEN_ANTHROPIC_API_KEY
-npx warden
+npx @sentry/warden
 
 # Fix issues automatically
-npx warden --fix
+npx @sentry/warden --fix
 ```
 
 **[Read the full documentation →](https://warden.sentry.dev/)**

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -429,7 +429,7 @@ Add these as organization or repository secrets:
 ### Repository Setup
 
 ```bash
-npx warden init
+npx @sentry/warden init
 ```
 
 Creates `warden.toml` and `.github/workflows/warden.yml`.

--- a/packages/docs/src/pages/github-org-setup.astro
+++ b/packages/docs/src/pages/github-org-setup.astro
@@ -29,7 +29,7 @@ import { WARDEN_ACTION } from '../utils/version.js';
 
   <Terminal showCopy={true}>
     <Code
-      code={`npx warden setup-app --org your-org`}
+      code={`npx @sentry/warden setup-app --org your-org`}
       lang="bash"
       theme="vitesse-black"
     />

--- a/packages/docs/src/pages/guide.astro
+++ b/packages/docs/src/pages/guide.astro
@@ -309,7 +309,7 @@ Focus on issues in the changed code. For each issue found, report:
 
     <Terminal showCopy={true}>
       <Code
-        code={`npx warden init`}
+        code={`npx @sentry/warden init`}
         lang="bash"
         theme="vitesse-black"
       />
@@ -385,7 +385,7 @@ reportOn = "medium"      # Report findings at medium and above`}
 
     <Terminal showCopy={true}>
       <Code
-        code={`npx warden setup-app --org your-org`}
+        code={`npx @sentry/warden setup-app --org your-org`}
         lang="bash"
         theme="vitesse-black"
       />


### PR DESCRIPTION
Update the docs that invoke Warden through npx so they use the published scoped package, @sentry/warden.

The installed binary remains warden, but package-manager examples should resolve the scoped npm package instead of the unscoped package name.