### PR TITLE
fix(cli): Align local review diff context

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Your code is under new management. Agents that review your code - locally or on 
 # Initialize warden in your repository
 npx @sentry/warden init
 
-# Run on uncommitted changes
+# Run a pre-review on current branch changes
 # Uses Claude Code subscription if logged in, or set WARDEN_ANTHROPIC_API_KEY
 npx @sentry/warden
 

--- a/packages/docs/src/pages/cli.astro
+++ b/packages/docs/src/pages/cli.astro
@@ -27,15 +27,16 @@ const tocItems = [
   <div class="command-card">
     <h3 id="warden">warden</h3>
     <div class="synopsis">warden [target] [options]</div>
-    <p>Run code analysis on the specified target. If no target is given, analyzes uncommitted changes.</p>
+    <p>Run code analysis on the specified target. If no target is given, Warden reviews the current branch against the default branch.</p>
     <ul>
       <li><code>target</code> - Files, directories, or git refs to analyze (optional)</li>
     </ul>
     <Terminal>
       <Code
-        code={`warden                     # Analyze uncommitted changes (default)
+        code={`warden                     # Review current branch changes
 warden src/auth.ts         # Analyze specific file
 warden src/api/            # Analyze a directory
+warden --staged            # Analyze staged changes
 warden HEAD~3..HEAD        # Analyze changes in a git range`}
         lang="bash"
         theme="vitesse-black"

--- a/packages/docs/src/pages/config.astro
+++ b/packages/docs/src/pages/config.astro
@@ -427,6 +427,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ github.event.pull_request.head.sha }}
 
       # Uncomment for GitHub App (branded comments)
       # - uses: actions/create-github-app-token@v1

--- a/packages/docs/src/pages/github-org-setup.astro
+++ b/packages/docs/src/pages/github-org-setup.astro
@@ -75,6 +75,8 @@ jobs:
       WARDEN_SENTRY_DSN: \${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ github.event.pull_request.head.sha }}
 
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/packages/docs/src/pages/guide.astro
+++ b/packages/docs/src/pages/guide.astro
@@ -87,9 +87,9 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...`}
 
     <p>Get an API key from <a href="https://console.anthropic.com/">console.anthropic.com</a>. <code>ANTHROPIC_API_KEY</code> is also accepted as a fallback. CI/CD environments require an API key.</p>
 
-    <h3>Review Uncommitted Changes</h3>
+    <h3>Run a Pre-Review</h3>
 
-    <p>Run Warden with no arguments to review your working directory:</p>
+    <p>Run Warden with no arguments to review the current branch before opening or updating a pull request:</p>
 
     <Terminal showCopy={true}>
       <Code
@@ -99,7 +99,7 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...`}
       />
     </Terminal>
 
-    <p>Warden analyzes all uncommitted changes (staged and unstaged) against HEAD, running any skills that match via your configured triggers.</p>
+    <p>Warden compares your current branch to the default branch, preferring the local <code>origin/&lt;default&gt;</code> ref when it exists. This matches the pull request review workflow without requiring a network fetch.</p>
 
     <h3>Review Only Staged Changes</h3>
 
@@ -115,9 +115,9 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...`}
 
     <p>This uses <code>git diff --cached</code> so only staged files are analyzed.</p>
 
-    <h3>Review Before Pushing</h3>
+    <h3>Review a Git Range</h3>
 
-    <p>Review all commits on your branch that aren't on main:</p>
+    <p>Use an explicit git range when you need to review a specific slice of history:</p>
 
     <Terminal showCopy={true}>
       <Code
@@ -127,7 +127,7 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...`}
       />
     </Terminal>
 
-    <p>This catches everything you're about to push.</p>
+    <p>Explicit ranges are useful when the default branch is not the right comparison point.</p>
 
     <h3>Run a Specific Skill</h3>
 

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -150,7 +150,7 @@ You are a security expert analyzing code changes.
         <div class="cli-output-scroll">
           <pre class="cli-output cli-output-report"><span class="cli-dim">$</span> warden
 
-Analyzing uncommitted changes...
+Analyzing changes from origin/main to HEAD...
 
 <span class="cli-bold">FILES</span>  <span class="cli-cyan">4 files</span> <span class="cli-dim">· 6 chunks</span>
   <span class="cli-yellow">~</span> src/api/users.ts <span class="cli-dim">(2 chunks)</span>

