### PR TITLE
ci: Add GitHub Actions workflow skill

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -18,6 +18,22 @@ type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
+name = "wrdn-gha-workflows"
+remote = "getsentry/warden-skills"
+paths = [
+  ".github/workflows/*.yml",
+  ".github/workflows/*.yaml",
+  ".github/actions/**/*.yml",
+  ".github/actions/**/*.yaml",
+  "action.yml",
+  "action.yaml",
+]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
 name = "code-simplifier"
 remote = "getsentry/sentry-skills"
 


### PR DESCRIPTION
Add the remote Warden GitHub Actions workflow skill from getsentry/warden-skills to this repo's config. This makes Warden review workflow and local action YAML changes on pull request events, matching the setup in getsentry/sentry.