### PR TITLE
feat(cli): Build generated skills from path targets

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -407,6 +407,18 @@ describe('parseCliArgs', () => {
     expect(result.options.prompt).toBe('@prompts/security.md');
   });
 
+  it('parses build command with a path target', () => {
+    const result = parseCliArgs([
+      'build',
+      './skills/security-review',
+      '--prompt',
+      '@prompts/security.md',
+    ]);
+    expect(result.command).toBe('build');
+    expect(result.options.skill).toBe('./skills/security-review');
+    expect(result.options.prompt).toBe('@prompts/security.md');
+  });
+
   it('parses runs list command', () => {
     const result = parseCliArgs(['runs', 'list']);
     expect(result.command).toBe('runs');

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -9,6 +9,8 @@ import { runBuild } from './build.js';
 import { getRepoRoot } from '../git.js';
 import {
   buildGeneratedSkillDefinition,
+  createGeneratedSkillDefinition,
+  getGeneratedSkillRoot,
   generatedSkillDefinitionExists,
 } from '../../skill-builder/definition.js';
 import { buildSkillOutline } from '../../skill-builder/outline.js';
@@ -20,6 +22,7 @@ vi.mock('../git.js', () => ({
 }));
 
 vi.mock('../../skill-builder/definition.js', () => ({
+  GENERATED_SKILL_DEFINITION_FILE: 'warden.yaml',
   generatedSkillDefinitionExists: vi.fn(),
   buildGeneratedSkillDefinition: vi.fn(),
   createGeneratedSkillDefinition: vi.fn(),
@@ -81,6 +84,8 @@ describe('runBuild', () => {
   const getRepoRootMock = vi.mocked(getRepoRoot);
   const generatedSkillDefinitionExistsMock = vi.mocked(generatedSkillDefinitionExists);
   const buildGeneratedSkillDefinitionMock = vi.mocked(buildGeneratedSkillDefinition);
+  const createGeneratedSkillDefinitionMock = vi.mocked(createGeneratedSkillDefinition);
+  const getGeneratedSkillRootMock = vi.mocked(getGeneratedSkillRoot);
   const buildSkillOutlineMock = vi.mocked(buildSkillOutline);
   const buildGeneratedSkillMock = vi.mocked(buildGeneratedSkill);
   const getRuntimeMock = vi.mocked(getRuntime);
@@ -89,15 +94,23 @@ describe('runBuild', () => {
   let originalCwd: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tempDir = mkdtempSync(join(tmpdir(), 'warden-build-test-'));
     originalCwd = process.cwd();
     process.chdir(tempDir);
 
     getRepoRootMock.mockReturnValue(tempDir);
+    getGeneratedSkillRootMock.mockReturnValue(join(tempDir, '.warden', 'skills', 'security'));
     generatedSkillDefinitionExistsMock.mockReturnValue(true);
     buildGeneratedSkillDefinitionMock.mockReturnValue({
       name: 'security',
       description: 'Generated security skill',
+      prompt: 'Find security issues.',
+      rootDir: join(tempDir, '.warden', 'skills', 'security'),
+    });
+    createGeneratedSkillDefinitionMock.mockReturnValue({
+      name: 'security',
+      description: 'security',
       prompt: 'Find security issues.',
       rootDir: join(tempDir, '.warden', 'skills', 'security'),
     });
@@ -197,5 +210,63 @@ describe('runBuild', () => {
     expect(output).toContain('SKILL');
     expect(output.indexOf('TRACKS  2 tracks')).toBeGreaterThan(output.indexOf('OUTLINE'));
     expect(output.indexOf('TRACKS  2 tracks')).toBeLessThan(output.indexOf('SKILL'));
+  });
+
+  it('loads an existing generated skill from an explicit root path', async () => {
+    const reporter = createTestReporter();
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const rootDir = join(tempDir, 'skills', 'security');
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: |-
+  Find security issues.
+`, 'utf-8');
+    buildGeneratedSkillDefinitionMock.mockReturnValueOnce({
+      name: 'security',
+      description: 'Generated security skill',
+      prompt: 'Find security issues.',
+      rootDir,
+    });
+
+    const exitCode = await runBuild(createOptions({ skill: './skills/security' }), reporter);
+
+    expect(exitCode).toBe(0);
+    expect(generatedSkillDefinitionExistsMock).not.toHaveBeenCalled();
+    expect(buildGeneratedSkillDefinitionMock).toHaveBeenCalledWith(rootDir);
+    expect(buildGeneratedSkillMock).toHaveBeenCalledWith(expect.objectContaining({
+      rootDir,
+    }));
+    const output = stderrSpy.mock.calls
+      .map((call) => call.map((part) => String(part)).join(' '))
+      .join('\n');
+    expect(output).toContain('warden src/file.ts --skill ./skills/security');
+  });
+
+  it('creates a generated skill at an explicit root path from the prompt', async () => {
+    const reporter = createTestReporter();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const rootDir = join(tempDir, 'skills', 'security');
+    createGeneratedSkillDefinitionMock.mockReturnValueOnce({
+      name: 'security',
+      description: 'security',
+      prompt: 'Find security issues.',
+      rootDir,
+    });
+
+    const exitCode = await runBuild(createOptions({
+      skill: './skills/security',
+      prompt: 'Find security issues.',
+    }), reporter);
+
+    expect(exitCode).toBe(0);
+    expect(generatedSkillDefinitionExistsMock).not.toHaveBeenCalled();
+    expect(createGeneratedSkillDefinitionMock).toHaveBeenCalledWith({
+      repoRoot: tempDir,
+      name: 'security',
+      prompt: 'Find security issues.',
+      rootDir,
+    });
   });
 });

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, isAbsolute, join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import chalk from 'chalk';
 import { emptyToUndefined, loadWardenConfigFile } from '../../config/loader.js';
 import type { SkillDefinition, WardenConfig } from '../../config/schema.js';
@@ -8,7 +8,7 @@ import type { CLIOptions } from '../args.js';
 import type { Reporter } from '../output/reporter.js';
 import { formatBytes, formatCost, formatDuration, formatTokens } from '../output/formatters.js';
 import { runWithLiveStatus } from '../output/live-status.js';
-import { getAnthropicApiKey } from '../../utils/index.js';
+import { getAnthropicApiKey, isPathLike } from '../../utils/index.js';
 import { promptLine, promptMultiline } from '../input.js';
 import { getRepoRoot } from '../git.js';
 import {
@@ -145,21 +145,12 @@ function resolvePromptValue(prompt: string): string {
   return prompt.trim();
 }
 
-function isPathLikeTarget(value: string): boolean {
-  return (
-    isAbsolute(value) ||
-    value.startsWith('.') ||
-    value.includes('/') ||
-    value.includes('\\')
-  );
-}
-
 function resolveGeneratedSkillTarget(target: string, repoRoot: string): {
   displayName: string;
   isPath: boolean;
   rootDir: string;
 } {
-  if (isPathLikeTarget(target)) {
+  if (isPathLike(target)) {
     const rootDir = resolve(repoRoot, target);
     return {
       displayName: target,
@@ -406,7 +397,7 @@ export async function runBuild(
           turns: artifact.numTurns,
         }));
       }
-      renderTryIt(reporter, isPathLikeTarget(skillName) ? skillName : skill.name);
+      renderTryIt(reporter, isPathLike(skillName) ? skillName : skill.name);
     } else {
       process.stdout.write(`${JSON.stringify({
         skill: {

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, isAbsolute, join, resolve } from 'node:path';
 import chalk from 'chalk';
 import { emptyToUndefined, loadWardenConfigFile } from '../../config/loader.js';
 import type { SkillDefinition, WardenConfig } from '../../config/schema.js';
@@ -14,6 +14,7 @@ import { getRepoRoot } from '../git.js';
 import {
   buildGeneratedSkillDefinition,
   createGeneratedSkillDefinition,
+  GENERATED_SKILL_DEFINITION_FILE,
   getGeneratedSkillRoot,
   inferGeneratedSkillDescription,
   generatedSkillDefinitionExists,
@@ -144,6 +145,36 @@ function resolvePromptValue(prompt: string): string {
   return prompt.trim();
 }
 
+function isPathLikeTarget(value: string): boolean {
+  return (
+    isAbsolute(value) ||
+    value.startsWith('.') ||
+    value.includes('/') ||
+    value.includes('\\')
+  );
+}
+
+function resolveGeneratedSkillTarget(target: string, repoRoot: string): {
+  displayName: string;
+  isPath: boolean;
+  rootDir: string;
+} {
+  if (isPathLikeTarget(target)) {
+    const rootDir = resolve(repoRoot, target);
+    return {
+      displayName: target,
+      isPath: true,
+      rootDir,
+    };
+  }
+
+  return {
+    displayName: target,
+    isPath: false,
+    rootDir: getGeneratedSkillRoot(repoRoot, target),
+  };
+}
+
 function resolveSynthesisModel(
   config: WardenConfig | undefined,
   options: CLIOptions,
@@ -180,22 +211,28 @@ async function ensureSynthesizedSkill(args: {
   reporter: Reporter;
 }): Promise<{ skill: SkillDefinition; created: boolean; promptLength?: number }> {
   const { skillName, repoRoot, options, reporter } = args;
-  if (generatedSkillDefinitionExists(repoRoot, skillName)) {
-    const rootDir = getGeneratedSkillRoot(repoRoot, skillName);
-    return { skill: buildGeneratedSkillDefinition(rootDir), created: false };
+  const target = resolveGeneratedSkillTarget(skillName, repoRoot);
+  const definitionExists = target.isPath
+    ? existsSync(join(target.rootDir, GENERATED_SKILL_DEFINITION_FILE))
+    : generatedSkillDefinitionExists(repoRoot, skillName);
+
+  if (definitionExists) {
+    return { skill: buildGeneratedSkillDefinition(target.rootDir), created: false };
   }
 
   const prompt = await resolvePrompt(options, skillName);
   if (!prompt) {
-    reporter.error(`Generated skill not found: ${skillName}`);
-    reporter.tip(`Run interactively, or pass --prompt/-p to create .warden/skills/${skillName}`);
+    reporter.error(`Generated skill not found: ${target.displayName}`);
+    const createTarget = target.isPath ? target.displayName : `.warden/skills/${skillName}`;
+    reporter.tip(`Run interactively, or pass --prompt/-p to create ${createTarget}`);
     throw new SkillBuildOutlineError(`Missing prompt for new generated skill: ${skillName}`);
   }
 
   const skill = createGeneratedSkillDefinition({
     repoRoot,
-    name: skillName,
+    name: target.isPath ? basename(target.rootDir) : skillName,
     prompt,
+    rootDir: target.rootDir,
   });
   return { skill, created: true, promptLength: prompt.length };
 }
@@ -369,7 +406,7 @@ export async function runBuild(
           turns: artifact.numTurns,
         }));
       }
-      renderTryIt(reporter, skill.name);
+      renderTryIt(reporter, isPathLikeTarget(skillName) ? skillName : skill.name);
     } else {
       process.stdout.write(`${JSON.stringify({
         skill: {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -294,12 +294,12 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
   },
   build: {
     summary: 'Build a repo-local generated skill',
-    description: 'Create or refresh one generated skill under .warden/skills from a prompt-backed definition.',
+    description: 'Create or refresh one generated skill by name under .warden/skills, or at an explicit skill root path.',
     usage: [
       'warden build <skill> [options]',
     ],
     arguments: [
-      { label: 'skill', description: 'Generated skill name' },
+      { label: 'skill', description: 'Generated skill name or skill root path' },
     ],
     options: [
       'cwd',
@@ -313,6 +313,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
     examples: [
       'warden build security --regenerate',
       'warden build security -p @prompt.md',
+      'warden build ./skills/security -p @prompt.md',
       'warden build sentry-security --json',
     ],
   },

--- a/src/skill-builder/definition.test.ts
+++ b/src/skill-builder/definition.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { loadGeneratedSkillDefinition } from './definition.js';
+import { createGeneratedSkillDefinition, loadGeneratedSkillDefinition } from './definition.js';
 
 describe('loadGeneratedSkillDefinition', () => {
   const tempDirs: string[] = [];
@@ -27,6 +27,24 @@ prompt: |-
     const definition = loadGeneratedSkillDefinition(rootDir);
 
     expect(definition.data.kind).toBe('generated-skill');
+    expect(definition.data.name).toBe('security');
+    expect(definition.data.prompt).toBe('Find security issues.');
+  });
+
+  it('creates generated skill definitions at an explicit root path', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(repoRoot);
+    const rootDir = join(repoRoot, 'skills', 'security');
+
+    const skill = createGeneratedSkillDefinition({
+      repoRoot,
+      name: 'security',
+      prompt: 'Find security issues.',
+      rootDir,
+    });
+
+    expect(skill.rootDir).toBe(rootDir);
+    const definition = loadGeneratedSkillDefinition(rootDir);
     expect(definition.data.name).toBe('security');
     expect(definition.data.prompt).toBe('Find security issues.');
   });

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -112,8 +112,9 @@ export function createGeneratedSkillDefinition(args: {
   repoRoot: string;
   name: string;
   prompt: string;
+  rootDir?: string;
 }): SkillDefinition {
-  const rootDir = getGeneratedSkillRoot(args.repoRoot, args.name);
+  const rootDir = args.rootDir ?? getGeneratedSkillRoot(args.repoRoot, args.name);
   mkdirSync(rootDir, { recursive: true });
 
   writeFileSync(join(rootDir, GENERATED_SKILL_DEFINITION_FILE), `version: 1

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import type { SkillDefinition, ToolName } from '../config/schema.js';
 import { ToolNameSchema } from '../config/schema.js';
+import { isPathLike } from '../utils/path.js';
 
 export class SkillLoaderError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
@@ -62,13 +63,6 @@ export const AGENT_DIRECTORIES = [
 
 /** Marker filename for agent definitions */
 export const AGENT_MARKER_FILE = 'AGENT.md';
-
-/**
- * Check if a string looks like a path (contains path separators or starts with .)
- */
-function isSkillPath(nameOrPath: string): boolean {
-  return nameOrPath.includes('/') || nameOrPath.includes('\\') || nameOrPath.startsWith('.');
-}
 
 /**
  * Resolve a skill path, handling absolute paths, tilde expansion, and relative paths.
@@ -447,7 +441,7 @@ async function resolveEntry(
   }
 
   // 2. Direct path resolution
-  if (isSkillPath(nameOrPath)) {
+  if (isPathLike(nameOrPath)) {
     const resolvedPath = resolveSkillPath(nameOrPath, repoRoot);
 
     const markerPath = join(resolvedPath, config.markerFile);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ export {
   execGitNonInteractive,
   GIT_NON_INTERACTIVE_ENV,
 } from './exec.js';
+export { isPathLike } from './path.js';
 export type { ExecOptions } from './exec.js';
 
 /** Default concurrency for parallel trigger/skill execution */

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { isPathLike } from './path.js';
+
+describe('isPathLike', () => {
+  it('identifies filesystem path targets', () => {
+    expect(isPathLike('./skills/security')).toBe(true);
+    expect(isPathLike('/Users/test/skills/security')).toBe(true);
+    expect(isPathLike('skills\\security')).toBe(true);
+    expect(isPathLike('security')).toBe(false);
+  });
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,6 @@
+/**
+ * Check whether a target string should be treated as a filesystem path.
+ */
+export function isPathLike(value: string): boolean {
+  return value.startsWith('.') || value.includes('/') || value.includes('\\');
+}


### PR DESCRIPTION
Allow `warden build` to accept either a generated skill name or a full skill root path like `./skills/wrd-security`. Name targets keep writing under `.warden/skills/<name>`, while path targets build at the requested `./path/skill-name` root and show a matching `--skill ./path/skill-name` try-it command.

**Path Targets**

Path-like positional values now load or create `warden.yaml` inside the full skill root directory. New path targets derive the skill name from that root basename, so `./skills/wrd-security` becomes `wrd-security`.

Validated with focused CLI/build tests, typecheck, and lint.