--- a/packages/docs/src/pages/skill.astro
+++ b/packages/docs/src/pages/skill.astro
@@ -51,27 +51,27 @@ const tocItems = [
 
   <p>The <code>/warden</code> skill teaches agents how to:</p>
   <ul>
-    <li>Run Warden against uncommitted changes before committing</li>
+    <li>Run Warden against current branch changes before review</li>
     <li>Interpret findings and fix the code</li>
     <li>Configure skills in <code>warden.toml</code></li>
     <li>Create custom skills</li>
   </ul>
 
-  <p>Agents load it automatically when they detect trigger phrases like "run warden", "check my changes", or "review before commit".</p>
+  <p>Agents load it automatically when they detect trigger phrases like "run warden", "check my changes", or "review before PR".</p>
 
   <h2 id="usage">Usage</h2>
 
-  <p>In any agent that supports the spec (like Claude Code), use <code>/warden</code> before committing:</p>
+  <p>In any agent that supports the spec (like Claude Code), use <code>/warden</code> before opening a pull request:</p>
 
   <Terminal showCopy={false}>
     <Code
-      code={`> Use /warden before committing`}
+      code={`> Use /warden before opening a PR`}
       lang="txt"
       theme="vitesse-black"
     />
   </Terminal>
 
-  <p>The agent runs <code>warden</code>, reads the output, fixes what it finds, and commits clean code.</p>
+  <p>The agent runs <code>warden</code>, reads the output, and fixes what it finds.</p>
 
   <h2 id="how-it-works">How It Works</h2>
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -97,7 +97,7 @@ Targets:
   <files>              Analyze specific files (e.g., src/auth.ts)
   <glob>               Analyze files matching pattern (e.g., "src/**/*.ts")
   <git-ref>            Analyze changes from git ref (e.g., HEAD~3, main..feature)
-  (none)               Analyze uncommitted changes using warden.toml triggers
+  (none)               Analyze current branch changes against the default branch
 
 Options:
   --skill <name>       Run only this skill (default: run all built-in skills)

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -79,6 +79,7 @@ describe('init command', () => {
       expect(content).toContain('permissions:');
       expect(content).toContain('pull-requests: write');
       expect(content).toContain('checks: write');
+      expect(content).toContain('ref: ${{ github.event.pull_request.head.sha }}');
       expect(content).toContain('WARDEN_ANTHROPIC_API_KEY');
       expect(content).toContain(`getsentry/warden@v${getMajorVersion()}`);
     });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -120,6 +120,8 @@ jobs:
       WARDEN_SENTRY_DSN: \${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ github.event.pull_request.head.sha }}
       - uses: getsentry/warden@v${majorVersion}
         with:
           anthropic-api-key: \${{ secrets.WARDEN_ANTHROPIC_API_KEY }}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -56,7 +56,7 @@ export function buildLocalEventContext(options: LocalContextOptions = {}): Event
   const base = staged ? 'HEAD' : (options.base ?? defaultBranch);
   const head = options.head; // undefined means working tree
   const currentBranch = getCurrentBranch(cwd);
-  const headSha = head ? head : getHeadSha(cwd);
+  const headSha = head ? resolveRef(head, cwd) : getHeadSha(cwd);
 
   const changedFiles = getChangedFilesWithPatches(base, head, cwd, { staged });
   const files = changedFiles.map(toFileChange);
@@ -75,6 +75,12 @@ export function buildLocalEventContext(options: LocalContextOptions = {}): Event
     title = `Local changes: ${currentBranch}`;
     body = `Analyzing local changes from ${base} to working tree`;
   }
+
+  const diffContextSource = staged
+    ? { type: 'git-index' as const }
+    : head
+      ? { type: 'git-ref' as const, ref: headSha }
+      : { type: 'working-tree' as const };
 
   return {
     eventType: 'pull_request',
@@ -96,6 +102,7 @@ export function buildLocalEventContext(options: LocalContextOptions = {}): Event
       baseSha: resolveRef(base, cwd),
       files,
     },
+    diffContextSource,
     repoPath,
   };
 }
@@ -136,6 +143,7 @@ export async function buildFileEventContext(options: FileContextOptions): Promis
       baseSha: 'file-analysis',
       files,
     },
+    diffContextSource: { type: 'working-tree' },
     repoPath: cwd,
   };
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -13,7 +13,7 @@ import { filterFindings } from '../types/index.js';
 import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
 import { parseCliArgs, showHelp, showVersion, classifyTargets, type CLIOptions } from './args.js';
 import { buildLocalEventContext, buildFileEventContext } from './context.js';
-import { getRepoRoot, getHeadSha, refExists, hasUncommittedChanges } from './git.js';
+import { getRepoRoot, getHeadSha, refExists, getDefaultBranch } from './git.js';
 import { renderTerminalReport, filterReports } from './terminal.js';
 import {
   Reporter,
@@ -102,6 +102,22 @@ function createReporter(options: CLIOptions): Reporter {
 function resolveConfigPath(options: CLIOptions, repoPath: string): string {
   const cwd = process.cwd();
   return options.config ? resolve(cwd, options.config) : resolve(repoPath, 'warden.toml');
+}
+
+function resolveLocalReviewBase(configDefaultBranch: string | undefined, repoPath: string): {
+  defaultBranch: string;
+  base: string;
+} {
+  const defaultBranch = configDefaultBranch ?? getDefaultBranch(repoPath);
+  if (defaultBranch.includes('/')) {
+    return { defaultBranch, base: defaultBranch };
+  }
+
+  const remoteTrackingRef = `origin/${defaultBranch}`;
+  return {
+    defaultBranch,
+    base: refExists(remoteTrackingRef, repoPath) ? remoteTrackingRef : defaultBranch,
+  };
 }
 
 /**
@@ -924,13 +940,18 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
   // Load config
   const config = loadWardenConfig(dirname(configPath));
 
-  // Build context from local git — default to HEAD so only uncommitted changes are analyzed
-  const statusMessage = options.staged ? 'Analyzing staged changes...' : 'Analyzing uncommitted changes...';
+  // Build context from local git. By default, mirror PR-style analysis:
+  // compare the configured/default branch merge base to HEAD.
+  const localReviewBase = resolveLocalReviewBase(config.defaults?.defaultBranch, repoPath);
+  const statusMessage = options.staged
+    ? 'Analyzing staged changes...'
+    : `Analyzing changes from ${localReviewBase.base} to HEAD...`;
   reporter.startContext(statusMessage);
   const context = buildLocalEventContext({
-    base: 'HEAD',
+    base: options.staged ? 'HEAD' : localReviewBase.base,
+    head: options.staged ? undefined : 'HEAD',
     cwd: repoPath,
-    defaultBranch: config.defaults?.defaultBranch,
+    defaultBranch: localReviewBase.defaultBranch,
     staged: options.staged,
   });
 
@@ -946,10 +967,10 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
       if (options.staged) {
         reporter.renderEmptyState('No staged changes found');
       } else {
-        const tip = !hasUncommittedChanges(repoPath)
-          ? 'Specify a git ref: warden HEAD~3 --skill <name>'
-          : undefined;
-        reporter.renderEmptyState('No uncommitted changes found', tip);
+        reporter.renderEmptyState(
+          `No changes found from ${pullRequest.baseBranch} to HEAD`,
+          'Use --staged to analyze staged changes'
+        );
       }
       reporter.blank();
     }
@@ -1092,7 +1113,7 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
 }
 
 /**
- * Run in direct skill mode: run a specific skill on uncommitted changes.
+ * Run in direct skill mode: run a specific skill on current branch changes.
  * Used when --skill is specified without targets.
  */
 async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Promise<number> {
@@ -1111,13 +1132,18 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
   const configPath = resolveConfigPath(options, repoPath);
   const config = existsSync(configPath) ? loadWardenConfig(dirname(configPath)) : null;
 
-  // Build context from local git - compare against HEAD for true uncommitted changes
-  const statusMessage = options.staged ? 'Analyzing staged changes...' : 'Analyzing uncommitted changes...';
+  // Build context from local git. By default, mirror PR-style analysis:
+  // compare the configured/default branch merge base to HEAD.
+  const localReviewBase = resolveLocalReviewBase(config?.defaults?.defaultBranch, repoPath);
+  const statusMessage = options.staged
+    ? 'Analyzing staged changes...'
+    : `Analyzing changes from ${localReviewBase.base} to HEAD...`;
   reporter.startContext(statusMessage);
   const context = buildLocalEventContext({
-    base: 'HEAD',
+    base: options.staged ? 'HEAD' : localReviewBase.base,
+    head: options.staged ? undefined : 'HEAD',
     cwd: repoPath,
-    defaultBranch: config?.defaults?.defaultBranch,
+    defaultBranch: localReviewBase.defaultBranch,
     staged: options.staged,
   });
 
@@ -1133,8 +1159,10 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
       if (options.staged) {
         reporter.renderEmptyState('No staged changes found');
       } else {
-        const tip = 'Specify a git ref to analyze committed changes: warden main --skill <name>';
-        reporter.renderEmptyState('No uncommitted changes found', tip);
+        reporter.renderEmptyState(
+          `No changes found from ${pullRequest.baseBranch} to HEAD`,
+          'Use --staged to analyze staged changes'
+        );
       }
       reporter.blank();
     }
@@ -1154,7 +1182,7 @@ async function runCommand(options: CLIOptions, reporter: Reporter): Promise<numb
     reporter.warning('--staged is ignored when targets are specified');
   }
 
-  // No targets with --skill → run skill directly on uncommitted changes
+  // No targets with --skill → run skill directly on current branch changes
   if (targets.length === 0 && options.skill) {
     return runDirectSkillMode(options, reporter);
   }

--- a/src/diff/context.ts
+++ b/src/diff/context.ts
@@ -1,10 +1,20 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { DiffHunk, ParsedDiff } from './parser.js';
 import { getExpandedLineRange } from './parser.js';
+import type { DiffContextSource } from '../types/index.js';
+import { GIT_NON_INTERACTIVE_ENV } from '../utils/exec.js';
 
 /** Cache for file contents to avoid repeated reads */
 const fileCache = new Map<string, string[] | null>();
+
+export interface ExpandContextOptions {
+  /** Number of context lines to read before and after each hunk */
+  contextLines?: number;
+  /** Source tree to read hunk context from */
+  contentSource?: DiffContextSource;
+}
 
 /** Clear the file cache (useful for testing or long-running processes) */
 export function clearFileCache(): void {
@@ -12,26 +22,92 @@ export function clearFileCache(): void {
 }
 
 /** Get cached file lines or read and cache them */
-function getCachedFileLines(filePath: string): string[] | null {
-  if (fileCache.has(filePath)) {
-    return fileCache.get(filePath) ?? null;
+function normalizeOptions(options: number | ExpandContextOptions): Required<ExpandContextOptions> {
+  if (typeof options === 'number') {
+    return {
+      contextLines: options,
+      contentSource: { type: 'working-tree' },
+    };
   }
 
+  return {
+    contextLines: options.contextLines ?? 20,
+    contentSource: options.contentSource ?? { type: 'working-tree' },
+  };
+}
+
+function cacheKey(repoPath: string, filename: string, source: DiffContextSource): string {
+  const sourceKey = source.type === 'git-ref' ? `${source.type}:${source.ref}` : source.type;
+  return `${sourceKey}:${repoPath}:${filename}`;
+}
+
+function isInsideRepo(repoPath: string, filename: string): boolean {
+  const resolvedRepo = resolve(repoPath);
+  const resolvedFile = resolve(join(repoPath, filename));
+  return resolvedFile === resolvedRepo || resolvedFile.startsWith(resolvedRepo + '/');
+}
+
+function readWorkingTreeLines(repoPath: string, filename: string): string[] | null {
+  const filePath = join(repoPath, filename);
+
   if (!existsSync(filePath)) {
-    fileCache.set(filePath, null);
     return null;
   }
 
   try {
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
-    fileCache.set(filePath, lines);
-    return lines;
+    return content.split('\n');
   } catch {
     // Binary file or read error
-    fileCache.set(filePath, null);
     return null;
   }
+}
+
+function readGitSourceLines(
+  repoPath: string,
+  filename: string,
+  source: Extract<DiffContextSource, { type: 'git-index' | 'git-ref' }>
+): string[] | null {
+  const refPath = source.type === 'git-index'
+    ? `:${filename}`
+    : `${source.ref}:${filename}`;
+
+  const result = spawnSync('git', ['show', refPath], {
+    cwd: repoPath,
+    encoding: 'utf-8',
+    env: { ...process.env, ...GIT_NON_INTERACTIVE_ENV },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.error || result.status !== 0 || typeof result.stdout !== 'string') {
+    return null;
+  }
+
+  return result.stdout.split('\n');
+}
+
+/** Get cached file lines or read and cache them */
+function getCachedFileLines(
+  repoPath: string,
+  filename: string,
+  source: DiffContextSource
+): string[] | null {
+  const key = cacheKey(repoPath, filename, source);
+  if (fileCache.has(key)) {
+    return fileCache.get(key) ?? null;
+  }
+
+  if (!isInsideRepo(repoPath, filename)) {
+    fileCache.set(key, null);
+    return null;
+  }
+
+  const lines = source.type === 'working-tree'
+    ? readWorkingTreeLines(repoPath, filename)
+    : readGitSourceLines(repoPath, filename, source);
+
+  fileCache.set(key, lines);
+  return lines;
 }
 
 export interface HunkWithContext {
@@ -94,11 +170,13 @@ function detectLanguage(filename: string): string {
  * Returns empty array if file doesn't exist or is binary.
  */
 function readFileLines(
-  filePath: string,
+  repoPath: string,
+  filename: string,
+  source: DiffContextSource,
   startLine: number,
   endLine: number
 ): string[] {
-  const lines = getCachedFileLines(filePath);
+  const lines = getCachedFileLines(repoPath, filename, source);
   if (!lines) {
     return [];
   }
@@ -113,12 +191,12 @@ export function expandHunkContext(
   repoPath: string,
   filename: string,
   hunk: DiffHunk,
-  contextLines = 20
+  options: number | ExpandContextOptions = 20
 ): HunkWithContext {
-  const filePath = join(repoPath, filename);
+  const { contextLines, contentSource } = normalizeOptions(options);
 
   // Defense-in-depth: ensure filename doesn't escape repo directory
-  if (!resolve(filePath).startsWith(resolve(repoPath) + '/')) {
+  if (!isInsideRepo(repoPath, filename)) {
     return { filename, hunk, contextBefore: [], contextAfter: [], contextStartLine: 1, language: detectLanguage(filename) };
   }
 
@@ -126,14 +204,18 @@ export function expandHunkContext(
 
   // Read context before the hunk
   const contextBefore = readFileLines(
-    filePath,
+    repoPath,
+    filename,
+    contentSource,
     expandedRange.start,
     hunk.newStart - 1
   );
 
   // Read context after the hunk
   const contextAfter = readFileLines(
-    filePath,
+    repoPath,
+    filename,
+    contentSource,
     hunk.newStart + hunk.newCount,
     expandedRange.end
   );
@@ -154,10 +236,10 @@ export function expandHunkContext(
 export function expandDiffContext(
   repoPath: string,
   diff: ParsedDiff,
-  contextLines = 20
+  options: number | ExpandContextOptions = 20
 ): HunkWithContext[] {
   return diff.hunks.map((hunk) =>
-    expandHunkContext(repoPath, diff.filename, hunk, contextLines)
+    expandHunkContext(repoPath, diff.filename, hunk, options)
   );
 }
 

--- a/src/event/context.ts
+++ b/src/event/context.ts
@@ -99,6 +99,7 @@ export async function buildEventContext(
     action: payload.action,
     repository,
     pullRequest,
+    diffContextSource: { type: 'working-tree' },
     repoPath,
   };
 

--- a/src/event/schedule-context.ts
+++ b/src/event/schedule-context.ts
@@ -72,6 +72,7 @@ export async function buildScheduleEventContext(
       baseSha: headSha, // No actual base for scheduled runs
       files: fileChanges,
     },
+    diffContextSource: { type: 'working-tree' },
     repoPath,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   PullRequestActionSchema,
   // File Changes
   FileChangeSchema,
+  DiffContextSourceSchema,
   // Context
   PullRequestContextSchema,
   RepositoryContextSchema,
@@ -56,6 +57,7 @@ export type {
   GitHubEventType,
   PullRequestAction,
   FileChange,
+  DiffContextSource,
   PullRequestContext,
   RepositoryContext,
   EventContext,

--- a/src/sdk/prepare.test.ts
+++ b/src/sdk/prepare.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
 import { prepareFiles } from './prepare.js';
 import type { EventContext, FileChange } from '../types/index.js';
+import { buildLocalEventContext } from '../cli/context.js';
 
 function makeContext(
   files: { filename: string; patch: string; status?: FileChange['status'] }[],
@@ -33,6 +38,36 @@ function makeContext(
 }
 
 describe('prepareFiles', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function git(cwd: string, args: string[]): string {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  }
+
+  function createGitRepo(): string {
+    const repoPath = mkdtempSync(join(tmpdir(), 'warden-prepare-'));
+    tempDirs.push(repoPath);
+    git(repoPath, ['init']);
+    git(repoPath, ['config', 'user.email', 'warden@example.com']);
+    git(repoPath, ['config', 'user.name', 'Warden Test']);
+    return repoPath;
+  }
+
+  function writeTrackedFile(repoPath: string, lines: string[]): void {
+    mkdirSync(join(repoPath, 'src'), { recursive: true });
+    writeFileSync(join(repoPath, 'src/file.ts'), `${lines.join('\n')}\n`);
+  }
+
   it('skips files with empty patch content (zero-line hunks)', () => {
     const context = makeContext([
       { filename: 'empty.ts', patch: '@@ -0,0 +0,0 @@\n' },
@@ -84,5 +119,48 @@ describe('prepareFiles', () => {
 
     expect(result.files).toEqual([]);
     expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('reads git-ref hunk context from the analyzed commit, not the dirty working tree', () => {
+    const repoPath = createGitRepo();
+    const baseLines = ['one', 'two', 'three', 'old value', 'after one', 'after two', 'after three', 'clean context'];
+    const headLines = [...baseLines];
+    headLines[3] = 'new value';
+    const dirtyLines = [...headLines];
+    dirtyLines[7] = 'dirty context';
+
+    writeTrackedFile(repoPath, baseLines);
+    git(repoPath, ['add', 'src/file.ts']);
+    git(repoPath, ['commit', '-m', 'base']);
+    writeTrackedFile(repoPath, headLines);
+    git(repoPath, ['add', 'src/file.ts']);
+    git(repoPath, ['commit', '-m', 'head']);
+    writeTrackedFile(repoPath, dirtyLines);
+
+    const context = buildLocalEventContext({ base: 'HEAD^', head: 'HEAD', cwd: repoPath });
+    const result = prepareFiles(context, { contextLines: 1 });
+
+    expect(result.files[0]?.hunks[0]?.contextAfter).toEqual(['clean context']);
+  });
+
+  it('reads staged hunk context from the index, not unstaged changes', () => {
+    const repoPath = createGitRepo();
+    const baseLines = ['one', 'two', 'three', 'old value', 'after one', 'after two', 'after three', 'index context'];
+    const stagedLines = [...baseLines];
+    stagedLines[3] = 'new value';
+    const dirtyLines = [...stagedLines];
+    dirtyLines[7] = 'dirty context';
+
+    writeTrackedFile(repoPath, baseLines);
+    git(repoPath, ['add', 'src/file.ts']);
+    git(repoPath, ['commit', '-m', 'base']);
+    writeTrackedFile(repoPath, stagedLines);
+    git(repoPath, ['add', 'src/file.ts']);
+    writeTrackedFile(repoPath, dirtyLines);
+
+    const context = buildLocalEventContext({ cwd: repoPath, staged: true });
+    const result = prepareFiles(context, { contextLines: 1 });
+
+    expect(result.files[0]?.hunks[0]?.contextAfter).toEqual(['index context']);
   });
 });

--- a/src/sdk/prepare.ts
+++ b/src/sdk/prepare.ts
@@ -91,7 +91,10 @@ export function prepareFiles(
         })
       : splitHunks;
 
-    const hunksWithContext = expandDiffContext(context.repoPath, { ...diff, hunks }, contextLines);
+    const hunksWithContext = expandDiffContext(context.repoPath, { ...diff, hunks }, {
+      contextLines,
+      contentSource: context.diffContextSource,
+    });
     allHunks.push(...hunksWithContext);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -307,6 +307,14 @@ export const FileChangeSchema = z.object({
 });
 export type FileChange = z.infer<typeof FileChangeSchema>;
 
+// Source used to read surrounding file context for diff hunks.
+export const DiffContextSourceSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('working-tree') }),
+  z.object({ type: z.literal('git-index') }),
+  z.object({ type: z.literal('git-ref'), ref: z.string() }),
+]);
+export type DiffContextSource = z.infer<typeof DiffContextSourceSchema>;
+
 /**
  * Count the number of chunks/hunks in a patch string.
  * Each chunk starts with @@ -X,Y +A,B @@
@@ -347,6 +355,7 @@ export const EventContextSchema = z.object({
   repository: RepositoryContextSchema,
   pullRequest: PullRequestContextSchema.optional(),
   repoPath: z.string(),
+  diffContextSource: DiffContextSourceSchema.optional(),
 });
 export type EventContext = z.infer<typeof EventContextSchema>;
 


### PR DESCRIPTION
Default local CLI runs now behave like pre-review: Warden compares the current branch against the repository default branch, preferring a local origin/<default> ref when available. Explicit file/glob targets still scan specific codebase slices, and --staged remains the index-only pre-commit workflow.

This also threads a diff context source through hunk expansion so surrounding context is read from the same tree as the diff being analyzed. Git-ref runs read from the analyzed commit, staged runs read from the index, and working-tree scans keep using the working tree.

Docs and generated workflow snippets now describe those workflows and check out the PR head SHA in CI examples so file reads match the Pulls API diff.

Fixes #257