### PR TITLE
fix(skill-builder): Stabilize generated skill authoring

### DIFF
--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -15,8 +15,17 @@ Good generated skills usually have:
 - remediation guidance that points toward an actual patch
 - source provenance or explicit gaps when the skill claims broad expertise
 - segmentation that makes the skill usable without loading irrelevant material
+- reference-backed layouts where references behave as focused lookup leaves,
+  with navigation or further splitting when a leaf becomes hard to scan
 
 Many broad skills will naturally become reference-backed, often with roughly one focused reference per major topic and sometimes multiple references for a large topic. That is an expected outcome, not a required layout. Smaller skills may stay mostly inline. Some topics may share a reference. Some topics may not need a separate file at all. The authoring provider owns that choice.
+
+Reference-backed does not mean "one giant catalog per topic." Each reference
+should have a direct open-when route from `SKILL.md`, one dominant lookup need,
+and enough structure that the runtime agent can open only the material relevant
+to the current changed hunk. Oversized, mixed-purpose, or unnavigable references
+are quality failures even though the exact split remains the authoring
+provider's choice.
 
 ## Builder Contract
 
@@ -97,10 +106,10 @@ All other files are generated artifacts. The authoring provider decides whether 
 2. Synthesizes internal Warden context for the build
 3. Resolves an authoring provider, defaulting to the vendored `src/internal-skills/skill-writer`
 4. Plans the authoring run: brief, topics, ordered tasks, source plan, and review rubric
-5. Runs implementation through the authoring provider
-6. Runs qualitative review against skill-writer and Warden's acceptance bar
-7. Runs one bounded revision pass for concrete review failures
-8. Writes the returned generated file map only after final review and mechanical validation pass
+5. Runs implementation through the authoring provider in the target skill root
+6. Reads generated artifacts from disk and runs qualitative review against skill-writer and Warden's acceptance bar
+7. Runs bounded writer/reviewer revision rounds for concrete review failures
+8. Stores artifact metadata only after the review loop and mechanical validation pass
 9. Stores provider/version/hash and validation metadata in build state
 
 The internal outline is Warden context only. It is not a runnable skill and it does not prescribe the final artifact layout. It should help the planner identify topics, work lanes, source expectations, and non-overlap boundaries.
@@ -111,15 +120,12 @@ The builder passes the full authoring skill directory to the agent and tells it 
 
 The vendored provider is internal runtime data, not an installable bundled skill, and Warden does not discover `skill-writer` from user skill directories. User-facing bundled skills stay under `skills/`.
 
-The provider returns a file map:
+The provider writes artifacts directly under the target skill root and returns
+metadata about the pass:
 
 ```json
 {
   "version": 1,
-  "name": "wrdn-example",
-  "files": [
-    {"path": "SKILL.md", "content": "..."}
-  ],
   "summary": "...",
   "validationNotes": [],
   "missingInputs": [],
@@ -127,7 +133,10 @@ The provider returns a file map:
 }
 ```
 
-Warden owns writing, cache invalidation, runtime constraints, and minimal mechanical validation. The provider owns authoring method, layout choice, source synthesis, and how to package depth into skill artifacts.
+Warden owns cache invalidation, runtime constraints, minimal mechanical
+validation, and artifact metadata. The provider owns disk writes, authoring
+method, layout choice, source synthesis, and how to package depth into skill
+artifacts.
 
 ## Planner Output
 
@@ -154,11 +163,11 @@ The implementation writer should:
 - cover each task's required evidence, false-positive controls, and remediation expectations somewhere useful
 - preserve non-overlap boundaries between sibling topics
 - record missing source/context when a task cannot be covered honestly
-- return one complete file map for the chosen skill-writer layout
+- leave one complete artifact tree on disk for the chosen skill-writer layout
 
 Completion is not "this topic name appears." Completion means the generated runtime guidance gives the later Warden run enough evidence, false-positive controls, and remediation direction to make useful findings.
 
-Warden should not run automatic per-task artifact edit passes. The reviewer enforces task coverage qualitatively and gives one bounded revision pass when the generated skill is shallow, incomplete, or inconsistent with skill-writer.
+Warden should not run automatic per-task artifact edit passes. The reviewer enforces task coverage qualitatively and can drive bounded writer revision rounds when the generated skill is shallow, incomplete, or inconsistent with skill-writer.
 
 ## Runtime Contract
 
@@ -184,6 +193,9 @@ Deterministic checks should stay mechanical:
 - local runtime files referenced by generated artifacts exist
 
 Deterministic validation should not judge taste, depth, segmentation quality, source adequacy, or preferred layout.
+It should also not enforce maintenance-document template headings. Those are
+authoring-quality signals only when the reviewer finds a concrete usability or
+maintenance problem.
 
 The authoring-provider review should judge quality:
 
@@ -195,8 +207,10 @@ The authoring-provider review should judge quality:
 - is guidance over-broad, catalog-only, or shallow?
 - are false-positive controls and remediation patterns concrete?
 - is segmentation useful without being forced?
+- are reference-backed artifacts focused, directly routed, and navigable enough
+  for runtime use?
 
-The reviewer should return concrete feedback for one bounded revision pass. If final review still reports unresolved issues, Warden should fail the build and keep the previous artifact on disk.
+The reviewer should return concrete feedback for bounded revision rounds. If the reviewer still requests changes after the maximum rounds, Warden should keep the latest writer draft, store the reviewer feedback as warnings, and continue unless mechanical validation found an unrunnable artifact.
 
 ## Caching
 

--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -2,6 +2,72 @@
 
 Warden can build one repo-local skill from a prompt-backed definition. The builder is an authoring harness, not a fixed skill-template generator.
 
+## Desired Outcome
+
+Generated skills should be rich runtime skills with enough depth for a later Warden run to make good decisions from changed hunks.
+
+Good generated skills usually have:
+
+- clear runtime trigger language and scope
+- topic coverage broken into useful semantic areas
+- concrete evidence requirements, not only API or vulnerability catalogs
+- false-positive controls and safe counterexamples
+- remediation guidance that points toward an actual patch
+- source provenance or explicit gaps when the skill claims broad expertise
+- segmentation that makes the skill usable without loading irrelevant material
+
+Many broad skills will naturally become reference-backed, often with roughly one focused reference per major topic and sometimes multiple references for a large topic. That is an expected outcome, not a required layout. Smaller skills may stay mostly inline. Some topics may share a reference. Some topics may not need a separate file at all. The authoring provider owns that choice.
+
+## Builder Contract
+
+Warden supplies the authoring context and acceptance bar. The authoring provider, normally `skill-writer`, owns the artifact layout and authoring method.
+
+Warden provides:
+
+- the generated skill goal from `warden.yaml`
+- the internal outline as planning context
+- semantic topics that need coverage
+- sequential authoring tasks or work lanes
+- runtime constraints for Warden skills
+- source-depth expectations and known source gaps
+- a qualitative review rubric
+- minimal mechanical validation for runnability
+
+Warden does not prescribe:
+
+- reference filenames
+- folder conventions
+- one topic per file
+- one task per file
+- route table shape beyond local runtime dependencies being usable
+- `skill-writer` internals copied into Warden prompts
+
+The wrapper prompt should say, in effect:
+
+> Use skill-writer as the authoring method. Warden provides the goal, coverage topics, sequential tasks, source expectations, runtime constraints, and qualitative rubric. Choose the simplest artifact layout that satisfies skill-writer and the rubric.
+
+## Topics And Tasks
+
+The planner should separate coverage from execution.
+
+`topics` are semantic coverage areas the final skill must handle. A topic describes what needs to be covered and how deep that coverage must be:
+
+- coverage goal
+- required evidence
+- false-positive controls
+- remediation expectations
+- source requirements or gaps
+
+`tasks` are sequential authoring work items. A task tells the writer what to deepen next:
+
+- objective
+- topic ids covered by the task
+- source work to perform
+- non-overlap boundaries
+- done criteria
+
+A task may cover one topic, part of a topic, or multiple topics. A topic may be handled inline, in one reference, in several references, in a shared reference, or in another valid skill-writer layout. Tracks/tasks are not filesystem taxonomy.
+
 ## Artifact Layout
 
 Generated skills live under `.warden/skills/<name>/`.
@@ -30,11 +96,15 @@ All other files are generated artifacts. The authoring provider decides whether 
 1. Reads or creates `.warden/skills/<name>/warden.yaml`
 2. Synthesizes internal Warden context for the build
 3. Resolves an authoring provider, defaulting to the vendored `src/internal-skills/skill-writer`
-4. Runs plan, implementation, and validation passes through that provider
-5. Writes the returned generated file map
-6. Stores provider/version/hash and validation metadata in build state
+4. Plans the authoring run: brief, topics, sequential tasks, source plan, and review rubric
+5. Runs implementation through the authoring provider
+6. Runs sequential task passes to deepen coverage without duplicating prior work
+7. Runs qualitative review against skill-writer and Warden's acceptance bar
+8. Runs one bounded revision pass for concrete review failures
+9. Writes the returned generated file map only after final review and mechanical validation pass
+10. Stores provider/version/hash and validation metadata in build state
 
-The internal outline is Warden context only. It is not a runnable skill and it does not prescribe the final artifact layout.
+The internal outline is Warden context only. It is not a runnable skill and it does not prescribe the final artifact layout. It should help the planner identify topics, work lanes, source expectations, and non-overlap boundaries.
 
 ## Authoring Provider
 
@@ -58,35 +128,75 @@ The provider returns a file map:
 }
 ```
 
-Warden owns writing, cache invalidation, and validation. The provider owns authoring method, layout choice, depth gates, and source synthesis.
+Warden owns writing, cache invalidation, runtime constraints, and minimal mechanical validation. The provider owns authoring method, layout choice, source synthesis, and how to package depth into skill artifacts.
+
+## Planner Output
+
+The planner should produce an artifact-agnostic authoring plan. It should avoid file paths unless it is referring to an existing input file that was actually inspected.
+
+Expected planner concepts:
+
+- `authoringBrief`: goal, runtime use, audience, non-goals, and depth bar
+- `sourcePlan`: known sources, required source classes, and gaps
+- `topics`: semantic coverage requirements
+- `tasks`: sequential work items that deepen topics
+- `reviewRubric`: concrete qualitative checks for completion
+
+The planner should not propose reference filenames or imply that a topic maps to a file. Layout belongs to skill-writer.
+
+## Sequential Task Passes
+
+Task passes are how the builder gets depth without making one giant prompt do everything.
+
+Each task pass should:
+
+- inspect the current file map
+- use skill-writer again as the authoring authority
+- deepen only the assigned coverage
+- preserve good non-overlapping guidance from earlier tasks
+- avoid duplicating sibling-topic material
+- return only changed or new files, with full contents
+- explain where the current file map already satisfies the task if no changes are needed
+
+Completion is not "this topic name appears." Completion means the generated runtime guidance gives the later Warden run enough evidence, false-positive controls, and remediation direction to make useful findings.
 
 ## Runtime Contract
 
 Generated skills are normal Warden skills.
 
 - `warden ... --skill <name>` resolves the generated `SKILL.md`
-- `SKILL.md` must be a usable runtime router
-- `SKILL.md` must define the core review approach: task set, routing cues, and evidence requirements
-- every runtime reference must have a direct "when to read" route from `SKILL.md`
+- `SKILL.md` must provide enough runtime entry guidance for the chosen layout
+- local runtime dependencies referenced by generated artifacts must exist
 - findings still use normal changed-line anchoring and normal Warden reporting behavior
 
 There is no required filename, track split, parent/child runtime orchestration, or fixed reference tree.
 
 ## Validation
 
-Warden runs deterministic validation and an authoring-provider validation pass.
+Warden runs minimal deterministic validation and an authoring-provider review pass.
 
-Deterministic gates include:
+Deterministic checks should stay mechanical:
 
 - `SKILL.md` exists
 - frontmatter `name` matches the generated skill name
+- frontmatter has a non-empty description
 - generated files do not overwrite `warden.yaml` or `build-state.json`
-- runtime references are routed from `SKILL.md`
-- long references include navigation or are split
-- stale provenance language is flagged
-- generated-template boilerplate is flagged
+- local runtime files referenced by generated artifacts exist
 
-The provider validation pass can return a revised file map. Warden writes the revised files only after deterministic errors are resolved.
+Deterministic validation should not judge taste, depth, segmentation quality, source adequacy, or preferred layout.
+
+The authoring-provider review should judge quality:
+
+- did the artifact follow skill-writer?
+- does the skill meet the authoring brief?
+- are topics covered in enough depth?
+- are broad claims backed by enough source coverage?
+- are source gaps recorded instead of hidden?
+- is guidance over-broad, catalog-only, or shallow?
+- are false-positive controls and remediation patterns concrete?
+- is segmentation useful without being forced?
+
+The reviewer should return concrete feedback for one bounded revision pass. If final review still reports unresolved issues, Warden should fail the build and keep the previous artifact on disk.
 
 ## Caching
 

--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -11,6 +11,8 @@ Good generated skills usually have:
 - clear runtime trigger language and scope
 - topic coverage broken into useful semantic areas
 - concrete evidence requirements, not only API or issue catalogs
+- a finding proof model: changed-line evidence, boundary/invariant, cause,
+  affected operation, missing guard, impact, and fix
 - false-positive controls and safe counterexamples
 - remediation guidance that points toward an actual patch
 - source provenance or explicit gaps when the skill claims broad expertise
@@ -218,6 +220,7 @@ The authoring-provider review should judge quality:
 - did the artifact follow skill-writer?
 - does the skill meet the authoring brief?
 - are topics covered in enough depth?
+- can findings be proven from the runtime guidance, not just matched by pattern?
 - are broad claims backed by enough source coverage?
 - are source gaps recorded instead of hidden?
 - does `SOURCES.md`, if present, match the consulted-source ledger instead of

--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -10,7 +10,7 @@ Good generated skills usually have:
 
 - clear runtime trigger language and scope
 - topic coverage broken into useful semantic areas
-- concrete evidence requirements, not only API or vulnerability catalogs
+- concrete evidence requirements, not only API or issue catalogs
 - false-positive controls and safe counterexamples
 - remediation guidance that points toward an actual patch
 - source provenance or explicit gaps when the skill claims broad expertise
@@ -27,7 +27,7 @@ Warden provides:
 - the generated skill goal from `warden.yaml`
 - the internal outline as planning context
 - semantic topics that need coverage
-- sequential authoring tasks or work lanes
+- ordered authoring tasks or work lanes
 - runtime constraints for Warden skills
 - source-depth expectations and known source gaps
 - a qualitative review rubric
@@ -44,7 +44,7 @@ Warden does not prescribe:
 
 The wrapper prompt should say, in effect:
 
-> Use skill-writer as the authoring method. Warden provides the goal, coverage topics, sequential tasks, source expectations, runtime constraints, and qualitative rubric. Choose the simplest artifact layout that satisfies skill-writer and the rubric.
+> Use skill-writer as the authoring method. Warden provides the goal, coverage topics, ordered tasks, source expectations, runtime constraints, and qualitative rubric. Choose the simplest artifact layout that satisfies skill-writer and the rubric.
 
 ## Topics And Tasks
 
@@ -58,7 +58,7 @@ The planner should separate coverage from execution.
 - remediation expectations
 - source requirements or gaps
 
-`tasks` are sequential authoring work items. A task tells the writer what to deepen next:
+`tasks` are ordered authoring work items. A task tells the writer what to deepen:
 
 - objective
 - topic ids covered by the task
@@ -96,13 +96,12 @@ All other files are generated artifacts. The authoring provider decides whether 
 1. Reads or creates `.warden/skills/<name>/warden.yaml`
 2. Synthesizes internal Warden context for the build
 3. Resolves an authoring provider, defaulting to the vendored `src/internal-skills/skill-writer`
-4. Plans the authoring run: brief, topics, sequential tasks, source plan, and review rubric
+4. Plans the authoring run: brief, topics, ordered tasks, source plan, and review rubric
 5. Runs implementation through the authoring provider
-6. Runs sequential task passes to deepen coverage without duplicating prior work
-7. Runs qualitative review against skill-writer and Warden's acceptance bar
-8. Runs one bounded revision pass for concrete review failures
-9. Writes the returned generated file map only after final review and mechanical validation pass
-10. Stores provider/version/hash and validation metadata in build state
+6. Runs qualitative review against skill-writer and Warden's acceptance bar
+7. Runs one bounded revision pass for concrete review failures
+8. Writes the returned generated file map only after final review and mechanical validation pass
+9. Stores provider/version/hash and validation metadata in build state
 
 The internal outline is Warden context only. It is not a runnable skill and it does not prescribe the final artifact layout. It should help the planner identify topics, work lanes, source expectations, and non-overlap boundaries.
 
@@ -139,26 +138,27 @@ Expected planner concepts:
 - `authoringBrief`: goal, runtime use, audience, non-goals, and depth bar
 - `sourcePlan`: known sources, required source classes, and gaps
 - `topics`: semantic coverage requirements
-- `tasks`: sequential work items that deepen topics
+- `tasks`: ordered work items that deepen topics
 - `reviewRubric`: concrete qualitative checks for completion
 
 The planner should not propose reference filenames or imply that a topic maps to a file. Layout belongs to skill-writer.
 
-## Sequential Task Passes
+## Task Coverage
 
-Task passes are how the builder gets depth without making one giant prompt do everything.
+Tasks are how the builder communicates depth expectations without turning Warden into the artifact editor.
 
-Each task pass should:
+The implementation writer should:
 
-- inspect the current file map
-- use skill-writer again as the authoring authority
-- deepen only the assigned coverage
-- preserve good non-overlapping guidance from earlier tasks
-- avoid duplicating sibling-topic material
-- return only changed or new files, with full contents
-- explain where the current file map already satisfies the task if no changes are needed
+- use skill-writer as the authoring authority
+- treat tasks as a coverage checklist inside the single implementation pass
+- cover each task's required evidence, false-positive controls, and remediation expectations somewhere useful
+- preserve non-overlap boundaries between sibling topics
+- record missing source/context when a task cannot be covered honestly
+- return one complete file map for the chosen skill-writer layout
 
 Completion is not "this topic name appears." Completion means the generated runtime guidance gives the later Warden run enough evidence, false-positive controls, and remediation direction to make useful findings.
+
+Warden should not run automatic per-task artifact edit passes. The reviewer enforces task coverage qualitatively and gives one bounded revision pass when the generated skill is shallow, incomplete, or inconsistent with skill-writer.
 
 ## Runtime Contract
 

--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -16,7 +16,7 @@ Good generated skills usually have:
 - source provenance or explicit gaps when the skill claims broad expertise
 - segmentation that makes the skill usable without loading irrelevant material
 - reference-backed layouts where references behave as focused lookup leaves,
-  with navigation or further splitting when a leaf becomes hard to scan
+  with `## Contents` or further splitting when a leaf becomes hard to scan
 
 Many broad skills will naturally become reference-backed, often with roughly one focused reference per major topic and sometimes multiple references for a large topic. That is an expected outcome, not a required layout. Smaller skills may stay mostly inline. Some topics may share a reference. Some topics may not need a separate file at all. The authoring provider owns that choice.
 
@@ -26,6 +26,14 @@ and enough structure that the runtime agent can open only the material relevant
 to the current changed hunk. Oversized, mixed-purpose, or unnavigable references
 are quality failures even though the exact split remains the authoring
 provider's choice.
+
+Source provenance should be honest and compact. `externalSources` is the
+consulted-source ledger Warden stores in metadata. A generated `SOURCES.md` is
+optional; when present, its consulted-source claims should correspond to
+`externalSources`. Useful source classes that were not actually consulted belong
+in missing inputs or an explicitly labeled gap/candidate section, not in a
+"consulted sources" list. Broad "no gaps" claims are quality failures unless
+the consulted sources and missing-input list support them.
 
 ## Builder Contract
 
@@ -204,6 +212,8 @@ The authoring-provider review should judge quality:
 - are topics covered in enough depth?
 - are broad claims backed by enough source coverage?
 - are source gaps recorded instead of hidden?
+- does `SOURCES.md`, if present, match the consulted-source ledger instead of
+  claiming unconsulted generic source classes?
 - is guidance over-broad, catalog-only, or shallow?
 - are false-positive controls and remediation patterns concrete?
 - is segmentation useful without being forced?

--- a/specs/generated-skills.md
+++ b/specs/generated-skills.md
@@ -120,6 +120,14 @@ All other files are generated artifacts. The authoring provider decides whether 
 8. Stores artifact metadata only after the review loop and mechanical validation pass
 9. Stores provider/version/hash and validation metadata in build state
 
+`warden improve <name>` uses the same planner, writer, reviewer, revision loop,
+and mechanical validation. The difference is the authoring intent: the source
+packet includes the improvement brief and current generated artifacts, the
+writer edits the existing target directory as the draft, and Warden does not
+clear generated artifacts before the writer pass. The reviewer remains the
+quality gate for whether the improvement brief was addressed without regressing
+useful existing behavior.
+
 The internal outline is Warden context only. It is not a runnable skill and it does not prescribe the final artifact layout. It should help the planner identify topics, work lanes, source expectations, and non-overlap boundaries.
 
 ## Authoring Provider

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -116,6 +116,12 @@ describe('parseCliArgs', () => {
     expect(result.helpTarget).toBe('build');
   });
 
+  it('resolves improve help via --help', () => {
+    const result = parseCliArgs(['improve', 'security-review', '--help']);
+    expect(result.command).toBe('help');
+    expect(result.helpTarget).toBe('improve');
+  });
+
   it('resolves explicit help targets', () => {
     const result = parseCliArgs(['help', 'runs', 'show']);
     expect(result.command).toBe('help');
@@ -417,6 +423,31 @@ describe('parseCliArgs', () => {
     expect(result.command).toBe('build');
     expect(result.options.skill).toBe('./skills/security-review');
     expect(result.options.prompt).toBe('@prompts/security.md');
+  });
+
+  it('parses improve command with prompt options', () => {
+    const result = parseCliArgs([
+      'improve',
+      'security-review',
+      '-p',
+      'Preserve references and tighten provenance.',
+    ]);
+    expect(result.command).toBe('improve');
+    expect(result.options.skill).toBe('security-review');
+    expect(result.options.prompt).toBe('Preserve references and tighten provenance.');
+    expect(result.options.regenerate).toBe(true);
+  });
+
+  it('parses improve command with a path target', () => {
+    const result = parseCliArgs([
+      'improve',
+      './skills/security-review',
+      '--prompt',
+      '@feedback.md',
+    ]);
+    expect(result.command).toBe('improve');
+    expect(result.options.skill).toBe('./skills/security-review');
+    expect(result.options.prompt).toBe('@feedback.md');
   });
 
   it('parses runs list command', () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -73,7 +73,7 @@ export interface RunsOptions {
 }
 
 export interface ParsedArgs {
-  command: 'run' | 'help' | 'init' | 'add' | 'version' | 'setup-app' | 'sync' | 'runs' | 'build';
+  command: 'run' | 'help' | 'init' | 'add' | 'version' | 'setup-app' | 'sync' | 'runs' | 'build' | 'improve';
   options: CLIOptions;
   helpTarget?: HelpTarget;
   setupAppOptions?: SetupAppOptions;
@@ -125,6 +125,8 @@ function resolveHelpTarget(tokens: string[], values: ParsedOptionValues): HelpTa
       return 'sync';
     case 'build':
       return 'build';
+    case 'improve':
+      return 'improve';
     case 'setup-app':
       return 'setup-app';
     case 'runs':
@@ -382,6 +384,23 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
         model: typeof values.model === 'string' ? values.model : undefined,
         json: Boolean(values.json),
         regenerate: Boolean(values.regenerate),
+        prompt: typeof values.prompt === 'string' ? values.prompt : undefined,
+        remote: typeof values.remote === 'string' ? values.remote : undefined,
+        offline: Boolean(values.offline),
+      }),
+    };
+  }
+
+  if (command === 'improve') {
+    return {
+      command: 'improve',
+      options: parseCliOptions({
+        ...sharedOptions(values, verboseCount),
+        skill: typeof values.skill === 'string' ? values.skill : rest[0],
+        config: typeof values.config === 'string' ? values.config : undefined,
+        model: typeof values.model === 'string' ? values.model : undefined,
+        json: Boolean(values.json),
+        regenerate: true,
         prompt: typeof values.prompt === 'string' ? values.prompt : undefined,
         remote: typeof values.remote === 'string' ? values.remote : undefined,
         offline: Boolean(values.offline),

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -324,7 +324,7 @@ prompt: |-
     const output = stderrSpy.mock.calls
       .map((call) => call.map((part) => String(part)).join(' '))
       .join('\n');
-    expect(output).toContain('warden src/file.ts --skill security');
+    expect(output).toContain('warden src/file.ts --skill actual-security');
   });
 
   it('creates a generated skill at an explicit root path from the prompt', async () => {

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -189,6 +189,7 @@ describe('runBuild', () => {
       usage: { inputTokens: 200, outputTokens: 100, costUSD: 0.02 },
       externalSources: [],
       missingInputs: [],
+      warnings: [],
       numTurns: 2,
     });
   });
@@ -244,6 +245,7 @@ describe('runBuild', () => {
       usage: { inputTokens: 200, outputTokens: 100, costUSD: 0.02 },
       externalSources: [],
       missingInputs: [],
+      warnings: [],
       numTurns: 2,
     });
 
@@ -260,6 +262,33 @@ describe('runBuild', () => {
     expect(output).not.toContain('$0.01');
     expect(output).not.toContain('0 sources');
     expect(output).not.toContain('1 turn');
+  });
+
+  it('prints generated skill authoring warnings', async () => {
+    const reporter = createTestReporter();
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    buildGeneratedSkillMock.mockResolvedValueOnce({
+      kind: 'generated-skill',
+      source: 'generated',
+      name: 'security',
+      path: join(tempDir, '.warden', 'skills', 'security', 'SKILL.md'),
+      bytes: 2_048,
+      durationMs: 2_000,
+      usage: { inputTokens: 200, outputTokens: 100, costUSD: 0.02 },
+      externalSources: [],
+      missingInputs: [],
+      warnings: ['Authoring reviewer still requested changes after 3 revision passes; using the latest writer draft.'],
+      numTurns: 2,
+    });
+
+    const exitCode = await runBuild(createOptions(), reporter);
+
+    expect(exitCode).toBe(0);
+    const output = stderrSpy.mock.calls
+      .map((call) => call.map((part) => String(part)).join(' '))
+      .join('\n');
+    expect(output).toContain('Authoring reviewer still requested changes after 3 revision passes');
   });
 
   it('loads an existing generated skill from an explicit root path', async () => {

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -218,6 +218,8 @@ describe('runBuild', () => {
     expect(output).toContain('SKILL');
     expect(output.indexOf('TRACKS  2 tracks')).toBeGreaterThan(output.indexOf('OUTLINE'));
     expect(output.indexOf('TRACKS  2 tracks')).toBeLessThan(output.indexOf('SKILL'));
+    expect(output).toContain('Context   2 turns');
+    expect(output).not.toContain('0 sources');
   });
 
   it('does not report historical usage for cached outline loads', async () => {

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CLIOptions } from '../args.js';
 import { Reporter } from '../output/reporter.js';
 import { Verbosity } from '../output/verbosity.js';
-import { runBuild } from './build.js';
+import { runBuild, runImprove } from './build.js';
 import { getRepoRoot } from '../git.js';
 import {
   buildGeneratedSkillDefinition,
@@ -13,7 +13,12 @@ import {
   generatedSkillDefinitionRootExists,
   resolveGeneratedSkillTarget,
 } from '../../skill-builder/definition.js';
-import { buildSkillOutline, type SkillBuildOutline } from '../../skill-builder/outline.js';
+import {
+  buildSkillOutline,
+  collectSkillBuildSource,
+  collectSkillImproveSource,
+  type SkillBuildOutline,
+} from '../../skill-builder/outline.js';
 import { buildGeneratedSkill } from '../../skill-builder/skill.js';
 import { getRuntime } from '../../sdk/runtimes/index.js';
 
@@ -38,6 +43,7 @@ vi.mock('../../skill-builder/outline.js', () => ({
     }
   },
   collectSkillBuildSource: vi.fn(),
+  collectSkillImproveSource: vi.fn(),
   buildSkillOutline: vi.fn(),
 }));
 
@@ -139,6 +145,8 @@ describe('runBuild', () => {
   const generatedSkillDefinitionRootExistsMock = vi.mocked(generatedSkillDefinitionRootExists);
   const resolveGeneratedSkillTargetMock = vi.mocked(resolveGeneratedSkillTarget);
   const buildSkillOutlineMock = vi.mocked(buildSkillOutline);
+  const collectSkillBuildSourceMock = vi.mocked(collectSkillBuildSource);
+  const collectSkillImproveSourceMock = vi.mocked(collectSkillImproveSource);
   const buildGeneratedSkillMock = vi.mocked(buildGeneratedSkill);
   const getRuntimeMock = vi.mocked(getRuntime);
 
@@ -171,6 +179,17 @@ describe('runBuild', () => {
       rootDir: join(tempDir, '.warden', 'skills', 'security'),
     });
     getRuntimeMock.mockReturnValue({} as never);
+    collectSkillBuildSourceMock.mockReturnValue({
+      hash: 'build-source-hash',
+      files: [{ path: 'warden.yaml', content: 'version: 1\n' }],
+    });
+    collectSkillImproveSourceMock.mockReturnValue({
+      hash: 'improve-source-hash',
+      files: [
+        { path: 'warden.yaml', content: 'version: 1\n' },
+        { path: 'improvement-brief.md', content: 'Improve the skill.' },
+      ],
+    });
     buildSkillOutlineMock.mockResolvedValue({
       outline: createTestOutline(),
       source: 'generated',
@@ -388,5 +407,63 @@ prompt: |-
       prompt: 'Find security issues.',
       rootDir,
     });
+  });
+
+  it('improves an existing generated skill through the shared builder pipeline', async () => {
+    const reporter = createTestReporter();
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const exitCode = await runImprove(createOptions({
+      prompt: 'Tighten source provenance and reference navigation.',
+    }), reporter);
+
+    expect(exitCode).toBe(0);
+    expect(createGeneratedSkillDefinitionMock).not.toHaveBeenCalled();
+    expect(collectSkillImproveSourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'security' }),
+      'Tighten source provenance and reference navigation.',
+    );
+    expect(buildSkillOutlineMock).toHaveBeenCalledWith(expect.objectContaining({
+      regenerate: true,
+      source: {
+        hash: 'improve-source-hash',
+        files: [
+          { path: 'warden.yaml', content: 'version: 1\n' },
+          { path: 'improvement-brief.md', content: 'Improve the skill.' },
+        ],
+      },
+    }));
+    expect(buildGeneratedSkillMock).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'improve',
+      improvementPrompt: 'Tighten source provenance and reference navigation.',
+      regenerate: true,
+      source: {
+        hash: 'improve-source-hash',
+        files: [
+          { path: 'warden.yaml', content: 'version: 1\n' },
+          { path: 'improvement-brief.md', content: 'Improve the skill.' },
+        ],
+      },
+    }));
+    const output = stderrSpy.mock.calls
+      .map((call) => call.map((part) => String(part)).join(' '))
+      .join('\n');
+    expect(output).toContain('IMPROVE');
+    expect(output).toContain('Brief');
+  });
+
+  it('does not create missing generated skills from improve', async () => {
+    const reporter = createTestReporter();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    generatedSkillDefinitionRootExistsMock.mockReturnValueOnce(false);
+
+    const exitCode = await runImprove(createOptions({
+      prompt: 'Improve the skill.',
+    }), reporter);
+
+    expect(exitCode).toBe(1);
+    expect(createGeneratedSkillDefinitionMock).not.toHaveBeenCalled();
+    expect(buildSkillOutlineMock).not.toHaveBeenCalled();
+    expect(buildGeneratedSkillMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/build.test.ts
+++ b/src/cli/commands/build.test.ts
@@ -10,10 +10,10 @@ import { getRepoRoot } from '../git.js';
 import {
   buildGeneratedSkillDefinition,
   createGeneratedSkillDefinition,
-  getGeneratedSkillRoot,
-  generatedSkillDefinitionExists,
+  generatedSkillDefinitionRootExists,
+  resolveGeneratedSkillTarget,
 } from '../../skill-builder/definition.js';
-import { buildSkillOutline } from '../../skill-builder/outline.js';
+import { buildSkillOutline, type SkillBuildOutline } from '../../skill-builder/outline.js';
 import { buildGeneratedSkill } from '../../skill-builder/skill.js';
 import { getRuntime } from '../../sdk/runtimes/index.js';
 
@@ -23,10 +23,10 @@ vi.mock('../git.js', () => ({
 
 vi.mock('../../skill-builder/definition.js', () => ({
   GENERATED_SKILL_DEFINITION_FILE: 'warden.yaml',
-  generatedSkillDefinitionExists: vi.fn(),
+  generatedSkillDefinitionRootExists: vi.fn(),
   buildGeneratedSkillDefinition: vi.fn(),
   createGeneratedSkillDefinition: vi.fn(),
-  getGeneratedSkillRoot: vi.fn(),
+  resolveGeneratedSkillTarget: vi.fn(),
   inferGeneratedSkillDescription: vi.fn((name: string) => name),
 }));
 
@@ -80,12 +80,64 @@ function createOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
   };
 }
 
+function createTestOutline(): SkillBuildOutline {
+  return {
+    version: 1,
+    skill: 'security',
+    sourceHash: 'source-hash',
+    buildVersion: '1',
+    scopeProfile: {
+      kind: 'domain',
+      subject: 'Generic security review',
+      localContextUsed: false,
+      observedContext: ['Generic security review'],
+      unresolvedContext: [],
+    },
+    build: {
+      phases: [{ id: 'outline', status: 'generated' }],
+      externalSources: [],
+    },
+    tracks: [
+      {
+        id: 'auth-bypass',
+        title: 'Authentication bypasses',
+        goal: 'Find broken authentication checks.',
+        rationale: 'Authentication bugs are core security issues.',
+        sourceSignals: ['Auth endpoints'],
+        owns: ['Missing auth checks'],
+        excludes: ['Credential storage'],
+        relevanceSignals: ['Session checks'],
+        evidenceFocus: ['Changed auth conditions'],
+        checks: ['Trace auth preconditions'],
+        safeCounterpatterns: ['Explicit user verification'],
+        falsePositiveTraps: ['Defense-in-depth logging'],
+        researchHints: [],
+      },
+      {
+        id: 'injection',
+        title: 'Injection vulnerabilities',
+        goal: 'Find unsafe interpreter boundaries.',
+        rationale: 'Injection bugs are high impact.',
+        sourceSignals: ['SQL and shell sinks'],
+        owns: ['Command and SQL injection'],
+        excludes: ['Authorization failures'],
+        relevanceSignals: ['Dynamic string assembly'],
+        evidenceFocus: ['Changed sink usage'],
+        checks: ['Trace input into sinks'],
+        safeCounterpatterns: ['Parameterized queries'],
+        falsePositiveTraps: ['Static strings'],
+        researchHints: [],
+      },
+    ],
+  };
+}
+
 describe('runBuild', () => {
   const getRepoRootMock = vi.mocked(getRepoRoot);
-  const generatedSkillDefinitionExistsMock = vi.mocked(generatedSkillDefinitionExists);
   const buildGeneratedSkillDefinitionMock = vi.mocked(buildGeneratedSkillDefinition);
   const createGeneratedSkillDefinitionMock = vi.mocked(createGeneratedSkillDefinition);
-  const getGeneratedSkillRootMock = vi.mocked(getGeneratedSkillRoot);
+  const generatedSkillDefinitionRootExistsMock = vi.mocked(generatedSkillDefinitionRootExists);
+  const resolveGeneratedSkillTargetMock = vi.mocked(resolveGeneratedSkillTarget);
   const buildSkillOutlineMock = vi.mocked(buildSkillOutline);
   const buildGeneratedSkillMock = vi.mocked(buildGeneratedSkill);
   const getRuntimeMock = vi.mocked(getRuntime);
@@ -100,8 +152,12 @@ describe('runBuild', () => {
     process.chdir(tempDir);
 
     getRepoRootMock.mockReturnValue(tempDir);
-    getGeneratedSkillRootMock.mockReturnValue(join(tempDir, '.warden', 'skills', 'security'));
-    generatedSkillDefinitionExistsMock.mockReturnValue(true);
+    resolveGeneratedSkillTargetMock.mockReturnValue({
+      displayName: 'security',
+      isPath: false,
+      rootDir: join(tempDir, '.warden', 'skills', 'security'),
+    });
+    generatedSkillDefinitionRootExistsMock.mockReturnValue(true);
     buildGeneratedSkillDefinitionMock.mockReturnValue({
       name: 'security',
       description: 'Generated security skill',
@@ -116,55 +172,7 @@ describe('runBuild', () => {
     });
     getRuntimeMock.mockReturnValue({} as never);
     buildSkillOutlineMock.mockResolvedValue({
-      outline: {
-        version: 1,
-        skill: 'security',
-        sourceHash: 'source-hash',
-        buildVersion: '1',
-        scopeProfile: {
-          kind: 'domain',
-          subject: 'Generic security review',
-          localContextUsed: false,
-          observedContext: ['Generic security review'],
-          unresolvedContext: [],
-        },
-        build: {
-          phases: [{ id: 'outline', status: 'generated' }],
-          externalSources: [],
-        },
-        tracks: [
-          {
-            id: 'auth-bypass',
-            title: 'Authentication bypasses',
-            goal: 'Find broken authentication checks.',
-            rationale: 'Authentication bugs are core security issues.',
-            sourceSignals: ['Auth endpoints'],
-            owns: ['Missing auth checks'],
-            excludes: ['Credential storage'],
-            relevanceSignals: ['Session checks'],
-            evidenceFocus: ['Changed auth conditions'],
-            checks: ['Trace auth preconditions'],
-            safeCounterpatterns: ['Explicit user verification'],
-            falsePositiveTraps: ['Defense-in-depth logging'],
-            researchHints: [],
-          },
-          {
-            id: 'injection',
-            title: 'Injection vulnerabilities',
-            goal: 'Find unsafe interpreter boundaries.',
-            rationale: 'Injection bugs are high impact.',
-            sourceSignals: ['SQL and shell sinks'],
-            owns: ['Command and SQL injection'],
-            excludes: ['Authorization failures'],
-            relevanceSignals: ['Dynamic string assembly'],
-            evidenceFocus: ['Changed sink usage'],
-            checks: ['Trace input into sinks'],
-            safeCounterpatterns: ['Parameterized queries'],
-            falsePositiveTraps: ['Static strings'],
-            researchHints: [],
-          },
-        ],
-      },
+      outline: createTestOutline(),
       source: 'generated',
       statePath: join(tempDir, '.warden', 'skills', 'security', 'build-state.json'),
       durationMs: 1_000,
@@ -212,10 +220,55 @@ describe('runBuild', () => {
     expect(output.indexOf('TRACKS  2 tracks')).toBeLessThan(output.indexOf('SKILL'));
   });
 
+  it('does not report historical usage for cached outline loads', async () => {
+    const reporter = createTestReporter();
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    buildSkillOutlineMock.mockResolvedValueOnce({
+      outline: createTestOutline(),
+      source: 'cache',
+      statePath: join(tempDir, '.warden', 'skills', 'security', 'build-state.json'),
+      durationMs: 1_000,
+      usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      numTurns: 1,
+    });
+    buildGeneratedSkillMock.mockResolvedValueOnce({
+      kind: 'generated-skill',
+      source: 'cache',
+      name: 'security',
+      path: join(tempDir, '.warden', 'skills', 'security', 'SKILL.md'),
+      bytes: 2_048,
+      durationMs: 2_000,
+      usage: { inputTokens: 200, outputTokens: 100, costUSD: 0.02 },
+      externalSources: [],
+      missingInputs: [],
+      numTurns: 2,
+    });
+
+    const exitCode = await runBuild(createOptions(), reporter);
+
+    expect(exitCode).toBe(0);
+
+    const output = stderrSpy.mock.calls
+      .map((call) => call.map((part) => String(part)).join(' '))
+      .join('\n');
+
+    expect(output).toContain('Loaded outline with 2 tracks  [cached]');
+    expect(output).not.toContain('100 input');
+    expect(output).not.toContain('$0.01');
+    expect(output).not.toContain('0 sources');
+    expect(output).not.toContain('1 turn');
+  });
+
   it('loads an existing generated skill from an explicit root path', async () => {
     const reporter = createTestReporter();
     const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const rootDir = join(tempDir, 'skills', 'security');
+    resolveGeneratedSkillTargetMock.mockReturnValueOnce({
+      displayName: './skills/security',
+      isPath: true,
+      rootDir,
+    });
     mkdirSync(rootDir, { recursive: true });
     writeFileSync(join(rootDir, 'warden.yaml'), `version: 1
 kind: generated-skill
@@ -233,7 +286,7 @@ prompt: |-
     const exitCode = await runBuild(createOptions({ skill: './skills/security' }), reporter);
 
     expect(exitCode).toBe(0);
-    expect(generatedSkillDefinitionExistsMock).not.toHaveBeenCalled();
+    expect(generatedSkillDefinitionRootExistsMock).toHaveBeenCalledWith(rootDir);
     expect(buildGeneratedSkillDefinitionMock).toHaveBeenCalledWith(rootDir);
     expect(buildGeneratedSkillMock).toHaveBeenCalledWith(expect.objectContaining({
       rootDir,
@@ -244,10 +297,46 @@ prompt: |-
     expect(output).toContain('warden src/file.ts --skill ./skills/security');
   });
 
+  it('loads an existing generated skill by name from the resolved root', async () => {
+    const reporter = createTestReporter();
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const rootDir = join(tempDir, '.agents', 'skills', 'security');
+    resolveGeneratedSkillTargetMock.mockReturnValueOnce({
+      displayName: 'security',
+      isPath: false,
+      rootDir,
+    });
+    buildGeneratedSkillDefinitionMock.mockReturnValueOnce({
+      name: 'actual-security',
+      description: 'Generated security skill',
+      prompt: 'Find security issues.',
+      rootDir,
+    });
+
+    const exitCode = await runBuild(createOptions({ skill: 'security' }), reporter);
+
+    expect(exitCode).toBe(0);
+    expect(resolveGeneratedSkillTargetMock).toHaveBeenCalledWith(tempDir, 'security');
+    expect(buildGeneratedSkillDefinitionMock).toHaveBeenCalledWith(rootDir);
+    expect(buildGeneratedSkillMock).toHaveBeenCalledWith(expect.objectContaining({
+      rootDir,
+    }));
+    const output = stderrSpy.mock.calls
+      .map((call) => call.map((part) => String(part)).join(' '))
+      .join('\n');
+    expect(output).toContain('warden src/file.ts --skill security');
+  });
+
   it('creates a generated skill at an explicit root path from the prompt', async () => {
     const reporter = createTestReporter();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const rootDir = join(tempDir, 'skills', 'security');
+    resolveGeneratedSkillTargetMock.mockReturnValueOnce({
+      displayName: './skills/security',
+      isPath: true,
+      rootDir,
+    });
+    generatedSkillDefinitionRootExistsMock.mockReturnValueOnce(false);
     createGeneratedSkillDefinitionMock.mockReturnValueOnce({
       name: 'security',
       description: 'security',
@@ -261,7 +350,7 @@ prompt: |-
     }), reporter);
 
     expect(exitCode).toBe(0);
-    expect(generatedSkillDefinitionExistsMock).not.toHaveBeenCalled();
+    expect(generatedSkillDefinitionRootExistsMock).toHaveBeenCalledWith(rootDir);
     expect(createGeneratedSkillDefinitionMock).toHaveBeenCalledWith({
       repoRoot: tempDir,
       name: 'security',

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -20,6 +20,7 @@ import {
 } from '../../skill-builder/definition.js';
 import {
   collectSkillBuildSource,
+  collectSkillImproveSource,
   type SkillBuildOutline,
   SkillBuildOutlineError,
   buildSkillOutline,
@@ -126,12 +127,14 @@ function outlineStatusDetail(): string {
   return 'Build the internal outline and track split.';
 }
 
-function skillStatusMessage(skill: SkillDefinition): string {
-  return `Generate ${skill.name}`;
+function skillStatusMessageForMode(skill: SkillDefinition, mode: GeneratedSkillCommandMode): string {
+  return `${mode === 'improve' ? 'Improve' : 'Generate'} ${skill.name}`;
 }
 
-function skillStatusDetail(): string {
-  return 'Plan, write, and validate skill artifacts with the authoring provider.';
+function skillStatusDetail(mode: GeneratedSkillCommandMode): string {
+  return mode === 'improve'
+    ? 'Plan, revise, and review skill artifacts with the authoring provider.'
+    : 'Plan, write, and validate skill artifacts with the authoring provider.';
 }
 
 function readPromptFile(path: string): string {
@@ -160,15 +163,22 @@ function resolveSynthesisModel(
   );
 }
 
-async function resolvePrompt(options: CLIOptions, skillName: string): Promise<string | undefined> {
+type GeneratedSkillCommandMode = 'build' | 'improve';
+
+async function resolvePrompt(
+  options: CLIOptions,
+  skillName: string,
+  mode: GeneratedSkillCommandMode,
+): Promise<string | undefined> {
   if (options.prompt?.trim()) {
     return resolvePromptValue(options.prompt);
   }
   if (!process.stdin.isTTY) {
     return undefined;
   }
+  const label = mode === 'improve' ? 'IMPROVEMENT BRIEF' : 'SKILL PROMPT';
   return promptMultiline(
-    `${chalk.bold('SKILL PROMPT')}\n` +
+    `${chalk.bold(label)}\n` +
     `  Skill    ${chalk.cyan(skillName)}`,
     {
       hint: chalk.dim('  Finish with an empty line.'),
@@ -182,26 +192,44 @@ async function ensureSynthesizedSkill(args: {
   repoRoot: string;
   options: CLIOptions;
   reporter: Reporter;
+  mode: GeneratedSkillCommandMode;
 }): Promise<{
   skill: SkillDefinition;
   created: boolean;
   promptLength?: number;
+  improvementPrompt?: string;
   tryItSkillName: string;
 }> {
-  const { skillName, repoRoot, options, reporter } = args;
+  const { skillName, repoRoot, options, reporter, mode } = args;
   const target = resolveGeneratedSkillTarget(repoRoot, skillName);
   const definitionExists = generatedSkillDefinitionRootExists(target.rootDir);
 
   if (definitionExists) {
     const skill = buildGeneratedSkillDefinition(target.rootDir);
+    const improvementPrompt = mode === 'improve'
+      ? await resolvePrompt(options, target.displayName, mode)
+      : undefined;
+    if (mode === 'improve' && !improvementPrompt?.trim()) {
+      reporter.error(`Missing improvement brief for ${target.displayName}`);
+      reporter.tip('Pass --prompt/-p, prefix with @ to read from a file, or run interactively.');
+      throw new SkillBuildOutlineError(`Missing improvement brief for generated skill: ${skillName}`);
+    }
     return {
       skill,
       created: false,
+      improvementPrompt,
+      promptLength: improvementPrompt?.length,
       tryItSkillName: target.isPath ? target.displayName : skill.name,
     };
   }
 
-  const prompt = await resolvePrompt(options, skillName);
+  if (mode === 'improve') {
+    reporter.error(`Generated skill not found: ${target.displayName}`);
+    reporter.tip(`Run warden build ${target.displayName} --prompt <prompt> first`);
+    throw new SkillBuildOutlineError(`Missing generated skill for improvement: ${skillName}`);
+  }
+
+  const prompt = await resolvePrompt(options, skillName, mode);
   if (!prompt) {
     reporter.error(`Generated skill not found: ${target.displayName}`);
     const createTarget = target.isPath ? target.displayName : `.warden/skills/${skillName}`;
@@ -238,9 +266,10 @@ function isInterrupted(error: unknown, state: RunBuildState | undefined): boolea
   return error.name === 'AbortError' || /\b(aborted|cancelled|canceled|interrupted)\b/i.test(error.message);
 }
 
-export async function runBuild(
+async function runGeneratedSkillCommand(
   options: CLIOptions,
   reporter: Reporter,
+  mode: GeneratedSkillCommandMode,
   state?: RunBuildState,
 ): Promise<number> {
   let skillName = options.skill;
@@ -253,7 +282,7 @@ export async function runBuild(
       );
     }
     if (!skillName) {
-      reporter.error('Missing skill name. Usage: warden build <skill>');
+      reporter.error(`Missing skill name. Usage: warden ${mode} <skill>`);
       return 1;
     }
   }
@@ -277,21 +306,25 @@ export async function runBuild(
     return 1;
   }
 
-  const resolved = await ensureSynthesizedSkill({
-    skillName,
-    repoRoot,
-    options,
-    reporter,
-  });
-  const { skill } = resolved;
-
-  const runtimeName = config?.defaults?.runtime ?? 'claude';
-  const runtime = getRuntime(runtimeName);
-  const model = resolveSynthesisModel(config, options);
-  const repairModel = emptyToUndefined(config?.defaults?.auxiliary?.model);
-  const maxRetries = config?.defaults?.auxiliary?.maxRetries ?? config?.defaults?.auxiliaryMaxRetries;
-
   try {
+    const resolved = await ensureSynthesizedSkill({
+      skillName,
+      repoRoot,
+      options,
+      reporter,
+      mode,
+    });
+    const { skill } = resolved;
+    const source = mode === 'improve' && resolved.improvementPrompt
+      ? collectSkillImproveSource(skill, resolved.improvementPrompt)
+      : collectSkillBuildSource(skill);
+
+    const runtimeName = config?.defaults?.runtime ?? 'claude';
+    const runtime = getRuntime(runtimeName);
+    const model = resolveSynthesisModel(config, options);
+    const repairModel = emptyToUndefined(config?.defaults?.auxiliary?.model);
+    const maxRetries = config?.defaults?.auxiliary?.maxRetries ?? config?.defaults?.auxiliaryMaxRetries;
+
     if (!options.json) {
       renderHeader({
         reporter,
@@ -309,6 +342,10 @@ export async function runBuild(
         }
         renderDetail(reporter, 'Model', `${model ?? 'default'} [${runtimeName}]`);
         reporter.blank();
+      } else if (mode === 'improve') {
+        reporter.bold('IMPROVE');
+        renderDetail(reporter, 'Brief', `${resolved.promptLength?.toLocaleString() ?? 0} chars`);
+        reporter.blank();
       }
       reporter.bold('OUTLINE');
     }
@@ -324,9 +361,10 @@ export async function runBuild(
         apiKey: getAnthropicApiKey(),
         model,
         previousOutline: undefined,
-        regenerate: options.regenerate,
+        regenerate: options.regenerate || mode === 'improve',
         abortController: state?.abortController,
         repoPath: repoRoot,
+        source,
         repairModel,
         repairMaxRetries: maxRetries,
         onStatus: setDetail,
@@ -356,11 +394,11 @@ export async function runBuild(
     const artifact = await runWithLiveStatus({
       mode: reporter.mode,
       verbosity: reporter.verbosity,
-      message: skillStatusMessage(skill),
-      detail: skillStatusDetail(),
+      message: skillStatusMessageForMode(skill, mode),
+      detail: skillStatusDetail(mode),
       task: ({ setDetail }) => buildGeneratedSkill({
         outline: outlineResult.outline,
-        source: collectSkillBuildSource(skill),
+        source,
         rootDir: (() => {
           if (!skill.rootDir) {
             throw new GeneratedSkillBuildError(`Generated skill ${skill.name} is missing a root directory`);
@@ -369,12 +407,14 @@ export async function runBuild(
         })(),
         runtime,
         repoPath: repoRoot,
+        mode,
+        improvementPrompt: resolved.improvementPrompt,
         model,
         apiKey: getAnthropicApiKey(),
         repairModel,
         repairMaxRetries: maxRetries,
         abortController: state?.abortController,
-        regenerate: options.regenerate || outlineResult.source === 'generated',
+        regenerate: options.regenerate || outlineResult.source === 'generated' || mode === 'improve',
         onStatus: setDetail,
       }),
     });
@@ -432,4 +472,21 @@ export async function runBuild(
     }
     throw error;
   }
+}
+
+export async function runBuild(
+  options: CLIOptions,
+  reporter: Reporter,
+  state?: RunBuildState,
+): Promise<number> {
+  return runGeneratedSkillCommand(options, reporter, 'build', state);
+}
+
+/** Run the generated skill improvement command through the shared builder. */
+export async function runImprove(
+  options: CLIOptions,
+  reporter: Reporter,
+  state?: RunBuildState,
+): Promise<number> {
+  return runGeneratedSkillCommand(options, reporter, 'improve', state);
 }

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -394,6 +394,9 @@ export async function runBuild(
           turns: artifact.numTurns,
         }));
       }
+      for (const warning of artifact.warnings) {
+        reporter.warning(warning);
+      }
       renderTryIt(reporter, resolved.tryItSkillName);
     } else {
       process.stdout.write(`${JSON.stringify({
@@ -410,6 +413,7 @@ export async function runBuild(
           usage: artifact.usage,
           externalSources: artifact.externalSources,
           missingInputs: artifact.missingInputs,
+          warnings: artifact.warnings,
           responseModel: artifact.responseModel,
           numTurns: artifact.numTurns,
         },

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import chalk from 'chalk';
 import { emptyToUndefined, loadWardenConfigFile } from '../../config/loader.js';
 import type { SkillDefinition, WardenConfig } from '../../config/schema.js';
@@ -8,16 +8,15 @@ import type { CLIOptions } from '../args.js';
 import type { Reporter } from '../output/reporter.js';
 import { formatBytes, formatCost, formatDuration, formatTokens } from '../output/formatters.js';
 import { runWithLiveStatus } from '../output/live-status.js';
-import { getAnthropicApiKey, isPathLike } from '../../utils/index.js';
+import { getAnthropicApiKey } from '../../utils/index.js';
 import { promptLine, promptMultiline } from '../input.js';
 import { getRepoRoot } from '../git.js';
 import {
   buildGeneratedSkillDefinition,
   createGeneratedSkillDefinition,
-  GENERATED_SKILL_DEFINITION_FILE,
-  getGeneratedSkillRoot,
   inferGeneratedSkillDescription,
-  generatedSkillDefinitionExists,
+  generatedSkillDefinitionRootExists,
+  resolveGeneratedSkillTarget,
 } from '../../skill-builder/definition.js';
 import {
   collectSkillBuildSource,
@@ -145,27 +144,6 @@ function resolvePromptValue(prompt: string): string {
   return prompt.trim();
 }
 
-function resolveGeneratedSkillTarget(target: string, repoRoot: string): {
-  displayName: string;
-  isPath: boolean;
-  rootDir: string;
-} {
-  if (isPathLike(target)) {
-    const rootDir = resolve(repoRoot, target);
-    return {
-      displayName: target,
-      isPath: true,
-      rootDir,
-    };
-  }
-
-  return {
-    displayName: target,
-    isPath: false,
-    rootDir: getGeneratedSkillRoot(repoRoot, target),
-  };
-}
-
 function resolveSynthesisModel(
   config: WardenConfig | undefined,
   options: CLIOptions,
@@ -202,10 +180,8 @@ async function ensureSynthesizedSkill(args: {
   reporter: Reporter;
 }): Promise<{ skill: SkillDefinition; created: boolean; promptLength?: number }> {
   const { skillName, repoRoot, options, reporter } = args;
-  const target = resolveGeneratedSkillTarget(skillName, repoRoot);
-  const definitionExists = target.isPath
-    ? existsSync(join(target.rootDir, GENERATED_SKILL_DEFINITION_FILE))
-    : generatedSkillDefinitionExists(repoRoot, skillName);
+  const target = resolveGeneratedSkillTarget(repoRoot, skillName);
+  const definitionExists = generatedSkillDefinitionRootExists(target.rootDir);
 
   if (definitionExists) {
     return { skill: buildGeneratedSkillDefinition(target.rootDir), created: false };
@@ -338,12 +314,14 @@ export async function runBuild(
       }),
     });
 
-    const outlineStats = formatStats({
-      durationMs: outlineResult.source === 'generated' ? outlineResult.durationMs : undefined,
-      usage: outlineResult.usage,
-      sources: outlineResult.outline.build.externalSources?.length ?? 0,
-      turns: outlineResult.numTurns,
-    });
+    const outlineStats = outlineResult.source === 'cache'
+      ? chalk.dim('[cached]')
+      : formatStats({
+        durationMs: outlineResult.durationMs,
+        usage: outlineResult.usage,
+        sources: outlineResult.outline.build.externalSources?.length ?? 0,
+        turns: outlineResult.numTurns,
+      });
 
     if (!options.json) {
       reporter.success(
@@ -397,7 +375,7 @@ export async function runBuild(
           turns: artifact.numTurns,
         }));
       }
-      renderTryIt(reporter, isPathLike(skillName) ? skillName : skill.name);
+      renderTryIt(reporter, skillName);
     } else {
       process.stdout.write(`${JSON.stringify({
         skill: {

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -178,13 +178,23 @@ async function ensureSynthesizedSkill(args: {
   repoRoot: string;
   options: CLIOptions;
   reporter: Reporter;
-}): Promise<{ skill: SkillDefinition; created: boolean; promptLength?: number }> {
+}): Promise<{
+  skill: SkillDefinition;
+  created: boolean;
+  promptLength?: number;
+  tryItSkillName: string;
+}> {
   const { skillName, repoRoot, options, reporter } = args;
   const target = resolveGeneratedSkillTarget(repoRoot, skillName);
   const definitionExists = generatedSkillDefinitionRootExists(target.rootDir);
 
   if (definitionExists) {
-    return { skill: buildGeneratedSkillDefinition(target.rootDir), created: false };
+    const skill = buildGeneratedSkillDefinition(target.rootDir);
+    return {
+      skill,
+      created: false,
+      tryItSkillName: target.isPath ? target.displayName : skill.name,
+    };
   }
 
   const prompt = await resolvePrompt(options, skillName);
@@ -201,7 +211,12 @@ async function ensureSynthesizedSkill(args: {
     prompt,
     rootDir: target.rootDir,
   });
-  return { skill, created: true, promptLength: prompt.length };
+  return {
+    skill,
+    created: true,
+    promptLength: prompt.length,
+    tryItSkillName: target.isPath ? target.displayName : skill.name,
+  };
 }
 
 interface RunBuildState {
@@ -375,7 +390,7 @@ export async function runBuild(
           turns: artifact.numTurns,
         }));
       }
-      renderTryIt(reporter, skillName);
+      renderTryIt(reporter, resolved.tryItSkillName);
     } else {
       process.stdout.write(`${JSON.stringify({
         skill: {

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -70,7 +70,9 @@ function formatUsageCostDetail(usage: UsageStats | undefined): string | undefine
 
 function formatContextDetail(args: { sources?: number; turns?: number }): string | undefined {
   const parts = [
-    args.sources === undefined ? undefined : `${args.sources} ${args.sources === 1 ? 'source' : 'sources'}`,
+    args.sources === undefined || args.sources === 0
+      ? undefined
+      : `${args.sources} external ${args.sources === 1 ? 'source' : 'sources'}`,
     args.turns === undefined ? undefined : `${args.turns} ${args.turns === 1 ? 'turn' : 'turns'}`,
   ].filter((part): part is string => Boolean(part));
   return parts.length > 0 ? parts.join(' / ') : undefined;
@@ -87,7 +89,9 @@ function formatStats(args: {
     args.bytes === undefined ? undefined : formatBytes(args.bytes),
     args.durationMs === undefined ? undefined : formatDuration(args.durationMs),
     formatUsageCostDetail(args.usage),
-    args.sources === undefined ? undefined : `${args.sources} ${args.sources === 1 ? 'source' : 'sources'}`,
+    args.sources === undefined || args.sources === 0
+      ? undefined
+      : `${args.sources} external ${args.sources === 1 ? 'source' : 'sources'}`,
     args.turns === undefined ? undefined : `${args.turns} ${args.turns === 1 ? 'turn' : 'turns'}`,
   ].filter((part): part is string => Boolean(part));
   return parts.length > 0 ? chalk.dim(`[${parts.join(' · ')}]`) : '';

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -20,6 +20,15 @@ describe('renderHelp', () => {
     expect(output).not.toContain('--org <name>');
   });
 
+  it('renders improve help', () => {
+    const output = renderHelp('improve');
+
+    expect(output).toContain('warden improve <skill> [options]');
+    expect(output).toContain('-p, --prompt <value>');
+    expect(output).not.toContain('--regenerate');
+    expect(output).not.toContain('--org <name>');
+  });
+
   it('renders shared output flags on non-run commands that accept them', () => {
     const output = renderHelp('init');
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -40,6 +40,7 @@ export type HelpTarget =
   | 'add'
   | 'sync'
   | 'build'
+  | 'improve'
   | 'setup-app'
   | 'runs'
   | 'runs:list'
@@ -177,7 +178,7 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
   },
   prompt: {
     label: '-p, --prompt <value>',
-    description: 'Create a missing generated skill from prompt text',
+    description: 'Generated skill prompt or improvement brief',
     continuation: 'Prefix with @ to read the prompt from a file',
   },
   org: {
@@ -315,6 +316,29 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
       'warden build security -p @prompt.md',
       'warden build ./skills/security -p @prompt.md',
       'warden build sentry-security --json',
+    ],
+  },
+  improve: {
+    summary: 'Improve a repo-local generated skill',
+    description: 'Revise an existing generated skill from an improvement brief using the generated-skill reviewer loop.',
+    usage: [
+      'warden improve <skill> [options]',
+    ],
+    arguments: [
+      { label: 'skill', description: 'Generated skill name or skill root path' },
+    ],
+    options: [
+      'cwd',
+      'config',
+      'model',
+      'json',
+      'prompt',
+      ...SHARED_COMMAND_OPTIONS,
+    ],
+    examples: [
+      'warden improve security -p "Deepen source provenance and reference routing"',
+      'warden improve security -p @feedback.md',
+      'warden improve ./skills/security -p @feedback.md',
     ],
   },
   'setup-app': {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -83,8 +83,8 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
     description: 'Show version number',
   },
   skill: {
-    label: '--skill <name>',
-    description: 'Run only this skill',
+    label: '--skill <name|path>',
+    description: 'Run only this skill by name or path',
   },
   config: {
     label: '--config <path>',
@@ -294,7 +294,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
   },
   build: {
     summary: 'Build a repo-local generated skill',
-    description: 'Create or refresh one generated skill by name under .warden/skills, or at an explicit skill root path.',
+    description: 'Create or refresh one generated skill. A name resolves through .warden/skills, .agents/skills, then .claude/skills; use a path for other roots.',
     usage: [
       'warden build <skill> [options]',
     ],

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
+import type { CLIOptions } from './args.js';
 import {
+  createSkillTasks,
   mergeSkillRunnerOptions,
   processTaskResults,
   resolveInvocationCwd,
@@ -7,9 +12,19 @@ import {
   resolveCliDefaultSynthesisModel,
   resolveCliDefaultModel,
   resolveCliLogModel,
+  type RunSkillSpec,
 } from './main.js';
-import { MODEL_DEFAULT_SENTINEL } from './output/index.js';
+import { MODEL_DEFAULT_SENTINEL, Reporter, Verbosity } from './output/index.js';
 import type { SkillReport } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
 
 function makeReport(overrides: Partial<SkillReport> = {}): SkillReport {
   return {
@@ -19,6 +34,62 @@ function makeReport(overrides: Partial<SkillReport> = {}): SkillReport {
     ...overrides,
   };
 }
+
+function createTestReporter(): Reporter {
+  return new Reporter({ isTTY: false, supportsColor: false, columns: 80 }, Verbosity.Quiet);
+}
+
+function createCliOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
+  return {
+    json: false,
+    help: false,
+    quiet: true,
+    verbose: 0,
+    debug: false,
+    log: false,
+    fix: false,
+    force: false,
+    list: false,
+    git: false,
+    staged: false,
+    offline: false,
+    failFast: false,
+    regenerate: false,
+    ...overrides,
+  };
+}
+
+describe('createSkillTasks', () => {
+  it('reports missing generated artifacts for explicit generated skill paths', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-main-'));
+    tempDirs.push(repoRoot);
+    const rootDir = join(repoRoot, 'skills', 'security');
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: |-
+  Find security issues.
+`, 'utf-8');
+
+    const spec: RunSkillSpec = {
+      name: './skills/security',
+      skill: './skills/security',
+      context: {} as RunSkillSpec['context'],
+      runnerOptions: {},
+    };
+
+    await expect(createSkillTasks({
+      specs: [spec],
+      repoPath: repoRoot,
+      options: createCliOptions(),
+      parallel: 1,
+      reporter: createTestReporter(),
+    })).rejects.toThrow(
+      'Generated skill ./skills/security is missing generated artifacts. Run "warden build ./skills/security" first.',
+    );
+  });
+});
 
 describe('mergeSkillRunnerOptions', () => {
   it('preserves global defaults when per-skill options are undefined', () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -51,7 +51,7 @@ import { runAdd } from './commands/add.js';
 import { runSetupApp } from './commands/setup-app.js';
 import { runSync } from './commands/sync.js';
 import { runRuns } from './commands/runs.js';
-import { runBuild } from './commands/build.js';
+import { runBuild, runImprove } from './commands/build.js';
 import {
   generatedSkillDefinitionRootExists,
   resolveGeneratedSkillTarget,
@@ -1511,6 +1511,8 @@ export async function main(): Promise<void> {
           return runRuns(runsOptions, options, reporter);
         case 'build':
           return runBuild(options, reporter, { abortController, interrupted });
+        case 'improve':
+          return runImprove(options, reporter, { abortController, interrupted });
         default:
           return runCommand(options, reporter);
       }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -52,7 +52,10 @@ import { runSetupApp } from './commands/setup-app.js';
 import { runSync } from './commands/sync.js';
 import { runRuns } from './commands/runs.js';
 import { runBuild } from './commands/build.js';
-import { generatedSkillDefinitionExists } from '../skill-builder/definition.js';
+import {
+  generatedSkillDefinitionRootExists,
+  resolveGeneratedSkillTarget,
+} from '../skill-builder/definition.js';
 
 /**
  * Global abort controller for graceful shutdown on SIGINT.
@@ -565,7 +568,7 @@ async function createDirectSkillTask(args: {
     if (
       error instanceof SkillLoaderError &&
       repoPath &&
-      generatedSkillDefinitionExists(repoPath, spec.skill)
+      generatedSkillDefinitionRootExists(resolveGeneratedSkillTarget(repoPath, spec.skill).rootDir)
     ) {
       throw new Error(
         `Generated skill ${spec.skill} is missing generated artifacts. Run "warden build ${spec.skill}" first.`,

--- a/src/internal-skills/skill-writer/SOURCES.md
+++ b/src/internal-skills/skill-writer/SOURCES.md
@@ -41,10 +41,10 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 8. Hooks are deterministic enforcement and need narrow scope plus security notes because command hooks run with full user permissions.
 9. Multi-agent guidance should distinguish manager/orchestrator, handoff, and isolated subagent execution instead of collapsing them into one pattern.
 10. Reasoning-model guidance is a design option, not a universal default: planner/doer splits are useful when complexity warrants them.
-11. Validation should check architectural choices qualitatively, not only file structure and prose depth.
+11. Authoring review should check architectural choices qualitatively; the quick validator remains mechanical.
 12. Reference files remain split by lookup need rather than topic buckets, even as the set of supported shapes expands.
 13. Subfolders inside `references/` are acceptable when they create clearer lookup leaves, but every bundled reference should still be directly discoverable from `SKILL.md`.
-14. The validator should enforce durable structural guarantees and required fields, but should not hardcode provider-specific optional frontmatter keys.
+14. The validator should enforce durable SKILL.md frontmatter/YAML identity guarantees, but should not hardcode provider-specific optional frontmatter keys or markdown-content opinions.
 15. `skill-writer` should default to dense structures such as tables, checklists, templates, and I/O examples, and should cut explanatory prose unless it prevents a concrete mistake.
 16. `SKILL.md` should stay a thin router; repeated policy belongs in routed references rather than always-loaded step prose.
 17. Evaluation is conditional and should not be part of the default authoring path unless the user asks for it or the change is genuinely risky.
@@ -71,9 +71,8 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 
 ## Open gaps
 
-1. The validator still only partially checks advanced-shape contracts; deeper automated checks may be worth adding.
-2. This repository still has few real shipped examples using `hooks`, `context: fork`, `when_to_use`, `arguments`, `paths`, or `effort`.
-3. Public repo docs outside `skill-writer` may need follow-up updates to fully reflect the current Claude-specific skill fields.
+1. This repository still has few real shipped examples using `hooks`, `context: fork`, `when_to_use`, `arguments`, `paths`, or `effort`.
+2. Public repo docs outside `skill-writer` may need follow-up updates to fully reflect the current Claude-specific skill fields.
 
 ## Changelog
 
@@ -92,3 +91,4 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 - 2026-05-01: Removed the validator's hardcoded optional frontmatter allowlist so provider-specific field drift does not create noisy false warnings.
 - 2026-05-01: Reduced prose-heavy guidance in `skill-writer`, rewrote the main runtime refs into denser tables/checklists, and made compact runtime guidance an explicit contract.
 - 2026-05-01: Thinned `SKILL.md` back toward a true router, removed duplicated execution-shape detail from `mode-selection.md`, and made evaluation conditional instead of a default workflow path.
+- 2026-05-05: Reduced `quick_validate.py` to mechanical SKILL.md frontmatter/YAML and identity checks; markdown content quality now belongs to authoring review.

--- a/src/internal-skills/skill-writer/SPEC.md
+++ b/src/internal-skills/skill-writer/SPEC.md
@@ -117,8 +117,8 @@ Data that must not be stored:
 ## Evaluation
 
 - Lightweight validation:
-  - Run `uv run <skill-writer-root>/scripts/quick_validate.py <skill-writer-root> --skill-class skill-authoring --strict-depth`.
-  - Inspect changed references for focused scope, direct discoverability, and absence of host-specific paths.
+  - Run `uv run <skill-writer-root>/scripts/quick_validate.py <skill-writer-root> --skill-class skill-authoring --strict-depth` as a frontmatter/YAML smoke check.
+  - Inspect changed references qualitatively for focused scope, direct discoverability, and absence of host-specific paths.
   - Verify that the selected execution shape is explicit and that advanced mechanics, if any, are justified.
 - Deeper evaluation:
   - Use `references/evaluation-path.md` and `EVAL.md` only when the user requests it, the change is high-risk, or the architectural choice needs verification.
@@ -128,17 +128,16 @@ Data that must not be stored:
   - Keep durable holdout examples in `references/evidence/holdout-set.md` when repeated regressions appear.
   - Do not tune directly against holdout examples until they are intentionally moved to the working set.
 - Acceptance gates:
-  - Validator passes with no errors.
+  - Validator passes with no errors for SKILL.md frontmatter/YAML and identity fields.
   - New or changed workflow rules are represented in the correct artifact.
   - `SOURCES.md` records source-backed decisions and any remaining gaps.
   - `SPEC.md` is updated when intent, scope, evidence model, evaluation, or maintenance expectations change.
 
 ## Known Limitations
 
-- The validator checks structure and selected depth gates; it cannot prove that a generated skill is semantically complete.
-- The validator does not yet deeply verify every advanced-shape contract.
+- The validator intentionally checks only SKILL.md frontmatter/YAML and identity fields; markdown content quality belongs to authoring review.
+- The validator does not verify advanced-shape contracts, reference completeness, source depth, prose density, or `SPEC.md` heading templates.
 - The validator intentionally does not hardcode or exhaustively validate provider-specific optional frontmatter fields.
-- The validator does not yet strongly enforce prose density; that still relies mostly on authoring guidance and review.
 - Deeper evals are opt-in unless risk or user request justifies the extra cost.
 - Source discovery can still miss private operational knowledge if it is not present in local files, accessible issue/PR history, or supplied context.
 - Provider-specific skill extensions may drift; `skill-writer` treats them as compatibility guidance unless a skill is intentionally provider-specific.

--- a/src/internal-skills/skill-writer/scripts/quick_validate.py
+++ b/src/internal-skills/skill-writer/scripts/quick_validate.py
@@ -5,8 +5,9 @@
 """
 Quick validation script for Agent Skills.
 
-Validates SKILL.md frontmatter, naming conventions, directory structure, and
-optional strict depth gates for integration/documentation skills.
+Validates only mechanical SKILL.md frontmatter and identity requirements.
+Qualitative content, reference depth, routing, and prose structure belong to
+human/agent review, not this script.
 
 Usage:
     uv run quick_validate.py <skill_directory> [--skill-class <class>] [--strict-depth]
@@ -24,8 +25,6 @@ import yaml
 
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
-MAX_SKILL_LINES = 500
-REFERENCE_LINE_WARNING = 150
 
 SKILL_CLASSES = {
     "auto",
@@ -36,300 +35,15 @@ SKILL_CLASSES = {
     "generic",
 }
 
-INTEGRATION_REQUIRED_DIMENSIONS = [
-    ("API surface", ("api surface", "api contract", "public api")),
-    ("Config/runtime options", ("config", "runtime option", "configuration", "option")),
-    ("Common use cases", ("common use", "usage pattern", "normal usage", "use case")),
-    ("Known issues/workarounds", ("known issue", "failure mode", "troubleshooting", "workaround")),
-    ("Version/migration variance", ("version", "migration", "deprecation", "variance")),
-]
-
-SPEC_REQUIRED_HEADINGS = (
-    "Intent",
-    "Scope",
-    "Users And Trigger Context",
-    "Runtime Contract",
-    "Source And Evidence Model",
-    "Reference Architecture",
-    "Evaluation",
-    "Known Limitations",
-    "Maintenance Notes",
-)
-
-PARTIAL_STATUS_TOKENS = ("partial", "missing", "incomplete", "todo", "unknown")
-ACTION_TOKENS = (
-    "add",
-    "collect",
-    "document",
-    "retrieve",
-    "validate",
-    "test",
-    "confirm",
-    "expand",
-    "review",
-    "map",
-)
-
-SKILL_WRITER_ROUTING_EXCEPTIONS = {
-    "references/evidence/findings-log.md",
-    "references/evidence/holdout-set.md",
-    "references/evidence/working-set.md",
-}
-
-MACHINE_SPECIFIC_PATH_PATTERNS = (
-    re.compile(r"/Users/[^/\s`\"'<>)](?:[^\s`\"'<>)]*)"),
-    re.compile(r"/home/[^/\s`\"'<>)](?:[^\s`\"'<>)]*)"),
-    re.compile(r"/var/folders/[^/\s`\"'<>)](?:[^\s`\"'<>)]*)"),
-    re.compile(r"/private/var/folders/[^/\s`\"'<>)](?:[^\s`\"'<>)]*)"),
-    re.compile(r"[A-Za-z]:\\Users\\[^\s`\"'<>)](?:[^\s`\"'<>)]*)"),
-)
-
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Validate agent skill structure and optional depth gates.",
+        description="Validate agent skill frontmatter and identity fields.",
     )
     parser.add_argument("skill_directory")
     parser.add_argument("--skill-class", choices=sorted(SKILL_CLASSES), default="auto")
     parser.add_argument("--strict-depth", action="store_true")
     return parser.parse_args(argv)
-
-
-def infer_skill_class(description: str, content: str) -> str:
-    text = f"{description}\n{content}".lower()
-
-    if has_any_term(text, ("create a skill", "write a skill", "skill-writer", "maintain skill docs")):
-        return "skill-authoring"
-    if has_any_term(text, ("integrate", "sdk", "library", "api surface", "public api", "api contract")) and has_any_term(
-        text, ("use when", "downstream", "consumer", "abstraction")
-    ):
-        return "integration-documentation"
-    if has_any_term(text, ("vulnerability", "owasp", "injection", "xss", "idor")) or (
-        has_any_term(text, ("security",)) and has_any_term(text, ("review", "audit", "scan"))
-    ):
-        return "security-review"
-    if has_any_term(text, ("workflow", "ci", "branch", "checklist", "runbook", "triage")):
-        return "workflow-process"
-    return "generic"
-
-
-def has_any_term(text: str, terms: tuple[str, ...]) -> bool:
-    for term in terms:
-        if " " in term:
-            if term in text:
-                return True
-            continue
-        if re.search(rf"\b{re.escape(term)}\b", text):
-            return True
-    return False
-
-
-def get_section_lines(markdown: str, heading_name: str) -> list[str]:
-    lines = markdown.splitlines()
-    heading_index = None
-    needle = heading_name.lower()
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("## ") and needle in stripped.lower():
-            heading_index = i
-            break
-
-    if heading_index is None:
-        return []
-
-    out: list[str] = []
-    for line in lines[heading_index + 1 :]:
-        if line.strip().startswith("## "):
-            break
-        out.append(line)
-    return out
-
-
-def parse_coverage_rows(sources_markdown: str) -> list[tuple[str, str]]:
-    rows: list[tuple[str, str]] = []
-    section_lines = get_section_lines(sources_markdown, "coverage matrix")
-    for line in section_lines:
-        stripped = line.strip()
-        if not stripped.startswith("|"):
-            continue
-        if re.match(r"^\|\s*-+\s*\|", stripped):
-            continue
-        cols = [c.strip() for c in stripped.strip("|").split("|")]
-        if len(cols) < 2:
-            continue
-        # Skip header row.
-        if cols[0].lower() in {"dimension", "coverage status"}:
-            continue
-        rows.append((cols[0].lower(), cols[1].lower()))
-    return rows
-
-
-def parse_open_gap_lines(sources_markdown: str) -> list[str]:
-    raw_lines = get_section_lines(sources_markdown, "open gaps")
-    return [ln.strip() for ln in raw_lines if ln.strip()]
-
-
-def find_machine_specific_paths(text: str) -> list[str]:
-    matches: list[str] = []
-    for pattern in MACHINE_SPECIFIC_PATH_PATTERNS:
-        for match in pattern.finditer(text):
-            matched = match.group(0)
-            if matched not in matches:
-                matches.append(matched)
-    return matches
-
-
-def validate_portable_paths(
-    skill_path: Path,
-    skill_content: str,
-    strict_depth: bool,
-    errors: list[str],
-    warnings: list[str],
-) -> None:
-    severity = errors if strict_depth else warnings
-    portability_hits: list[str] = []
-
-    skill_hits = find_machine_specific_paths(skill_content)
-    if skill_hits:
-        portability_hits.append(f"SKILL.md: {', '.join(skill_hits[:3])}")
-
-    refs_dir = skill_path / "references"
-    if refs_dir.exists():
-        for ref_path in sorted(refs_dir.rglob("*.md")):
-            ref_hits = find_machine_specific_paths(ref_path.read_text())
-            if ref_hits:
-                portability_hits.append(
-                    f"{ref_path.relative_to(skill_path)}: {', '.join(ref_hits[:3])}"
-                )
-
-    if portability_hits:
-        severity.append(
-            "Machine-specific absolute filesystem paths detected. Use portable placeholders like "
-            "`<repo-root>/...` or `<skill-dir>/...`. Offenders: " + "; ".join(portability_hits)
-        )
-
-
-def validate_reference_lengths(skill_path: Path, warnings: list[str]) -> None:
-    refs_dir = skill_path / "references"
-    if not refs_dir.exists():
-        return
-
-    long_refs: list[str] = []
-    for ref_path in sorted(refs_dir.rglob("*.md")):
-        line_count = len(ref_path.read_text().splitlines())
-        if line_count > REFERENCE_LINE_WARNING:
-            long_refs.append(f"{ref_path.relative_to(skill_path)} ({line_count} lines)")
-
-    if long_refs:
-        warnings.append(
-            "Long reference file(s) detected. Consider splitting by lookup need or adding navigation: "
-            + "; ".join(long_refs)
-        )
-
-
-def validate_skill_writer_reference_routing(
-    skill_path: Path,
-    skill_content: str,
-    strict_depth: bool,
-    errors: list[str],
-    warnings: list[str],
-) -> None:
-    if skill_path.name != "skill-writer":
-        return
-
-    refs_dir = skill_path / "references"
-    if not refs_dir.exists():
-        return
-
-    all_refs: list[str] = []
-    for ref_path in sorted(refs_dir.rglob("*.md")):
-        rel_path = ref_path.relative_to(skill_path).as_posix()
-        if rel_path in SKILL_WRITER_ROUTING_EXCEPTIONS:
-            continue
-        all_refs.append(rel_path)
-
-    missing = [rel_path for rel_path in all_refs if rel_path not in skill_content]
-    if not missing:
-        return
-
-    severity = errors if strict_depth else warnings
-    severity.append(
-        "skill-writer references should be directly discoverable from SKILL.md. "
-        "Missing routing entries for: " + ", ".join(missing)
-    )
-
-
-def validate_spec_md(
-    skill_path: Path,
-    strict_depth: bool,
-    errors: list[str],
-    warnings: list[str],
-) -> None:
-    spec_md = skill_path / "SPEC.md"
-    if not spec_md.exists():
-        return
-
-    severity = errors if strict_depth else warnings
-    spec_content = spec_md.read_text()
-    missing_headings = [
-        heading
-        for heading in SPEC_REQUIRED_HEADINGS
-        if not re.search(rf"^##\s+{re.escape(heading)}\s*$", spec_content, re.MULTILINE)
-    ]
-    if missing_headings:
-        severity.append("SPEC.md is missing required heading(s): " + ", ".join(missing_headings))
-
-    spec_hits = find_machine_specific_paths(spec_content)
-    if spec_hits:
-        severity.append(
-            "SPEC.md contains machine-specific absolute filesystem paths. "
-            "Use portable placeholders like `<repo-root>/...` or `<skill-dir>/...`. "
-            "Offenders: " + ", ".join(spec_hits[:3])
-        )
-
-
-def validate_integration_depth(
-    skill_path: Path,
-    strict_depth: bool,
-    errors: list[str],
-    warnings: list[str],
-) -> None:
-    sources_md = skill_path / "SOURCES.md"
-    severity = errors if strict_depth else warnings
-
-    if not sources_md.exists():
-        severity.append(
-            "Integration/documentation skill should include SOURCES.md with a coverage matrix and open gaps section"
-        )
-        return
-
-    sources_content = sources_md.read_text()
-    coverage_rows = parse_coverage_rows(sources_content)
-    if not coverage_rows:
-        severity.append("SOURCES.md is missing a parseable `## Coverage matrix` table")
-    else:
-        missing_dimensions: list[str] = []
-        for label, tokens in INTEGRATION_REQUIRED_DIMENSIONS:
-            if not any(any(token in dim for token in tokens) for dim, _status in coverage_rows):
-                missing_dimensions.append(label)
-        if missing_dimensions:
-            severity.append(
-                "Coverage matrix is missing required integration dimensions: " + ", ".join(missing_dimensions)
-            )
-
-        partial_rows = [dim for dim, status in coverage_rows if any(tok in status for tok in PARTIAL_STATUS_TOKENS)]
-        if partial_rows:
-            open_gap_lines = parse_open_gap_lines(sources_content)
-            actionable = [
-                ln
-                for ln in open_gap_lines
-                if any(tok in ln.lower() for tok in ACTION_TOKENS)
-                and (ln.startswith("-") or re.match(r"^\d+\.", ln))
-            ]
-            if not actionable:
-                severity.append(
-                    "Coverage matrix has partial/missing dimensions but `## Open gaps` lacks actionable next retrieval steps"
-                )
 
 
 def validate_skill(
@@ -338,6 +52,8 @@ def validate_skill(
     strict_depth: bool = False,
 ) -> tuple[bool, list[str], list[str], str]:
     """Validate a skill directory. Returns (valid, errors, warnings, resolved_skill_class)."""
+    # Keep the flag for CLI compatibility; depth/content checks belong to review.
+    _ = strict_depth
     errors: list[str] = []
     warnings: list[str] = []
 
@@ -397,86 +113,20 @@ def validate_skill(
                 errors.append(f"name '{name}' does not match directory name '{skill_path.name}'")
 
     # Validate description.
-    description = ""
     if "description" not in frontmatter:
         errors.append("Missing required field: description")
     else:
         description = frontmatter["description"]
         if not isinstance(description, str):
             errors.append(f"description must be a string, got {type(description).__name__}")
-            description = ""
         else:
             description = description.strip()
             if not description:
                 errors.append("description must not be empty")
             elif len(description) > MAX_DESCRIPTION_LENGTH:
                 errors.append(f"description is too long ({len(description)} chars, max {MAX_DESCRIPTION_LENGTH})")
-            if "<" in description or ">" in description:
-                errors.append("description must not contain angle brackets (< or >)")
 
-            lower_desc = description.lower()
-            if not any(kw in lower_desc for kw in ["use when", "use for", "use to", "trigger", "invoke"]):
-                warnings.append(
-                    "description should include trigger phrases "
-                    '(e.g., \'Use when asked to "review code"\')'
-                )
-            if lower_desc.startswith(("i ", "i can", "you ")):
-                warnings.append(
-                    'description should be in third person ("Processes files..." not "I can process files...")'
-                )
-
-    # Check line count.
-    body_start = content.index("---", 3) + 3
-    body_lines = content[body_start:].strip().splitlines()
-    if len(body_lines) > MAX_SKILL_LINES:
-        warnings.append(
-            f"SKILL.md body is {len(body_lines)} lines (recommended max {MAX_SKILL_LINES}). "
-            "Consider moving content to references/."
-        )
-
-    # Check for common issues.
-    if "references/" in content or "scripts/" in content:
-        refs_dir = skill_path / "references"
-        scripts_dir = skill_path / "scripts"
-        if "references/" in content and not refs_dir.exists():
-            errors.append("SKILL.md references 'references/' but directory does not exist")
-        if "scripts/" in content and not scripts_dir.exists():
-            errors.append("SKILL.md references 'scripts/' but directory does not exist")
-
-    # If SOURCES.md is referenced, ensure it exists and includes provenance schema headers.
-    if "SOURCES.md" in content:
-        sources_md = skill_path / "SOURCES.md"
-        if not sources_md.exists():
-            errors.append("SKILL.md references 'SOURCES.md' but file does not exist")
-        else:
-            sources_content = sources_md.read_text()
-            required_headers = ("Trust tier", "Confidence", "Usage constraints")
-            missing_headers = [header for header in required_headers if header not in sources_content]
-            if missing_headers:
-                warnings.append(
-                    "SOURCES.md is missing expected provenance columns: " + ", ".join(missing_headers)
-                )
-
-    # Check for hardcoded repo paths.
-    if re.search(r"(?:plugins|skills)/[a-z-]+/(?:scripts|references|assets)/", content):
-        warnings.append(
-            "SKILL.md may contain hardcoded paths. "
-            "Use skill-local references/... paths and run scripts via <skill-dir>/scripts/..."
-        )
-
-    validate_skill_writer_reference_routing(skill_path, content, strict_depth, errors, warnings)
-
-    resolved_skill_class = (
-        selected_skill_class
-        if selected_skill_class != "auto"
-        else infer_skill_class(description, "\n".join(body_lines))
-    )
-
-    if resolved_skill_class == "integration-documentation":
-        validate_integration_depth(skill_path, strict_depth, errors, warnings)
-    validate_portable_paths(skill_path, content, strict_depth, errors, warnings)
-    validate_reference_lengths(skill_path, warnings)
-    validate_spec_md(skill_path, strict_depth, errors, warnings)
+    resolved_skill_class = selected_skill_class if selected_skill_class != "auto" else "generic"
 
     return len(errors) == 0, errors, warnings, resolved_skill_class
 

--- a/src/internal-skills/skill-writer/scripts/quick_validate_test.py
+++ b/src/internal-skills/skill-writer/scripts/quick_validate_test.py
@@ -1,0 +1,79 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("quick_validate.py")
+SPEC = importlib.util.spec_from_file_location("quick_validate", SCRIPT_PATH)
+assert SPEC is not None
+quick_validate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(quick_validate)
+
+
+class QuickValidateTest(unittest.TestCase):
+    def test_ignores_markdown_content_and_supporting_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_path = Path(temp_dir) / "example-skill"
+            skill_path.mkdir()
+            (skill_path / "SKILL.md").write_text(
+                """---
+name: example-skill
+description: I can review <example> content.
+---
+
+This intentionally references missing content that review may care about:
+
+- references/missing.md
+- scripts/missing.py
+- SOURCES.md
+
+/Users/example/private/path should not be script-validated.
+""",
+                encoding="utf-8",
+            )
+            (skill_path / "SPEC.md").write_text(
+                """# Example Skill Spec
+
+## Evaluation
+
+Run the local checks for this skill.
+""",
+                encoding="utf-8",
+            )
+
+            valid, errors, warnings, _skill_class = quick_validate.validate_skill(
+                skill_path,
+                selected_skill_class="integration-documentation",
+                strict_depth=True,
+            )
+
+        self.assertTrue(valid)
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_rejects_invalid_frontmatter_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_path = Path(temp_dir) / "example-skill"
+            skill_path.mkdir()
+            (skill_path / "SKILL.md").write_text(
+                """---
+name: [example-skill
+description: Use when reviewing example code.
+---
+
+Review example code.
+""",
+                encoding="utf-8",
+            )
+
+            valid, errors, warnings, _skill_class = quick_validate.validate_skill(skill_path)
+
+        self.assertFalse(valid)
+        self.assertEqual(warnings, [])
+        self.assertTrue(any("Invalid YAML in frontmatter" in message for message in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/sdk/runtimes/claude.test.ts
+++ b/src/sdk/runtimes/claude.test.ts
@@ -222,6 +222,28 @@ describe('claudeRuntime.runSkill', () => {
     });
   });
 
+  it('allows requested mutating tools only for trusted writer runs', async () => {
+    mockQuery.mockReturnValue(mockStream([successResult()]));
+
+    await claudeRuntime.runSkill({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      repoPath: '/repo/skill-root',
+      skillName: 'generated-skill-writer',
+      tools: { allowed: ['Read', 'Write', 'Edit', 'Bash'] },
+      allowMutatingTools: true,
+      options: {},
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith({
+      prompt: 'user',
+      options: expect.objectContaining({
+        allowedTools: ['Read', 'Write', 'Edit', 'Bash'],
+        disallowedTools: ['Grep', 'Glob', 'WebFetch', 'WebSearch', 'Task', 'TodoWrite'],
+      }),
+    });
+  });
+
   it('surfaces auth status errors', async () => {
     mockQuery.mockReturnValue(mockStream([
       {

--- a/src/sdk/runtimes/claude.ts
+++ b/src/sdk/runtimes/claude.ts
@@ -9,6 +9,8 @@
  *
  * Important invariants:
  * - Claude receives only read-only tools for hunk analysis.
+ * - Mutating tools are available only to trusted internal writer tasks that
+ *   opt in at the runtime request boundary.
  * - SDK errors remain classifiable by downstream retry/auth logic.
  * - Runtime results always contain valid `UsageStats`.
  * - Claude-specific result subtypes normalize to Warden-owned statuses.
@@ -75,18 +77,25 @@ function missingApiKeyResult<T>(kind: 'auxiliary' | 'synthesis'): AuxiliaryRunRe
   };
 }
 
-function resolveClaudeSkillTools(tools: ToolConfig | undefined): {
+function resolveClaudeSkillTools(
+  tools: ToolConfig | undefined,
+  allowMutatingTools = false,
+): {
   allowedTools: string[];
   disallowedTools: string[];
 } {
   const denied = new Set(tools?.denied ?? []);
   const requested = tools?.allowed ?? DEFAULT_READ_ONLY_TOOLS;
-  const allowedTools = READ_ONLY_TOOLS.filter((tool) => requested.includes(tool) && !denied.has(tool));
-  const disallowedReadOnlyTools = READ_ONLY_TOOLS.filter((tool) => !allowedTools.includes(tool));
+  const availableTools = allowMutatingTools
+    ? [...READ_ONLY_TOOLS, ...MUTATING_TOOLS]
+    : READ_ONLY_TOOLS;
+  const allowedTools = availableTools.filter((tool) => requested.includes(tool) && !denied.has(tool));
+  const disallowedAvailableTools = availableTools.filter((tool) => !allowedTools.includes(tool));
+  const disallowedMutatingTools = allowMutatingTools ? [] : [...MUTATING_TOOLS];
 
   return {
     allowedTools,
-    disallowedTools: [...MUTATING_TOOLS, ...disallowedReadOnlyTools, ...CLAUDE_AGENT_TOOLS],
+    disallowedTools: [...disallowedMutatingTools, ...disallowedAvailableTools, ...CLAUDE_AGENT_TOOLS],
   };
 }
 
@@ -257,10 +266,19 @@ export const claudeRuntime: Runtime = {
   name: 'claude',
 
   async runSkill(request: SkillRunRequest): Promise<SkillRunResponse> {
-    const { systemPrompt, userPrompt, repoPath, options, skillName, providerOptions, tools } = request;
+    const {
+      systemPrompt,
+      userPrompt,
+      repoPath,
+      options,
+      skillName,
+      providerOptions,
+      tools,
+      allowMutatingTools,
+    } = request;
     const { maxTurns = 50, model, abortController } = options;
     const { pathToClaudeCodeExecutable } = getClaudeProviderOptions(providerOptions);
-    const skillTools = resolveClaudeSkillTools(tools);
+    const skillTools = resolveClaudeSkillTools(tools, allowMutatingTools);
     const modelId = model ?? 'unknown';
 
     return Sentry.startSpan(
@@ -289,9 +307,9 @@ export const claudeRuntime: Runtime = {
             maxTurns,
             cwd: repoPath,
             systemPrompt,
-            // Only allow read-only tools. Skills may opt into read-only web tools.
+            // Hunk analysis is read-only; trusted internal writer tasks may opt
+            // into mutating tools explicitly at the runtime request boundary.
             allowedTools: skillTools.allowedTools,
-            // Explicitly block modification/side-effect tools as defense-in-depth.
             disallowedTools: skillTools.disallowedTools,
             permissionMode: 'bypassPermissions',
             // Prevent SDK from writing session .jsonl files and polluting Claude Code's session index.

--- a/src/sdk/runtimes/types.ts
+++ b/src/sdk/runtimes/types.ts
@@ -41,6 +41,11 @@ export interface SkillRunRequest {
   skillName: string;
   options: SkillRunOptions;
   tools?: ToolConfig;
+  /**
+   * Allow explicitly requested mutating tools for trusted internal writer tasks.
+   * Normal skill analysis keeps this false so hunks remain read-only.
+   */
+  allowMutatingTools?: boolean;
   /** Provider-specific settings consumed only by the selected runtime adapter. */
   providerOptions?: unknown;
 }

--- a/src/skill-builder/agentic.ts
+++ b/src/skill-builder/agentic.ts
@@ -6,7 +6,8 @@ import { parseJsonFromOutput, type ParseJsonFromOutputResult } from '../sdk/json
 import { aggregateUsage, emptyUsage } from '../sdk/usage.js';
 import type { Runtime, SkillRunResult } from '../sdk/runtimes/index.js';
 
-const SKILL_BUILDER_AGENT_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+const SKILL_BUILDER_READ_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+const SKILL_BUILDER_WRITE_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob', 'Write', 'Edit', 'Bash', 'WebFetch', 'WebSearch'];
 const STRUCTURED_REPAIR_MAX_TURNS = 1;
 const STRUCTURED_REPAIR_MAX_CHARS = 60_000;
 
@@ -206,6 +207,7 @@ export async function runStructuredSkillBuilderAgent<T>(args: {
   schema: z.ZodType<T>;
   model?: string;
   maxTurns?: number;
+  writeAccess?: boolean;
   abortController?: AbortController;
   repair?: {
     apiKey?: string;
@@ -220,7 +222,8 @@ export async function runStructuredSkillBuilderAgent<T>(args: {
     userPrompt: args.userPrompt,
     repoPath: args.repoPath,
     skillName: args.skillName,
-    tools: { allowed: SKILL_BUILDER_AGENT_TOOLS },
+    tools: { allowed: args.writeAccess ? SKILL_BUILDER_WRITE_TOOLS : SKILL_BUILDER_READ_TOOLS },
+    allowMutatingTools: args.writeAccess,
     options: {
       model: args.model,
       maxTurns: args.maxTurns,

--- a/src/skill-builder/definition.test.ts
+++ b/src/skill-builder/definition.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  clearGeneratedSkillArtifacts,
   createGeneratedSkillDefinition,
   getGeneratedSkillRoot,
   loadGeneratedSkillDefinition,
@@ -109,5 +110,22 @@ prompt: |-
       isPath: true,
       rootDir: join(repoRoot, 'skills', 'security'),
     });
+  });
+
+  it('clears generated artifacts without deleting definition or build state', () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(rootDir);
+    mkdirSync(join(rootDir, 'references'), { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), 'version: 1\nkind: generated-skill\nname: security\nprompt: test\n', 'utf-8');
+    writeFileSync(join(rootDir, 'build-state.json'), '{"version":1}\n', 'utf-8');
+    writeFileSync(join(rootDir, 'SKILL.md'), 'draft\n', 'utf-8');
+    writeFileSync(join(rootDir, 'references', 'security.md'), 'draft\n', 'utf-8');
+
+    clearGeneratedSkillArtifacts(rootDir);
+
+    expect(existsSync(join(rootDir, 'warden.yaml'))).toBe(true);
+    expect(existsSync(join(rootDir, 'build-state.json'))).toBe(true);
+    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references'))).toBe(false);
   });
 });

--- a/src/skill-builder/definition.test.ts
+++ b/src/skill-builder/definition.test.ts
@@ -7,6 +7,7 @@ import {
   createGeneratedSkillDefinition,
   getGeneratedSkillRoot,
   loadGeneratedSkillDefinition,
+  readGeneratedSkillArtifactFiles,
   resolveGeneratedSkillRoot,
   resolveGeneratedSkillTarget,
 } from './definition.js';
@@ -127,5 +128,20 @@ prompt: |-
     expect(existsSync(join(rootDir, 'build-state.json'))).toBe(true);
     expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
     expect(existsSync(join(rootDir, 'references'))).toBe(false);
+  });
+
+  it('reads nested artifact files that share metadata filenames', () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(rootDir);
+    mkdirSync(join(rootDir, 'references'), { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), 'version: 1\nkind: generated-skill\nname: security\nprompt: test\n', 'utf-8');
+    writeFileSync(join(rootDir, 'build-state.json'), '{"version":1}\n', 'utf-8');
+    writeFileSync(join(rootDir, 'references', 'warden.yaml'), 'nested definition fixture\n', 'utf-8');
+    writeFileSync(join(rootDir, 'references', 'build-state.json'), '{"nested":true}\n', 'utf-8');
+
+    expect(readGeneratedSkillArtifactFiles(rootDir).map((file) => file.path)).toEqual([
+      'references/build-state.json',
+      'references/warden.yaml',
+    ]);
   });
 });

--- a/src/skill-builder/definition.test.ts
+++ b/src/skill-builder/definition.test.ts
@@ -1,8 +1,14 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createGeneratedSkillDefinition, loadGeneratedSkillDefinition } from './definition.js';
+import {
+  createGeneratedSkillDefinition,
+  getGeneratedSkillRoot,
+  loadGeneratedSkillDefinition,
+  resolveGeneratedSkillRoot,
+  resolveGeneratedSkillTarget,
+} from './definition.js';
 
 describe('loadGeneratedSkillDefinition', () => {
   const tempDirs: string[] = [];
@@ -47,5 +53,61 @@ prompt: |-
     const definition = loadGeneratedSkillDefinition(rootDir);
     expect(definition.data.name).toBe('security');
     expect(definition.data.prompt).toBe('Find security issues.');
+  });
+
+  it('resolves existing generated skill roots in conventional order', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(repoRoot);
+    const generatedRoot = join(repoRoot, '.warden', 'skills', 'security');
+    const agentsRoot = join(repoRoot, '.agents', 'skills', 'security');
+    mkdirSync(generatedRoot, { recursive: true });
+    mkdirSync(agentsRoot, { recursive: true });
+    writeFileSync(join(generatedRoot, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: |-
+  Find security issues.
+`, 'utf-8');
+    writeFileSync(join(agentsRoot, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: |-
+  Agents copy.
+`, 'utf-8');
+
+    expect(resolveGeneratedSkillRoot(repoRoot, 'security')).toBe(generatedRoot);
+  });
+
+  it('does not resolve bare names from non-conventional skill roots', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(repoRoot);
+    const rootDir = join(repoRoot, 'skills', 'security');
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: |-
+  Find security issues.
+`, 'utf-8');
+
+    expect(resolveGeneratedSkillRoot(repoRoot, 'security')).toBe(getGeneratedSkillRoot(repoRoot, 'security'));
+  });
+
+  it('falls back to the default .warden root for new generated skills', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(repoRoot);
+
+    expect(resolveGeneratedSkillRoot(repoRoot, 'security')).toBe(getGeneratedSkillRoot(repoRoot, 'security'));
+  });
+
+  it('resolves explicit generated skill path targets without conventional lookup', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-skill-definition-'));
+    tempDirs.push(repoRoot);
+
+    expect(resolveGeneratedSkillTarget(repoRoot, './skills/security')).toEqual({
+      displayName: './skills/security',
+      isPath: true,
+      rootDir: join(repoRoot, 'skills', 'security'),
+    });
   });
 });

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -33,6 +33,12 @@ export interface GeneratedSkillTarget {
   rootDir: string;
 }
 
+export interface GeneratedSkillArtifactFile {
+  path: string;
+  content: string;
+  bytes: number;
+}
+
 function safePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '-');
 }
@@ -178,4 +184,38 @@ export function clearGeneratedSkillArtifacts(rootDir: string): void {
     }
     rmSync(join(rootDir, entry.name), { recursive: true, force: true });
   }
+}
+
+/** Read generated runtime artifacts while excluding Warden-owned metadata files. */
+export function readGeneratedSkillArtifactFiles(rootDir: string): GeneratedSkillArtifactFile[] {
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: GeneratedSkillArtifactFile[] = [];
+
+  function visit(relativeDir: string): void {
+    for (const entry of readdirSync(join(rootDir, relativeDir), { withFileTypes: true })) {
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      if (entry.name === GENERATED_SKILL_DEFINITION_FILE || entry.name === BUILD_STATE_FILE) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        visit(relativePath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const content = readFileSync(join(rootDir, relativePath), 'utf-8');
+      files.push({
+        path: relativePath,
+        content,
+        bytes: Buffer.byteLength(content, 'utf-8'),
+      });
+    }
+  }
+
+  visit('');
+  return files.sort((a, b) => a.path.localeCompare(b.path));
 }

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -197,7 +197,7 @@ export function readGeneratedSkillArtifactFiles(rootDir: string): GeneratedSkill
   function visit(relativeDir: string): void {
     for (const entry of readdirSync(join(rootDir, relativeDir), { withFileTypes: true })) {
       const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
-      if (entry.name === GENERATED_SKILL_DEFINITION_FILE || entry.name === BUILD_STATE_FILE) {
+      if (!relativeDir && (entry.name === GENERATED_SKILL_DEFINITION_FILE || entry.name === BUILD_STATE_FILE)) {
         continue;
       }
       if (entry.isDirectory()) {

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -3,11 +3,17 @@ import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import type { SkillDefinition } from '../config/schema.js';
+import { isPathLike, resolvePathTarget } from '../utils/path.js';
 
 export const GENERATED_SKILLS_DIR = '.warden/skills';
 export const GENERATED_SKILL_DEFINITION_FILE = 'warden.yaml';
 export const BUILD_STATE_FILE = 'build-state.json';
 const DESCRIPTION_MAX_LENGTH = 88;
+const EXISTING_GENERATED_SKILL_DIRS = [
+  GENERATED_SKILLS_DIR,
+  '.agents/skills',
+  '.claude/skills',
+] as const;
 
 export const GeneratedSkillDefinitionSchema = z.object({
   version: z.literal(1),
@@ -19,6 +25,13 @@ export const GeneratedSkillDefinitionSchema = z.object({
 }).passthrough();
 
 export type GeneratedSkillDefinition = z.infer<typeof GeneratedSkillDefinitionSchema>;
+
+/** A generated skill target resolved from a CLI name or filesystem path. */
+export interface GeneratedSkillTarget {
+  displayName: string;
+  isPath: boolean;
+  rootDir: string;
+}
 
 function safePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '-');
@@ -71,8 +84,40 @@ export function getGeneratedSkillRoot(repoRoot: string, skillName: string): stri
   return join(getGeneratedSkillsRoot(repoRoot), safePathSegment(skillName));
 }
 
+export function generatedSkillDefinitionRootExists(rootDir: string): boolean {
+  return existsSync(join(rootDir, GENERATED_SKILL_DEFINITION_FILE));
+}
+
+/** Resolve a generated skill CLI target using the shared name and path semantics. */
+export function resolveGeneratedSkillTarget(repoRoot: string, target: string): GeneratedSkillTarget {
+  if (isPathLike(target)) {
+    return {
+      displayName: target,
+      isPath: true,
+      rootDir: resolvePathTarget(target, repoRoot),
+    };
+  }
+
+  return {
+    displayName: target,
+    isPath: false,
+    rootDir: resolveGeneratedSkillRoot(repoRoot, target),
+  };
+}
+
+export function resolveGeneratedSkillRoot(repoRoot: string, skillName: string): string {
+  const safeName = safePathSegment(skillName);
+  for (const dir of EXISTING_GENERATED_SKILL_DIRS) {
+    const rootDir = join(repoRoot, dir, safeName);
+    if (generatedSkillDefinitionRootExists(rootDir)) {
+      return rootDir;
+    }
+  }
+  return getGeneratedSkillRoot(repoRoot, skillName);
+}
+
 export function generatedSkillDefinitionExists(repoRoot: string, skillName: string): boolean {
-  return existsSync(join(getGeneratedSkillRoot(repoRoot, skillName), GENERATED_SKILL_DEFINITION_FILE));
+  return generatedSkillDefinitionRootExists(resolveGeneratedSkillRoot(repoRoot, skillName));
 }
 
 export function loadGeneratedSkillDefinition(rootDir: string): {

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -116,10 +116,6 @@ export function resolveGeneratedSkillRoot(repoRoot: string, skillName: string): 
   return getGeneratedSkillRoot(repoRoot, skillName);
 }
 
-export function generatedSkillDefinitionExists(repoRoot: string, skillName: string): boolean {
-  return generatedSkillDefinitionRootExists(resolveGeneratedSkillRoot(repoRoot, skillName));
-}
-
 export function loadGeneratedSkillDefinition(rootDir: string): {
   content: string;
   data: GeneratedSkillDefinition;

--- a/src/skill-builder/definition.ts
+++ b/src/skill-builder/definition.ts
@@ -173,7 +173,7 @@ export function clearGeneratedSkillArtifacts(rootDir: string): void {
     return;
   }
   for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
-    if (entry.name === GENERATED_SKILL_DEFINITION_FILE) {
+    if (entry.name === GENERATED_SKILL_DEFINITION_FILE || entry.name === BUILD_STATE_FILE) {
       continue;
     }
     rmSync(join(rootDir, entry.name), { recursive: true, force: true });

--- a/src/skill-builder/outline-state.ts
+++ b/src/skill-builder/outline-state.ts
@@ -35,6 +35,7 @@ export const GeneratedSkillArtifactStateSchema = z.object({
     reason: z.string().min(1),
   }).strict()),
   missingInputs: z.array(z.string().min(1)),
+  authoringWarnings: z.array(z.string().min(1)).default([]),
   responseModel: z.string().optional(),
   numTurns: z.number().int().nonnegative().optional(),
   generatedAt: z.string().min(1),

--- a/src/skill-builder/outline-state.ts
+++ b/src/skill-builder/outline-state.ts
@@ -11,7 +11,7 @@ export const SKILL_BUILD_STATE_SCHEMA_VERSION = 1;
 export const SKILL_BUILD_STATE_KIND = 'skill-build-state';
 
 export const GeneratedSkillArtifactStateSchema = z.object({
-  version: z.literal(4),
+  version: z.literal(5),
   sourceHash: z.string().min(1),
   outlineHash: z.string().min(1),
   buildVersion: z.string().min(1),
@@ -26,12 +26,6 @@ export const GeneratedSkillArtifactStateSchema = z.object({
     bytes: z.number().int().nonnegative(),
   }).strict()).min(1),
   deterministicWarnings: z.array(z.string().min(1)).default([]),
-  validationIssues: z.array(z.object({
-    severity: z.enum(['error', 'warning']),
-    path: z.string().optional(),
-    message: z.string().min(1),
-    suggestedFix: z.string().optional(),
-  }).strict()).default([]),
   bytes: z.number().int().nonnegative(),
   durationMs: z.number().nonnegative(),
   usage: UsageStatsSchema,

--- a/src/skill-builder/outline.test.ts
+++ b/src/skill-builder/outline.test.ts
@@ -106,6 +106,7 @@ describe('skill build state', () => {
         },
         externalSources: [],
         missingInputs: [],
+        authoringWarnings: [],
         responseModel: 'claude-sonnet-4-5',
         numTurns: 2,
         generatedAt: '2026-05-01T00:00:00.000Z',

--- a/src/skill-builder/outline.test.ts
+++ b/src/skill-builder/outline.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { collectSkillImproveSource } from './outline.js';
 import {
   getBuildStatePath,
   readSkillBuildState,
@@ -126,5 +127,37 @@ describe('skill build state', () => {
         buildVersion: '1',
       },
     });
+  });
+
+  it('collects improvement briefs with current generated artifacts', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-improve-source-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'security');
+    mkdirSync(join(rootDir, 'references'), { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), `version: 1
+kind: generated-skill
+name: security
+prompt: Find security issues.
+`, 'utf-8');
+    writeFileSync(join(rootDir, 'SKILL.md'), '---\nname: security\n---\n', 'utf-8');
+    writeFileSync(join(rootDir, 'references', 'auth.md'), '# Auth\n', 'utf-8');
+    writeFileSync(join(rootDir, 'build-state.json'), '{"ignored":true}\n', 'utf-8');
+
+    const source = collectSkillImproveSource({
+      name: 'security',
+      description: 'Security skill',
+      prompt: 'Find security issues.',
+      rootDir,
+    }, 'Tighten auth guidance.');
+
+    expect(source.files.map((file) => file.path)).toEqual(expect.arrayContaining([
+      'warden.yaml',
+      'improvement-brief.md',
+      'current-artifacts/SKILL.md',
+      'current-artifacts/references/auth.md',
+    ]));
+    expect(source.files.find((file) => file.path === 'improvement-brief.md')?.content).toBe(
+      'Tighten auth guidance.',
+    );
   });
 });

--- a/src/skill-builder/outline.test.ts
+++ b/src/skill-builder/outline.test.ts
@@ -77,7 +77,7 @@ describe('skill build state', () => {
         numTurns: 1,
       },
       artifact: {
-        version: 4,
+        version: 5,
         sourceHash: 'source-hash',
         outlineHash: 'outline-hash',
         buildVersion: '1',
@@ -92,7 +92,6 @@ describe('skill build state', () => {
           { path: 'references/auth-bypass.md', bytes: 512 },
         ],
         deterministicWarnings: [],
-        validationIssues: [],
         bytes: 1024,
         durationMs: 5000,
         usage: {

--- a/src/skill-builder/outline.ts
+++ b/src/skill-builder/outline.ts
@@ -200,7 +200,7 @@ JSON shape:
   "buildVersion": "${SKILL_BUILD_VERSION}",
   "scopeProfile": {
     "kind": "repository",
-    "subject": "Security review for this repo's CLI and runtime surfaces",
+    "subject": "Code review for this repo's CLI and runtime surfaces",
     "localContextUsed": true,
     "observedContext": [
       "Node.js and TypeScript runtime",
@@ -260,9 +260,9 @@ ${sourceBlocks(source)}`;
 function buildOutlineSystemPrompt(): string {
   return `You build the internal outline for one generated Warden skill.
 
-Use Read, Grep, and Glob to inspect relevant repository source before deciding how to decompose the skill when local context is needed. Use WebSearch or WebFetch for public prior art and current external documentation when framework, runtime, vulnerability, or ecosystem behavior affects the outline.
+Use Read, Grep, and Glob to inspect relevant repository source before deciding how to decompose the skill when local context is needed. Use WebSearch or WebFetch for public prior art and current external documentation when framework, runtime, risk class, or ecosystem behavior affects the outline.
 
-Do not send repository code, secrets, private file paths, or proprietary details to web tools. Use public framework, package, API, vulnerability class, and documentation names only.
+Do not send repository code, secrets, private file paths, or proprietary details to web tools. Use public framework, package, API, risk class, and documentation names only.
 
 Return only the strict JSON object requested by the user prompt. Never return prose or follow-up questions.`;
 }

--- a/src/skill-builder/outline.ts
+++ b/src/skill-builder/outline.ts
@@ -8,6 +8,7 @@ import { runStructuredSkillBuilderAgent, StructuredSkillBuilderAgentError } from
 import {
   GENERATED_SKILL_DEFINITION_FILE,
   loadGeneratedSkillDefinition,
+  readGeneratedSkillArtifactFiles,
 } from './definition.js';
 import {
   outlineHash,
@@ -50,6 +51,7 @@ export interface BuildSkillOutlineOptions {
   repairModel?: string;
   repairMaxRetries?: number;
   onStatus?: (message: string) => void;
+  source?: SkillBuildSource;
 }
 
 export class SkillBuildOutlineError extends Error {
@@ -69,25 +71,55 @@ function sourceBlocks(source: SkillBuildSource): string {
     .join('\n\n---\n\n');
 }
 
-export function collectSkillBuildSource(skill: SkillDefinition): SkillBuildSource {
-  const files: SkillBuildSourceFile[] = [];
-
-  if (skill.rootDir) {
-    const { content } = loadGeneratedSkillDefinition(skill.rootDir);
-    files.push({ path: GENERATED_SKILL_DEFINITION_FILE, content });
-  } else {
-    files.push({
-      path: GENERATED_SKILL_DEFINITION_FILE,
-      content: `version: 1\nkind: generated-skill\nname: ${skill.name}\nprompt: ${JSON.stringify(skill.prompt)}\n`,
-    });
-  }
-
+function buildSkillSource(skillName: string, files: SkillBuildSourceFile[]): SkillBuildSource {
   const hash = sha256(JSON.stringify({
-    skill: skill.name,
+    skill: skillName,
     files,
   }));
 
   return { hash, files };
+}
+
+function generatedSkillDefinitionSourceFile(skill: SkillDefinition): SkillBuildSourceFile {
+  if (skill.rootDir) {
+    const { content } = loadGeneratedSkillDefinition(skill.rootDir);
+    return { path: GENERATED_SKILL_DEFINITION_FILE, content };
+  }
+
+  return {
+    path: GENERATED_SKILL_DEFINITION_FILE,
+    content: `version: 1\nkind: generated-skill\nname: ${skill.name}\nprompt: ${JSON.stringify(skill.prompt)}\n`,
+  };
+}
+
+export function collectSkillBuildSource(skill: SkillDefinition): SkillBuildSource {
+  const files: SkillBuildSourceFile[] = [];
+
+  files.push(generatedSkillDefinitionSourceFile(skill));
+
+  return buildSkillSource(skill.name, files);
+}
+
+/** Collect the improvement brief and current artifacts as source material. */
+export function collectSkillImproveSource(skill: SkillDefinition, improvementPrompt: string): SkillBuildSource {
+  const files: SkillBuildSourceFile[] = [
+    generatedSkillDefinitionSourceFile(skill),
+    {
+      path: 'improvement-brief.md',
+      content: improvementPrompt.trim(),
+    },
+  ];
+
+  if (skill.rootDir) {
+    files.push(
+      ...readGeneratedSkillArtifactFiles(skill.rootDir).map((file) => ({
+        path: `current-artifacts/${file.path}`,
+        content: file.content,
+      })),
+    );
+  }
+
+  return buildSkillSource(skill.name, files);
 }
 
 function validateOutlineIdentity(outline: SkillBuildOutline, skillName: string, sourceHash: string): void {
@@ -292,7 +324,7 @@ export async function buildSkillOutline(
 ): Promise<SkillBuildOutlineResult> {
   const { skill, apiKey, model, maxRetries, regenerate = false } = options;
   const runtime = options.runtime ?? getRuntime(options.runtimeName ?? 'claude');
-  const source = collectSkillBuildSource(skill);
+  const source = options.source ?? collectSkillBuildSource(skill);
   const rootDir = skill.rootDir;
   if (!rootDir) {
     throw new SkillBuildOutlineError(`Generated skill ${skill.name} is missing a root directory`);

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -87,6 +87,33 @@ export const GeneratedSkillFileMapSchema = z.object({
 
 export type GeneratedSkillFileMap = z.infer<typeof GeneratedSkillFileMapSchema>;
 
+export const GeneratedSkillContributionSchema = z.object({
+  version: z.literal(1),
+  files: z.array(GeneratedSkillArtifactFileSchema).default([]),
+  summary: z.string().min(1),
+  validationNotes: z.array(z.string().min(1)).default([]),
+  missingInputs: z.array(z.string().min(1)).default([]),
+  externalSources: z.array(z.object({
+    title: z.string().min(1),
+    url: z.string().min(1),
+    reason: z.string().min(1),
+  }).strict()).default([]),
+}).strict().superRefine((value, ctx) => {
+  const paths = new Set<string>();
+  for (const [index, file] of value.files.entries()) {
+    if (paths.has(file.path)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['files', index, 'path'],
+        message: `Duplicate generated artifact path: ${file.path}`,
+      });
+    }
+    paths.add(file.path);
+  }
+});
+
+export type GeneratedSkillContribution = z.infer<typeof GeneratedSkillContributionSchema>;
+
 export const GeneratedSkillValidationIssueSchema = z.object({
   severity: z.enum(['error', 'warning']),
   path: z.string().optional(),

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -28,10 +28,27 @@ export const GeneratedSkillAuthoringPlanSchema = z.object({
   summary: z.string().min(1),
   workflow: z.array(z.string().min(1)).min(1),
   researchPlan: z.array(z.string().min(1)).default([]),
+  sourceDecisions: z.array(z.object({
+    source: z.string().min(1),
+    decision: z.string().min(1),
+    implication: z.string().min(1),
+  }).strict()).default([]),
+  lookupQuestions: z.array(z.object({
+    question: z.string().min(1),
+    openWhen: z.string().min(1),
+    requiredEvidence: z.array(z.string().min(1)).min(1),
+    candidatePaths: z.array(z.string().min(1)).default([]),
+  }).strict()).default([]),
+  qualityBar: z.array(z.string().min(1)).default([]),
   artifactPlan: z.array(z.string().min(1)).min(1),
   validationPlan: z.array(z.string().min(1)).min(1),
   risks: z.array(z.string().min(1)).default([]),
   missingInputs: z.array(z.string().min(1)).default([]),
+  externalSources: z.array(z.object({
+    title: z.string().min(1),
+    url: z.string().min(1),
+    reason: z.string().min(1),
+  }).strict()).default([]),
 }).strict();
 
 export type GeneratedSkillAuthoringPlan = z.infer<typeof GeneratedSkillAuthoringPlanSchema>;

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -48,6 +48,10 @@ export const GeneratedSkillArtifactFileSchema = z.object({
 
 export type GeneratedSkillArtifactFile = z.infer<typeof GeneratedSkillArtifactFileSchema>;
 
+const GeneratedSkillValidationFileSchema = GeneratedSkillArtifactFileSchema.extend({
+  content: z.string(),
+});
+
 export const GeneratedSkillFileMapSchema = z.object({
   version: z.literal(1),
   name: z.string().min(1),
@@ -95,7 +99,7 @@ export const GeneratedSkillValidationResultSchema = z.object({
   valid: z.boolean(),
   summary: z.string().min(1),
   issues: z.array(GeneratedSkillValidationIssueSchema).default([]),
-  files: z.array(GeneratedSkillArtifactFileSchema).optional(),
+  files: z.array(GeneratedSkillValidationFileSchema).optional(),
   missingInputs: z.array(z.string().min(1)).default([]),
 }).strict().superRefine((value, ctx) => {
   if (value.files && value.files.length > 0) {

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -23,6 +23,10 @@ function isValidGeneratedArtifactPath(path: string): boolean {
   return path !== 'warden.yaml' && path !== 'build-state.json';
 }
 
+// The authoring plan is meant to describe semantic coverage, source depth,
+// sequential work, and review criteria. It must not become an artifact-layout
+// plan. `candidatePaths` is retained only for backwards-compatible parsing of
+// older plans; prompts should not rely on it as a file-placement contract.
 export const GeneratedSkillAuthoringPlanSchema = z.object({
   version: z.literal(1),
   summary: z.string().min(1),

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -84,6 +84,7 @@ export interface GeneratedSkillArtifact {
   usage: UsageStats;
   externalSources: SkillBuildExternalSource[];
   missingInputs: string[];
+  warnings: string[];
   responseModel?: string;
   numTurns?: number;
 }

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -48,10 +48,6 @@ export const GeneratedSkillArtifactFileSchema = z.object({
 
 export type GeneratedSkillArtifactFile = z.infer<typeof GeneratedSkillArtifactFileSchema>;
 
-const GeneratedSkillValidationFileSchema = GeneratedSkillArtifactFileSchema.extend({
-  content: z.string(),
-});
-
 export const GeneratedSkillFileMapSchema = z.object({
   version: z.literal(1),
   name: z.string().min(1),
@@ -114,44 +110,22 @@ export const GeneratedSkillContributionSchema = z.object({
 
 export type GeneratedSkillContribution = z.infer<typeof GeneratedSkillContributionSchema>;
 
-export const GeneratedSkillValidationIssueSchema = z.object({
+export const GeneratedSkillReviewIssueSchema = z.object({
   severity: z.enum(['error', 'warning']),
   path: z.string().optional(),
   message: z.string().min(1),
   suggestedFix: z.string().optional(),
 }).strict();
 
-export const GeneratedSkillValidationResultSchema = z.object({
+export const GeneratedSkillReviewResultSchema = z.object({
   version: z.literal(1),
   valid: z.boolean(),
   summary: z.string().min(1),
-  issues: z.array(GeneratedSkillValidationIssueSchema).default([]),
-  files: z.array(GeneratedSkillValidationFileSchema).optional(),
+  issues: z.array(GeneratedSkillReviewIssueSchema).default([]),
   missingInputs: z.array(z.string().min(1)).default([]),
-}).strict().superRefine((value, ctx) => {
-  if (value.files && value.files.length > 0) {
-    const paths = new Set<string>();
-    for (const [index, file] of value.files.entries()) {
-      if (paths.has(file.path)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['files', index, 'path'],
-          message: `Duplicate generated artifact path: ${file.path}`,
-        });
-      }
-      paths.add(file.path);
-    }
-    if (!paths.has('SKILL.md')) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['files'],
-        message: 'Validation file map must include SKILL.md when revised files are returned',
-      });
-    }
-  }
-});
+}).strict();
 
-export type GeneratedSkillValidationResult = z.infer<typeof GeneratedSkillValidationResultSchema>;
+export type GeneratedSkillReviewResult = z.infer<typeof GeneratedSkillReviewResultSchema>;
 
 export interface GeneratedSkillArtifact {
   kind: 'generated-skill';

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -25,8 +25,7 @@ function isValidGeneratedArtifactPath(path: string): boolean {
 
 // The authoring plan is meant to describe semantic coverage, source depth,
 // sequential work, and review criteria. It must not become an artifact-layout
-// plan. `candidatePaths` is retained only for backwards-compatible parsing of
-// older plans; prompts should not rely on it as a file-placement contract.
+// plan; the authoring skill owns artifact placement and routing choices.
 export const GeneratedSkillAuthoringPlanSchema = z.object({
   version: z.literal(1),
   summary: z.string().min(1),
@@ -41,7 +40,6 @@ export const GeneratedSkillAuthoringPlanSchema = z.object({
     question: z.string().min(1),
     openWhen: z.string().min(1),
     requiredEvidence: z.array(z.string().min(1)).min(1),
-    candidatePaths: z.array(z.string().min(1)).default([]),
   }).strict()).default([]),
   qualityBar: z.array(z.string().min(1)).default([]),
   artifactPlan: z.array(z.string().min(1)).min(1),

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -24,7 +24,7 @@ function isValidGeneratedArtifactPath(path: string): boolean {
 }
 
 // The authoring plan is meant to describe semantic coverage, source depth,
-// sequential work, and review criteria. It must not become an artifact-layout
+// ordered work, and review criteria. It must not become an artifact-layout
 // plan; the authoring skill owns artifact placement and routing choices.
 export const GeneratedSkillAuthoringPlanSchema = z.object({
   version: z.literal(1),
@@ -65,8 +65,6 @@ export const GeneratedSkillArtifactFileSchema = z.object({
   content: z.string().min(1),
 }).strict();
 
-export type GeneratedSkillArtifactFile = z.infer<typeof GeneratedSkillArtifactFileSchema>;
-
 export const GeneratedSkillFileMapSchema = z.object({
   version: z.literal(1),
   name: z.string().min(1),
@@ -101,33 +99,6 @@ export const GeneratedSkillFileMapSchema = z.object({
 });
 
 export type GeneratedSkillFileMap = z.infer<typeof GeneratedSkillFileMapSchema>;
-
-export const GeneratedSkillContributionSchema = z.object({
-  version: z.literal(1),
-  files: z.array(GeneratedSkillArtifactFileSchema).default([]),
-  summary: z.string().min(1),
-  validationNotes: z.array(z.string().min(1)).default([]),
-  missingInputs: z.array(z.string().min(1)).default([]),
-  externalSources: z.array(z.object({
-    title: z.string().min(1),
-    url: z.string().min(1),
-    reason: z.string().min(1),
-  }).strict()).default([]),
-}).strict().superRefine((value, ctx) => {
-  const paths = new Set<string>();
-  for (const [index, file] of value.files.entries()) {
-    if (paths.has(file.path)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['files', index, 'path'],
-        message: `Duplicate generated artifact path: ${file.path}`,
-      });
-    }
-    paths.add(file.path);
-  }
-});
-
-export type GeneratedSkillContribution = z.infer<typeof GeneratedSkillContributionSchema>;
 
 export const GeneratedSkillReviewIssueSchema = z.object({
   severity: z.enum(['error', 'warning']),

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -13,15 +13,11 @@ export interface SkillBuildAuthoringProvider {
   contentHash: string;
 }
 
-function isValidGeneratedArtifactPath(path: string): boolean {
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/.test(path)) {
-    return false;
-  }
-  if (path.startsWith('/') || path.includes('..') || path.includes('//')) {
-    return false;
-  }
-  return path !== 'warden.yaml' && path !== 'build-state.json';
-}
+const SkillBuildExternalSourceSchema = z.object({
+  title: z.string().min(1),
+  url: z.string().min(1),
+  reason: z.string().min(1),
+}).strict();
 
 // The authoring plan is meant to describe semantic coverage, source depth,
 // ordered work, and review criteria. It must not become an artifact-layout
@@ -46,59 +42,20 @@ export const GeneratedSkillAuthoringPlanSchema = z.object({
   validationPlan: z.array(z.string().min(1)).min(1),
   risks: z.array(z.string().min(1)).default([]),
   missingInputs: z.array(z.string().min(1)).default([]),
-  externalSources: z.array(z.object({
-    title: z.string().min(1),
-    url: z.string().min(1),
-    reason: z.string().min(1),
-  }).strict()).default([]),
+  externalSources: z.array(SkillBuildExternalSourceSchema).default([]),
 }).strict();
 
 export type GeneratedSkillAuthoringPlan = z.infer<typeof GeneratedSkillAuthoringPlanSchema>;
 
-export const GeneratedSkillArtifactFileSchema = z.object({
-  path: z.string()
-    .min(1)
-    .refine(
-      (value) => isValidGeneratedArtifactPath(value),
-      'Generated artifact paths must be relative, stay inside the skill root, and must not overwrite warden.yaml or build-state.json',
-    ),
-  content: z.string().min(1),
-}).strict();
-
-export const GeneratedSkillFileMapSchema = z.object({
+export const GeneratedSkillWriterResultSchema = z.object({
   version: z.literal(1),
-  name: z.string().min(1),
-  files: z.array(GeneratedSkillArtifactFileSchema).min(1),
   summary: z.string().min(1),
   validationNotes: z.array(z.string().min(1)).default([]),
   missingInputs: z.array(z.string().min(1)).default([]),
-  externalSources: z.array(z.object({
-    title: z.string().min(1),
-    url: z.string().min(1),
-    reason: z.string().min(1),
-  }).strict()).default([]),
-}).strict().superRefine((value, ctx) => {
-  const paths = new Set<string>();
-  for (const [index, file] of value.files.entries()) {
-    if (paths.has(file.path)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['files', index, 'path'],
-        message: `Duplicate generated artifact path: ${file.path}`,
-      });
-    }
-    paths.add(file.path);
-  }
-  if (!paths.has('SKILL.md')) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['files'],
-      message: 'Generated artifact file map must include SKILL.md',
-    });
-  }
+  externalSources: z.array(SkillBuildExternalSourceSchema).default([]),
 });
 
-export type GeneratedSkillFileMap = z.infer<typeof GeneratedSkillFileMapSchema>;
+export type GeneratedSkillWriterResult = z.infer<typeof GeneratedSkillWriterResultSchema>;
 
 export const GeneratedSkillReviewIssueSchema = z.object({
   severity: z.enum(['error', 'warning']),

--- a/src/skill-builder/skill-contract.ts
+++ b/src/skill-builder/skill-contract.ts
@@ -13,6 +13,8 @@ export interface SkillBuildAuthoringProvider {
   contentHash: string;
 }
 
+export type GeneratedSkillAuthoringMode = 'build' | 'improve';
+
 const SkillBuildExternalSourceSchema = z.object({
   title: z.string().min(1),
   url: z.string().min(1),

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -33,13 +33,18 @@ function wardenSkillConstraints(args: {
   authoringSkillRoot: string;
 }): string {
   return `Warden generated-skill constraints:
-- Use the full authoring skill at \`${args.authoringSkillRoot}\`. Start by reading its SKILL.md and follow its own routing. Do not rely on a hand-picked subset of its references.
+- Use the full authoring skill at \`${args.authoringSkillRoot}\` as the authoring method. Start by reading its SKILL.md and follow its own routing. Do not rely on a hand-picked subset of its references.
 - The target skill root is \`${args.targetRootDir}\`.
 - The generated SKILL.md frontmatter name must be exactly \`${args.targetName}\`.
 - Generated artifacts must be normal Warden skill files. Do not overwrite warden.yaml or build-state.json.
-- Let the authoring skill choose the artifact shape. Optimize for a usable runtime approach: clear review tasks, routing cues, evidence requirements, and supporting references/scripts/assets only when they help the skill execute.
-- Warden runs skills on changed hunks. Findings must anchor to changed lines and must be concrete enough for Warden's normal report schema.
-- SKILL.md should be the runtime router when references exist. Prefer clear "when to read" routes for runtime references, using an index reference when that is simpler than listing every file.
+- Choose the simplest adequate layout using the authoring skill's rules. Do not add files just to satisfy a template.
+- Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references. Inline or single-reference layouts are fine when they are genuinely enough.
+- References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
+- Use SPEC.md for new or materially scoped generated skills when it records a useful scope, evidence model, or maintenance contract.
+- Use SOURCES.md when provenance, source-depth decisions, external sources, or open gaps materially affect the generated skill.
+- Warden runs skills on changed hunks and injects the JSON finding schema separately. Do not create a custom plaintext output format.
+- Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
+- Security-review skills should include exploit-path evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep provenance and authoring decisions in SOURCES.md or SPEC.md, not in runtime references.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;
@@ -82,9 +87,9 @@ ${wardenSkillConstraints(args)}
 
 Use "tell them what you are going to tell them" discipline:
 - Read and use the authoring skill.
-- Decide the minimum workflow path it requires.
-- Decide what research is needed before implementation.
-- Decide the intended artifact layout without forcing a Warden template.
+- Decide the minimum workflow path and simplest adequate artifact layout.
+- Decide what research is needed before implementation and what gaps should be recorded.
+- Decide where runtime guidance, references, provenance, and maintenance contract belong.
 - Decide how Warden and the authoring skill should validate the output.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
@@ -126,7 +131,8 @@ Use "tell them" discipline:
 - Use the authoring skill again, starting from its SKILL.md.
 - Follow the plan unless new evidence proves the plan is wrong.
 - Return a complete file map for every generated artifact that should exist.
-- Include SKILL.md. Include SPEC.md, SOURCES.md, EVAL.md, references/, scripts/, or assets/ only when the authoring skill and this skill's needs justify them.
+- Include SKILL.md. Add SPEC.md, SOURCES.md, EVAL.md, references/, scripts/, or assets/ only when they add runtime, provenance, maintenance, validation, or reusable-example value.
+- Keep SKILL.md compact; put optional depth in routed references and authoring/provenance notes in SPEC.md or SOURCES.md.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
 
 Return JSON:
@@ -178,6 +184,7 @@ ${wardenSkillConstraints(args)}
 Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
+- Check for over-broad topic-bucket references, stale gap/provenance language, missing routes, and custom output formats that conflict with Warden's JSON finding schema.
 - If fixes are needed, return a complete revised file map in files.
 - If no fixes are needed, omit files or return an empty files array.
 - Report only issues that remain after any revised files you return.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -125,8 +125,7 @@ Return JSON:
     {
       "question": "Lookup question the reference or inline section must answer",
       "openWhen": "When the runtime agent should open or use it",
-      "requiredEvidence": ["Evidence or example this lookup must include"],
-      "candidatePaths": ["references/example.md"]
+      "requiredEvidence": ["Evidence or example this lookup must include"]
     }
   ],
   "qualityBar": ["Concrete depth requirement for the writer and reviewer"],

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -1,7 +1,7 @@
 import type { GeneratedSkillAuthoringPlan, GeneratedSkillFileMap } from './skill-contract.js';
 import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
 
-const GENERIC_SKILL_BUILD_MAX_TURNS = 12;
+const GENERIC_SKILL_BUILD_MAX_TURNS = 16;
 const LOCAL_SKILL_BUILD_MAX_TURNS = 24;
 const VALIDATION_MAX_TURNS = 8;
 
@@ -43,12 +43,12 @@ function wardenSkillConstraints(args: {
 - Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references. Inline or single-reference layouts are fine when they are genuinely enough.
 - References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
 - Use SPEC.md for new or materially scoped generated skills when it records a useful scope, evidence model, or maintenance contract.
-- Use SOURCES.md when provenance, source-depth decisions, external sources, or open gaps materially affect the generated skill.
-- Warden runs skills on changed hunks and injects the JSON finding schema separately. Do not create a custom plaintext output format.
+- Use SOURCES.md only when concrete external sources were consulted or unresolved source gaps materially affect future maintenance. Do not create SOURCES.md just to restate warden.yaml, the internal outline, build pipeline, authoring decisions, or "no external research".
+- Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
 - Security-review skills should include exploit-path evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
-- Keep provenance and authoring decisions in SOURCES.md or SPEC.md, not in runtime references.
+- Keep authoring decisions, build metadata, internal outline details, validation summaries, and future-work notes out of generated runtime artifacts.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;
 }
 
@@ -133,8 +133,10 @@ Use "tell them" discipline:
 - Use the authoring skill again, starting from its SKILL.md.
 - Follow the plan unless new evidence proves the plan is wrong.
 - Return a complete file map for every generated artifact that should exist.
-- Include SKILL.md. Add SPEC.md, SOURCES.md, EVAL.md, references/, scripts/, or assets/ only when they add runtime, provenance, maintenance, validation, or reusable-example value.
-- Keep SKILL.md compact; put optional depth in routed references and authoring/provenance notes in SPEC.md or SOURCES.md.
+- Include SKILL.md. Add references/ only for routed runtime lookup leaves. Add SPEC.md, EVAL.md, scripts/, assets/, or SOURCES.md only when they add concrete runtime, maintenance, validation, reusable-example, or external-source value.
+- Keep SKILL.md compact; put optional depth in routed references. Do not include authoring/provenance notes unless they describe real external sources or unresolved source gaps that future maintainers need.
+- Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline, build pipeline, or no external research.
+- The externalSources array is only for concrete external sources you actually consulted. Do not count warden.yaml, the internal outline, generated tracks, or the authoring plan as external sources.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
 
 Return JSON:
@@ -186,7 +188,7 @@ ${wardenSkillConstraints(args)}
 Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
-- Check for over-broad topic-bucket references, stale gap/provenance language, missing routes, and custom output formats that conflict with Warden's JSON finding schema.
+- Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
 - If fixes are needed, return a complete revised file map in files, including every referenced runtime file.
 - If no fixes are needed, omit files or return an empty files array.
 - Do not return placeholder files or empty file contents. Omit unchanged files instead.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -40,7 +40,8 @@ function wardenSkillConstraints(args: {
 - Treat existing generated artifacts in the target root as stale unless you intentionally re-emit them in the returned file map.
 - Use the source material and internal outline as the source of truth for regeneration.
 - Choose the simplest adequate layout using the authoring skill's rules. Do not add files just to satisfy a template.
-- Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references. Inline or single-reference layouts are fine when they are genuinely enough.
+- Tracks/tasks are planning work lanes, not filesystem taxonomy. Do not create \`references/tracks/\`; use \`references/<lookup-topic>.md\`, shared references, or inline guidance according to the authoring skill.
+- Broad or multi-track skills often need SKILL.md as a compact router plus focused routed references. Inline, shared-reference, one-reference-per-track, many-references-per-track, and fewer-references-than-tracks layouts are all valid when they fit the authoring skill.
 - References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
 - Use SPEC.md for new or materially scoped generated skills when it records a useful scope, evidence model, or maintenance contract.
 - Use SOURCES.md only when concrete external sources were consulted or unresolved source gaps materially affect future maintenance. Do not create SOURCES.md just to restate warden.yaml, the internal outline, build pipeline, authoring decisions, or "no external research".
@@ -90,9 +91,11 @@ ${wardenSkillConstraints(args)}
 Use "tell them what you are going to tell them" discipline:
 - Read and use the authoring skill.
 - Decide the minimum workflow path and simplest adequate artifact layout.
-- Decide what research is needed before implementation and what gaps should be recorded.
+- Do the first research and source-inspection pass yourself. Use that to identify the work lanes, larger plan, and obvious non-overlap boundaries.
+- Decide what additional research is needed during implementation and what gaps should be recorded.
 - Decide where runtime guidance, references, provenance, and maintenance contract belong.
-- Decide how Warden and the authoring skill should validate the output.
+- Decide the sequential task order for track/task additions without prescribing one reference file per track.
+- Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
 
@@ -134,6 +137,7 @@ Use "tell them" discipline:
 - Follow the plan unless new evidence proves the plan is wrong.
 - Return a complete file map for every generated artifact that should exist.
 - Include SKILL.md. Add references/ only for routed runtime lookup leaves. Add SPEC.md, EVAL.md, scripts/, assets/, or SOURCES.md only when they add concrete runtime, maintenance, validation, reusable-example, or external-source value.
+- If the outline has many tracks, build the baseline router/shared structure first; later track/task passes may add or refine focused runtime guidance without forcing a track directory.
 - Keep SKILL.md compact; put optional depth in routed references. Do not include authoring/provenance notes unless they describe real external sources or unresolved source gaps that future maintainers need.
 - Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline, build pipeline, or no external research.
 - The externalSources array is only for concrete external sources you actually consulted. Do not count warden.yaml, the internal outline, generated tracks, or the authoring plan as external sources.
@@ -151,6 +155,61 @@ Return JSON:
   "missingInputs": ["Missing input, if any"],
   "externalSources": [
     {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed the skill"}
+  ]
+}
+</instructions>`;
+}
+
+export function buildAuthoringTrackContributionPrompt(args: {
+  outline: SkillBuildOutline;
+  source: SkillBuildSource;
+  authoringSkillRoot: string;
+  targetName: string;
+  targetRootDir: string;
+  plan: GeneratedSkillAuthoringPlan;
+  fileMap: GeneratedSkillFileMap;
+  track: SkillBuildOutline['tracks'][number];
+}): string {
+  return `${contextPacket(args)}
+
+<authoring_plan>
+${JSON.stringify(args.plan, null, 2)}
+</authoring_plan>
+
+<assigned_track>
+${JSON.stringify(args.track, null, 2)}
+</assigned_track>
+
+<current_file_map>
+${JSON.stringify(args.fileMap, null, 2)}
+</current_file_map>
+
+<instructions>
+Add this track/task's contribution to the generated Warden skill.
+
+${wardenSkillConstraints(args)}
+
+Use "now tell them this part" discipline:
+- Use the authoring skill again, starting from its SKILL.md.
+- Treat the assigned track as a work lane. It may map to one reference, multiple references, a shared reference, or no new file.
+- Respect the track's owns/excludes boundaries. Do not duplicate sibling-track material already covered in the current file map.
+- Add or revise the smallest set of files needed for this track. Return only changed or new files, with full file contents.
+- If the current file map already covers this track well, return an empty files array and explain that in validationNotes.
+- Do not create \`references/tracks/\`. If adding references, use lookup-topic paths like \`references/authentication.md\` or \`references/injection.md\`.
+- Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
+- The externalSources array is only for concrete external sources you actually consulted during this task.
+
+Return JSON:
+{
+  "version": 1,
+  "files": [
+    {"path": "references/example.md", "content": "Full changed or new file contents"}
+  ],
+  "summary": "What this task contributed.",
+  "validationNotes": ["Self-check note"],
+  "missingInputs": ["Missing input, if any"],
+  "externalSources": [
+    {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed this contribution"}
   ]
 }
 </instructions>`;
@@ -176,12 +235,12 @@ ${JSON.stringify(args.plan, null, 2)}
 ${JSON.stringify(args.fileMap, null, 2)}
 </generated_file_map>
 
-<deterministic_validation_issues>
+<rough_validation_issues>
 ${JSON.stringify(args.deterministicIssues, null, 2)}
-</deterministic_validation_issues>
+</rough_validation_issues>
 
 <instructions>
-Validate the generated Warden skill.
+Roughly validate the generated Warden skill.
 
 ${wardenSkillConstraints(args)}
 
@@ -189,12 +248,12 @@ Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
 - Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
-- If fixes are needed, return a complete revised file map in files, including every referenced runtime file.
+- If clear fixes are needed, return a complete revised file map in files, including every referenced runtime file.
 - If no fixes are needed, omit files or return an empty files array.
 - Do not return placeholder files or empty file contents. Omit unchanged files instead.
 - Report only issues that remain after any revised files you return.
-- Set valid to true only when the generated or revised files are valid.
-- Treat deterministic validation issues as actionable unless the generated files were revised to fix them.
+- Set valid to false only when the generated or revised files are unusable, not when you disagree with a reasonable layout choice.
+- Treat rough validation issues as advisory signals. Fix concrete broken references or malformed artifacts, but do not hard-block on taste-level layout preferences.
 
 Return JSON:
 {

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -1,13 +1,24 @@
 import type {
   GeneratedSkillAuthoringPlan,
-  GeneratedSkillFileMap,
   GeneratedSkillReviewResult,
+  SkillBuildExternalSource,
 } from './skill-contract.js';
 import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
 
 const GENERIC_SKILL_BUILD_MAX_TURNS = 16;
 const LOCAL_SKILL_BUILD_MAX_TURNS = 24;
 const VALIDATION_MAX_TURNS = 8;
+
+interface GeneratedSkillArtifactSnapshot {
+  summary: string;
+  files: {
+    path: string;
+    content: string;
+  }[];
+  validationNotes: string[];
+  missingInputs: string[];
+  externalSources: SkillBuildExternalSource[];
+}
 
 function sourceBlocks(source: SkillBuildSource): string {
   return source.files
@@ -45,7 +56,8 @@ function wardenSkillConstraints(args: {
 - The target skill root is \`${args.targetRootDir}\`.
 - The generated SKILL.md frontmatter name must be exactly \`${args.targetName}\`.
 - Generated artifacts must be normal Warden skill files. Do not overwrite warden.yaml or build-state.json.
-- Treat existing generated artifacts in the target root as stale unless you intentionally re-emit them in the returned file map.
+- The writer owns disk changes inside the target skill root. Warden will read the files from disk after each writer pass.
+- If a stale generated artifact should not remain, remove it from the target root during the writer pass.
 - Use the source material and internal outline as the source of truth for regeneration.
 - Let the authoring skill decide the simplest adequate artifact layout and where guidance belongs. Warden supplies the goal, source packet, outline, runtime constraints, and quality bar.
 - Treat outline tracks/tasks as work lanes for coverage and sequencing, not as filesystem or artifact taxonomy.
@@ -163,8 +175,8 @@ ${wardenSkillConstraints(args)}
 Authoring behavior:
 - Use the authoring skill again, starting from its SKILL.md.
 - Treat the authoring plan as the source/depth brief. Follow it unless new evidence proves the plan is wrong.
-- Return a complete file map for every generated artifact that should exist according to the authoring skill.
-- Include SKILL.md. Include every local artifact that SKILL.md or another returned artifact requires at runtime.
+- Edit files directly under the target skill root. Do not modify warden.yaml or build-state.json.
+- Write SKILL.md and every local artifact that SKILL.md or another runtime artifact requires.
 - Satisfy the plan's lookupQuestions and qualityBar using the structure chosen by the authoring skill.
 - Treat the outline tracks/tasks as the coverage checklist for this single writer pass. Cover each track's goal, evidence focus, safe counterpatterns, and false-positive traps somewhere useful, or record the missing source/context that prevents that coverage.
 - Preserve track owns/excludes boundaries so sibling topics do not duplicate findings, but merge, split, inline, or reference guidance according to the authoring skill.
@@ -172,15 +184,11 @@ Authoring behavior:
 - Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, outline tracks, the target skill root, local paths, or the authoring plan itself as external sources.
 - For broad domain, ecosystem, or code-review style skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
-- If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
+- If validation later needs a correction, the current target directory should be the complete draft to revise.
 
 Return JSON:
 {
   "version": 1,
-  "name": "${args.targetName}",
-  "files": [
-    {"path": "SKILL.md", "content": "Full file contents"}
-  ],
   "summary": "What was generated.",
   "validationNotes": ["Self-check note"],
   "missingInputs": ["Missing input, if any"],
@@ -198,7 +206,7 @@ export function buildAuthoringValidationPrompt(args: {
   targetName: string;
   targetRootDir: string;
   plan: GeneratedSkillAuthoringPlan;
-  fileMap: GeneratedSkillFileMap;
+  artifact: GeneratedSkillArtifactSnapshot;
   deterministicIssues: string[];
 }): string {
   return `${contextPacket(args)}
@@ -207,9 +215,9 @@ export function buildAuthoringValidationPrompt(args: {
 ${JSON.stringify(args.plan, null, 2)}
 </authoring_plan>
 
-<generated_file_map>
-${JSON.stringify(args.fileMap, null, 2)}
-</generated_file_map>
+<generated_artifacts>
+${JSON.stringify(args.artifact, null, 2)}
+</generated_artifacts>
 
 <rough_validation_issues>
 ${JSON.stringify(args.deterministicIssues, null, 2)}
@@ -222,7 +230,7 @@ ${wardenSkillConstraints(args)}
 
 Review behavior:
 - Use the authoring skill again as the validation anchor.
-- Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
+- Check whether the generated artifacts on disk followed the plan, the authoring skill, and Warden constraints.
 - Check whether each outline track/task is covered with useful runtime guidance, merged into another section/reference with clear coverage, or explicitly recorded as missing input. Do not require one artifact per track.
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
 - Set valid to false for concrete quality failures that need one writer pass: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
@@ -254,7 +262,7 @@ export function buildAuthoringRevisionPrompt(args: {
   targetName: string;
   targetRootDir: string;
   plan: GeneratedSkillAuthoringPlan;
-  fileMap: GeneratedSkillFileMap;
+  artifact: GeneratedSkillArtifactSnapshot;
   review: GeneratedSkillReviewResult;
   deterministicIssues: string[];
 }): string {
@@ -264,9 +272,9 @@ export function buildAuthoringRevisionPrompt(args: {
 ${JSON.stringify(args.plan, null, 2)}
 </authoring_plan>
 
-<current_file_map>
-${JSON.stringify(args.fileMap, null, 2)}
-</current_file_map>
+<current_artifacts>
+${JSON.stringify(args.artifact, null, 2)}
+</current_artifacts>
 
 <standards_review>
 ${JSON.stringify(args.review, null, 2)}
@@ -283,25 +291,21 @@ ${wardenSkillConstraints(args)}
 
 Revision behavior:
 - Use the authoring skill again, starting from its SKILL.md.
-- Treat the current file map as the draft to improve, not as disposable scaffolding.
+- Treat the current target directory as the draft to improve, not as disposable scaffolding.
 - Apply concrete review feedback and rough validation signals when they identify broken references, malformed artifacts, authoring metadata, custom output schemas, or missing runtime guidance.
 - If feedback is only stylistic or conflicts with the authoring skill, keep the existing structure and explain why in validationNotes.
-- Return a complete file map for every generated artifact that should exist after revision.
+- Edit files directly under the target skill root. Do not modify warden.yaml or build-state.json.
 - If review feedback identifies missing local artifacts, either include them with useful runtime content or remove the dependency and record the lost coverage as a missing input. Do not return knowingly broken local links.
 - Keep the simplest adequate layout according to the authoring skill. Do not add artifacts just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good, and make any missing track/task coverage complete in this revision pass.
 - Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
-- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised file map still depends on and add concrete external sources consulted during revision.
+- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised artifacts still depend on and add concrete external sources consulted during revision.
 
 Return JSON:
 {
   "version": 1,
-  "name": "${args.targetName}",
-  "files": [
-    {"path": "SKILL.md", "content": "Full file contents"}
-  ],
   "summary": "What was revised.",
   "validationNotes": ["Self-check note"],
   "missingInputs": ["Missing input, if any"],

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -5,8 +5,7 @@ import type {
 } from './skill-contract.js';
 import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
 
-const GENERIC_SKILL_BUILD_MAX_TURNS = 16;
-const LOCAL_SKILL_BUILD_MAX_TURNS = 24;
+const GENERATED_SKILL_AUTHORING_MAX_TURNS = 80;
 const VALIDATION_MAX_TURNS = 8;
 
 interface GeneratedSkillArtifactSnapshot {
@@ -26,16 +25,8 @@ function sourceBlocks(source: SkillBuildSource): string {
     .join('\n\n');
 }
 
-export function requiresRepoInspection(outline: SkillBuildOutline): boolean {
-  return outline.scopeProfile.localContextUsed ||
-    outline.scopeProfile.kind === 'repository' ||
-    outline.scopeProfile.kind === 'product';
-}
-
-export function defaultBuildMaxTurns(outline: SkillBuildOutline): number {
-  return requiresRepoInspection(outline)
-    ? LOCAL_SKILL_BUILD_MAX_TURNS
-    : GENERIC_SKILL_BUILD_MAX_TURNS;
+export function defaultBuildMaxTurns(): number {
+  return GENERATED_SKILL_AUTHORING_MAX_TURNS;
 }
 
 export function defaultValidationMaxTurns(): number {

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -39,7 +39,7 @@ function wardenSkillConstraints(args: {
 - Generated artifacts must be normal Warden skill files. Do not overwrite warden.yaml or build-state.json.
 - Let the authoring skill choose the artifact shape. Optimize for a usable runtime approach: clear review tasks, routing cues, evidence requirements, and supporting references/scripts/assets only when they help the skill execute.
 - Warden runs skills on changed hunks. Findings must anchor to changed lines and must be concrete enough for Warden's normal report schema.
-- SKILL.md should be the runtime router when references exist. Every runtime reference must have a direct "when to read" route in SKILL.md.
+- SKILL.md should be the runtime router when references exist. Prefer clear "when to read" routes for runtime references, using an index reference when that is simpler than listing every file.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep provenance and authoring decisions in SOURCES.md or SPEC.md, not in runtime references.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -53,14 +53,15 @@ function wardenSkillConstraints(args: {
 - Let the authoring skill decide the simplest adequate artifact layout and where guidance belongs. Warden supplies the goal, source packet, outline, runtime constraints, and quality bar.
 - Treat outline tracks/tasks as work lanes for coverage and sequencing, not as filesystem or artifact taxonomy.
 - The writer and reviewer must handle all track/task coverage in this authoring run. Warden will not run automatic per-track artifact edit passes after the implementation pass.
-- If using references, keep them usable as lookup leaves: each reference should answer a dominant lookup question, have a direct open-when route from SKILL.md, and either stay short enough to scan or include navigation / split into clearer leaves.
+- If using references, keep them usable as lookup leaves: each reference should answer a dominant lookup question, have a direct open-when route from SKILL.md, and either stay short enough to scan or include a "## Contents" section / split into clearer leaves.
 - Treat guidance quality as evidence quality, not file count. Runtime guidance should help the later Warden run decide, verify, and fix issues with concrete evidence, false-positive controls, and remediation patterns where the domain warrants it.
 - Broad domain or ecosystem skills should use source discovery before claiming complete runtime guidance. If source coverage is too thin for the claimed scope, record the gap instead of filling with generic survey text.
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
 - Code-review style skills should include changed-line evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant to the requested domain.
 - Broad domain, ecosystem, or code-review style skills need a balanced source pack for the claimed scope: domain standards or prior art, failure modes, safe counterexamples, language/framework caveats, and remediation patterns, or an explicit blocking gap.
-- Preserve source provenance across passes. Keep external web/upstream sources in externalSources and local/provenance notes in whatever artifact the authoring skill chooses for that purpose.
+- Treat externalSources as the consulted-source ledger. If generating SOURCES.md, list only sources that also appear in externalSources as consulted; put useful but unconsulted source classes in missingInputs or an explicitly labeled gap/candidate section.
+- Do not claim complete source coverage or "no gaps" unless externalSources and missingInputs support that claim.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep authoring decisions, build metadata, internal outline details, validation summaries, and future-work notes out of generated runtime artifacts.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;
@@ -112,7 +113,7 @@ Work like an in-process skill-writer session:
 - Decide what additional research is needed during implementation and what gaps should be recorded before the skill can be considered complete.
 - Decide the ordered track/task coverage plan without turning tracks into layout rules or separate artifact-edit passes.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
-- Include a reference usability bar in qualityBar / validationPlan when the likely shape is reference-backed: references should be focused lookup leaves, not giant mixed catalogs, and long leaves need navigation or a clearer split.
+- Include a reference usability bar in qualityBar / validationPlan when the likely shape is reference-backed: references should be focused lookup leaves, not giant mixed catalogs, and long leaves need a "## Contents" section or a clearer split.
 - For broad domain, ecosystem, or code-review style skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards or prior art, failure-mode examples, safe counterexamples, language or framework docs, and remediation examples.
 - Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
@@ -177,6 +178,7 @@ Authoring behavior:
 - Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
 - Before finishing, run a reference usability self-check: every reference has a direct route, one dominant lookup need, and enough navigation or segmentation that the runtime agent can open only the relevant material. Split mixed references or add navigation when a leaf becomes hard to scan.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, outline tracks, the target skill root, local paths, or the authoring plan itself as external sources.
+- SOURCES.md is optional. If you create it, keep consulted-source claims aligned with externalSources. Do not list generic documentation buckets as consulted provenance unless you actually consulted and return a concrete source URL for them; record unconsulted but needed source classes as gaps instead.
 - For broad domain, ecosystem, or code-review style skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
 - If validation later needs a correction, the current target directory should be the complete draft to revise.
 
@@ -229,8 +231,9 @@ Review behavior:
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
 - Set valid to false for concrete quality failures that need a writer revision: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
 - Set valid to false when a track/task is represented only by a heading, topic name, or route entry without the evidence focus, safe counterpatterns, false-positive controls, and remediation guidance needed for runtime use.
-- Set valid to false when reference-backed output uses oversized, mixed-purpose, or unnavigable references. This is runtime usability, not a taste-level layout preference. Accept any layout that stays focused and navigable; do not require one reference per topic.
+- Set valid to false when reference-backed output uses oversized, mixed-purpose, or unnavigable references. This is runtime usability, not a taste-level layout preference. Accept any layout that stays focused and navigable; do not require one reference per topic. References over roughly 100 lines should have a "## Contents" section or be split when they contain multiple lookup needs.
 - Set valid to false when the skill claims broad domain coverage but the source base is too thin for that claim. Classification-only sources, a handful of generic sources, or provenance that omits failure-mode, safe-counterexample, and remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
+- Set valid to false when SOURCES.md claims sources were consulted but those sources do not appear in externalSources, or when it claims no source gaps despite thin or generic provenance.
 - Set valid to false for any missing local artifact needed by returned runtime guidance. That is a mechanical runnability failure, not a stylistic layout preference.
 - Do not rewrite files in this review pass. Give concrete feedback; a bounded writer revision round will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
@@ -297,6 +300,7 @@ Revision behavior:
 - Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
 - Fix oversized, mixed-purpose, or unnavigable references by adding concise navigation, splitting by lookup need, or moving short universal guidance back inline. Preserve layout freedom; the goal is runtime usability, not a required file count.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
+- Fix source-provenance overclaims by removing unsupported consulted-source claims, moving unconsulted sources to missingInputs or an explicit candidate/gap section, or returning concrete externalSources for sources actually consulted.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised artifacts still depend on and add concrete external sources consulted during revision.
 

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -55,6 +55,8 @@ function wardenSkillConstraints(args: {
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
 - Security-review skills should include exploit-path evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant.
+- Broad security-review skills need a balanced source pack: taxonomy standards are not enough. Use source discovery to cover exploit behavior, safe counterexamples, language/framework caveats, and remediation patterns across the claimed scope, or record the missing source coverage as a blocking quality gap.
+- Preserve source provenance across passes. If the skill depends on an outline source, prior source decision, or newly consulted source, keep external web/upstream sources in externalSources and local/provenance notes in SOURCES.md so the final artifact can explain its evidence base.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep authoring decisions, build metadata, internal outline details, validation summaries, and future-work notes out of generated runtime artifacts.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;
@@ -105,6 +107,8 @@ Work like an in-process skill-writer session:
 - Decide the sequential task order for track/task additions without prescribing one reference file per track.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
 - For every planned routed reference, define the lookup question, when to open it, and the evidence it must contain before it is useful.
+- For broad security skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards/taxonomy, exploit examples, safe counterexamples, language or framework docs, and remediation examples.
+- Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
 
@@ -161,12 +165,14 @@ Use "tell them" discipline:
 - Treat the authoring plan as the source/depth brief. Follow it unless new evidence proves the plan is wrong.
 - Return a complete file map for every generated artifact that should exist.
 - Include SKILL.md. Add references/ only for routed runtime lookup leaves. Add SPEC.md, EVAL.md, scripts/, assets/, or SOURCES.md only when they add concrete runtime, maintenance, validation, reusable-example, or external-source value.
+- If SKILL.md routes to a local file, include that file in the same file map. Do not emit a router that points at absent references.
 - If the outline has many tracks, build the baseline router/shared structure first; later track/task passes may add or refine focused runtime guidance without forcing a track directory.
 - Keep SKILL.md compact; put optional depth in routed references. Do not include authoring/provenance notes unless they describe real external sources or unresolved source gaps that future maintainers need.
 - Satisfy the plan's lookupQuestions and qualityBar. If a lookup question is too broad for one reference, split by lookup need. If it is too small for a reference, keep it inline.
 - Do not ship catalog-only references. A routed reference should help the runtime agent decide, do, or verify: exploit path or task path, false-positive controls, and remediation/example material where useful.
 - Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline, build pipeline, or no external research.
-- The externalSources array is only for concrete external sources you actually consulted. Do not count warden.yaml, the internal outline, generated tracks, or the authoring plan as external sources.
+- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, generated tracks, the target skill root, local paths, or the authoring plan itself as external sources.
+- For broad security-review skills, do not present a complete multi-language skill from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
 
 Return JSON:
@@ -221,10 +227,12 @@ Use "now tell them this part" discipline:
 - Respect the track's owns/excludes boundaries. Do not duplicate sibling-track material already covered in the current file map.
 - Add or revise the smallest set of files needed for this track. Return only changed or new files, with full file contents.
 - If the current file map already covers this track well, return an empty files array and explain exactly where the current files satisfy the track's required evidence. Topic names or sink catalogs alone do not count as coverage.
+- A compact SKILL.md taxonomy or routing table does not count as full coverage for a broad security track unless the required evidence, false-positive controls, and remediation guidance are present inline.
+- If the current file map routes this track to a missing local reference, return that reference file or revise the routing. Do not leave broken routes for the reviewer to discover.
 - Do not create \`references/tracks/\`. If adding references, use lookup-topic paths like \`references/authentication.md\` or \`references/injection.md\`.
 - Deepen weak shared references instead of adding a sibling file when the problem is missing exploit evidence, safe lookalikes, or remediation detail.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
-- The externalSources array is only for concrete external sources you actually consulted during this task.
+- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the current file map still depends on and add concrete external sources consulted during this task.
 
 Return JSON:
 {
@@ -276,6 +284,8 @@ Use "remind them what you told them" discipline:
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
 - Check for over-broad topic-bucket references, catalog-only references, missing source depth, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
 - Set valid to false for concrete quality failures that need one writer pass: a routed reference that lacks a lookup question, missing exploit/task evidence, missing false-positive controls for a risky domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, or a long reference that needs navigation or splitting by lookup need.
+- Set valid to false when the skill claims broad security coverage but the source base is too thin for that claim. Taxonomy-only sources, a handful of generic sources, or provenance that omits exploit/safe-counterexample/remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
+- Set valid to false for any missing routed local file. That is a mechanical runnability failure, not a stylistic layout preference.
 - Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
 - Set valid to false only when a concrete issue should trigger revision, not when you disagree with a reasonable layout choice.
@@ -334,11 +344,13 @@ Use "tell them again, but cleaner" discipline:
 - Apply concrete review feedback and rough validation signals when they identify broken references, malformed artifacts, authoring metadata, custom output schemas, or missing runtime guidance.
 - If feedback is only stylistic or conflicts with the authoring skill, keep the existing structure and explain why in validationNotes.
 - Return a complete file map for every generated artifact that should exist after revision.
+- If review feedback identifies missing routed files, either include those files with useful runtime content or remove the routes and record the lost coverage as a missing input. Do not return a knowingly broken router.
 - Keep the simplest adequate layout. Do not add references just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good.
 - Fix shallow or catalog-only references by adding targeted evidence and examples, splitting by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
+- Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
-- The externalSources array is only for concrete external sources you actually consulted during revision.
+- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised file map still depends on and add concrete external sources consulted during revision.
 
 Return JSON:
 {

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -37,26 +37,21 @@ function wardenSkillConstraints(args: {
   authoringSkillRoot: string;
 }): string {
   return `Warden generated-skill constraints:
-- Use the full authoring skill at \`${args.authoringSkillRoot}\` as the authoring method. Start by reading its SKILL.md and follow its own routing. Do not rely on a hand-picked subset of its references.
+- Use the full authoring skill at \`${args.authoringSkillRoot}\` as the authoring method. Start by reading its SKILL.md and follow its own routing.
 - The target skill root is \`${args.targetRootDir}\`.
 - The generated SKILL.md frontmatter name must be exactly \`${args.targetName}\`.
 - Generated artifacts must be normal Warden skill files. Do not overwrite warden.yaml or build-state.json.
 - Treat existing generated artifacts in the target root as stale unless you intentionally re-emit them in the returned file map.
 - Use the source material and internal outline as the source of truth for regeneration.
-- Choose the simplest adequate layout using the authoring skill's rules. Do not add files just to satisfy a template.
-- Tracks/tasks are planning work lanes, not filesystem taxonomy. Do not create \`references/tracks/\`; use \`references/<lookup-topic>.md\`, shared references, or inline guidance according to the authoring skill.
-- Broad or multi-track skills often need SKILL.md as a compact router plus focused routed references. Inline, shared-reference, one-reference-per-track, many-references-per-track, and fewer-references-than-tracks layouts are all valid when they fit the authoring skill.
-- References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
-- Treat reference quality as evidence quality, not file count. Each routed runtime reference should have a clear "open when" reason plus concrete checks, required evidence, safe lookalikes or false-positive suppressors, and patch-shaped remediation or examples when the domain warrants it.
-- Sink/API catalogs are supporting tables only. Do not make a reference that is mostly a broad catalog unless it also teaches how to prove exploitability, suppress false positives, and fix the issue.
-- Broad domain or ecosystem skills should use source discovery before writing deep runtime guidance. If no concrete sources or local examples were consulted, record that as a quality risk or missing input rather than filling gaps with generic survey text.
-- Use SPEC.md for new or materially scoped generated skills when it records a useful scope, evidence model, or maintenance contract.
-- Use SOURCES.md only when concrete external sources were consulted or unresolved source gaps materially affect future maintenance. Do not create SOURCES.md just to restate warden.yaml, the internal outline, build pipeline, authoring decisions, or "no external research".
+- Let the authoring skill decide the simplest adequate artifact layout and where guidance belongs. Warden supplies the goal, source packet, outline, runtime constraints, and quality bar.
+- Treat outline tracks/tasks as work lanes for coverage and sequencing, not as filesystem or artifact taxonomy.
+- Treat guidance quality as evidence quality, not file count. Runtime guidance should help the later Warden run decide, verify, and fix issues with concrete evidence, false-positive controls, and remediation patterns where the domain warrants it.
+- Broad domain or ecosystem skills should use source discovery before claiming complete runtime guidance. If source coverage is too thin for the claimed scope, record the gap instead of filling with generic survey text.
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
 - Security-review skills should include exploit-path evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant.
-- Broad security-review skills need a balanced source pack: taxonomy standards are not enough. Use source discovery to cover exploit behavior, safe counterexamples, language/framework caveats, and remediation patterns across the claimed scope, or record the missing source coverage as a blocking quality gap.
-- Preserve source provenance across passes. If the skill depends on an outline source, prior source decision, or newly consulted source, keep external web/upstream sources in externalSources and local/provenance notes in SOURCES.md so the final artifact can explain its evidence base.
+- Broad security-review skills need a balanced source pack: taxonomy standards, exploit behavior, safe counterexamples, language/framework caveats, and remediation patterns across the claimed scope, or an explicit blocking gap.
+- Preserve source provenance across passes. Keep external web/upstream sources in externalSources and local/provenance notes in whatever artifact the authoring skill chooses for that purpose.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep authoring decisions, build metadata, internal outline details, validation summaries, and future-work notes out of generated runtime artifacts.
 - Do not send repository code, secrets, private paths, or proprietary details to web tools.`;
@@ -100,13 +95,11 @@ ${wardenSkillConstraints(args)}
 Work like an in-process skill-writer session:
 - Read and use the authoring skill.
 - Build the authoring brief first: goal, runtime use, depth bar, sources or source gaps, and the kind of evidence the final skill must carry.
-- Decide the minimum workflow path and simplest adequate artifact layout.
-- Do the first research and source-inspection pass yourself. Use that to identify the work lanes, larger plan, and obvious non-overlap boundaries.
-- Decide what additional research is needed during implementation and what gaps should be recorded.
-- Decide where runtime guidance, references, provenance, and maintenance contract belong by lookup question, not by track name.
-- Decide the sequential task order for track/task additions without prescribing one reference file per track.
+- Decide the minimum skill-writer workflow path and artifact layout using the authoring skill's own guidance.
+- Do the first research and source-inspection pass yourself. Use that to identify the larger plan, coverage work lanes, and obvious non-overlap boundaries.
+- Decide what additional research is needed during implementation and what gaps should be recorded before the skill can be considered complete.
+- Decide the sequential task order for track/task additions without turning tracks into layout rules.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
-- For every planned routed reference, define the lookup question, when to open it, and the evidence it must contain before it is useful.
 - For broad security skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards/taxonomy, exploit examples, safe counterexamples, language or framework docs, and remediation examples.
 - Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
@@ -160,17 +153,13 @@ Create or update the generated Warden skill artifacts.
 
 ${wardenSkillConstraints(args)}
 
-Use "tell them" discipline:
+Authoring behavior:
 - Use the authoring skill again, starting from its SKILL.md.
 - Treat the authoring plan as the source/depth brief. Follow it unless new evidence proves the plan is wrong.
-- Return a complete file map for every generated artifact that should exist.
-- Include SKILL.md. Add references/ only for routed runtime lookup leaves. Add SPEC.md, EVAL.md, scripts/, assets/, or SOURCES.md only when they add concrete runtime, maintenance, validation, reusable-example, or external-source value.
-- If SKILL.md routes to a local file, include that file in the same file map. Do not emit a router that points at absent references.
-- If the outline has many tracks, build the baseline router/shared structure first; later track/task passes may add or refine focused runtime guidance without forcing a track directory.
-- Keep SKILL.md compact; put optional depth in routed references. Do not include authoring/provenance notes unless they describe real external sources or unresolved source gaps that future maintainers need.
-- Satisfy the plan's lookupQuestions and qualityBar. If a lookup question is too broad for one reference, split by lookup need. If it is too small for a reference, keep it inline.
-- Do not ship catalog-only references. A routed reference should help the runtime agent decide, do, or verify: exploit path or task path, false-positive controls, and remediation/example material where useful.
-- Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline, build pipeline, or no external research.
+- Return a complete file map for every generated artifact that should exist according to the authoring skill.
+- Include SKILL.md. Include every local artifact that SKILL.md or another returned artifact requires at runtime.
+- Satisfy the plan's lookupQuestions and qualityBar using the structure chosen by the authoring skill.
+- Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, generated tracks, the target skill root, local paths, or the authoring plan itself as external sources.
 - For broad security-review skills, do not present a complete multi-language skill from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
@@ -221,16 +210,15 @@ Add this track/task's contribution to the generated Warden skill.
 
 ${wardenSkillConstraints(args)}
 
-Use "now tell them this part" discipline:
+Contribution behavior:
 - Use the authoring skill again, starting from its SKILL.md.
-- Treat the assigned track as a work lane. It may map to one reference, multiple references, a shared reference, or no new file.
+- Treat the assigned track as a bounded coverage work lane. Let the authoring skill decide where any resulting guidance belongs.
 - Respect the track's owns/excludes boundaries. Do not duplicate sibling-track material already covered in the current file map.
 - Add or revise the smallest set of files needed for this track. Return only changed or new files, with full file contents.
 - If the current file map already covers this track well, return an empty files array and explain exactly where the current files satisfy the track's required evidence. Topic names or sink catalogs alone do not count as coverage.
 - A compact SKILL.md taxonomy or routing table does not count as full coverage for a broad security track unless the required evidence, false-positive controls, and remediation guidance are present inline.
 - If the current file map routes this track to a missing local reference, return that reference file or revise the routing. Do not leave broken routes for the reviewer to discover.
-- Do not create \`references/tracks/\`. If adding references, use lookup-topic paths like \`references/authentication.md\` or \`references/injection.md\`.
-- Deepen weak shared references instead of adding a sibling file when the problem is missing exploit evidence, safe lookalikes, or remediation detail.
+- Prefer deepening the existing chosen structure over adding parallel artifacts when the problem is missing exploit evidence, safe lookalikes, or remediation detail.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the current file map still depends on and add concrete external sources consulted during this task.
 
@@ -279,13 +267,13 @@ Review the generated Warden skill and return standards feedback only.
 
 ${wardenSkillConstraints(args)}
 
-Use "remind them what you told them" discipline:
+Review behavior:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
-- Check for over-broad topic-bucket references, catalog-only references, missing source depth, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
-- Set valid to false for concrete quality failures that need one writer pass: a routed reference that lacks a lookup question, missing exploit/task evidence, missing false-positive controls for a risky domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, or a long reference that needs navigation or splitting by lookup need.
+- Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
+- Set valid to false for concrete quality failures that need one writer pass: missing exploit/task evidence, missing false-positive controls for a risky domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
 - Set valid to false when the skill claims broad security coverage but the source base is too thin for that claim. Taxonomy-only sources, a handful of generic sources, or provenance that omits exploit/safe-counterexample/remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
-- Set valid to false for any missing routed local file. That is a mechanical runnability failure, not a stylistic layout preference.
+- Set valid to false for any missing local artifact needed by returned runtime guidance. That is a mechanical runnability failure, not a stylistic layout preference.
 - Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
 - Set valid to false only when a concrete issue should trigger revision, not when you disagree with a reasonable layout choice.
@@ -338,16 +326,16 @@ Revise the generated Warden skill artifacts from standards-review feedback.
 
 ${wardenSkillConstraints(args)}
 
-Use "tell them again, but cleaner" discipline:
+Revision behavior:
 - Use the authoring skill again, starting from its SKILL.md.
 - Treat the current file map as the draft to improve, not as disposable scaffolding.
 - Apply concrete review feedback and rough validation signals when they identify broken references, malformed artifacts, authoring metadata, custom output schemas, or missing runtime guidance.
 - If feedback is only stylistic or conflicts with the authoring skill, keep the existing structure and explain why in validationNotes.
 - Return a complete file map for every generated artifact that should exist after revision.
-- If review feedback identifies missing routed files, either include those files with useful runtime content or remove the routes and record the lost coverage as a missing input. Do not return a knowingly broken router.
-- Keep the simplest adequate layout. Do not add references just to mirror tracks/tasks.
+- If review feedback identifies missing local artifacts, either include them with useful runtime content or remove the dependency and record the lost coverage as a missing input. Do not return knowingly broken local links.
+- Keep the simplest adequate layout according to the authoring skill. Do not add artifacts just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good.
-- Fix shallow or catalog-only references by adding targeted evidence and examples, splitting by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
+- Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised file map still depends on and add concrete external sources consulted during revision.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -47,6 +47,9 @@ function wardenSkillConstraints(args: {
 - Tracks/tasks are planning work lanes, not filesystem taxonomy. Do not create \`references/tracks/\`; use \`references/<lookup-topic>.md\`, shared references, or inline guidance according to the authoring skill.
 - Broad or multi-track skills often need SKILL.md as a compact router plus focused routed references. Inline, shared-reference, one-reference-per-track, many-references-per-track, and fewer-references-than-tracks layouts are all valid when they fit the authoring skill.
 - References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
+- Treat reference quality as evidence quality, not file count. Each routed runtime reference should have a clear "open when" reason plus concrete checks, required evidence, safe lookalikes or false-positive suppressors, and patch-shaped remediation or examples when the domain warrants it.
+- Sink/API catalogs are supporting tables only. Do not make a reference that is mostly a broad catalog unless it also teaches how to prove exploitability, suppress false positives, and fix the issue.
+- Broad domain or ecosystem skills should use source discovery before writing deep runtime guidance. If no concrete sources or local examples were consulted, record that as a quality risk or missing input rather than filling gaps with generic survey text.
 - Use SPEC.md for new or materially scoped generated skills when it records a useful scope, evidence model, or maintenance contract.
 - Use SOURCES.md only when concrete external sources were consulted or unresolved source gaps materially affect future maintenance. Do not create SOURCES.md just to restate warden.yaml, the internal outline, build pipeline, authoring decisions, or "no external research".
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
@@ -92,14 +95,16 @@ Plan one generated Warden skill authoring run.
 
 ${wardenSkillConstraints(args)}
 
-Use "tell them what you are going to tell them" discipline:
+Work like an in-process skill-writer session:
 - Read and use the authoring skill.
+- Build the authoring brief first: goal, runtime use, depth bar, sources or source gaps, and the kind of evidence the final skill must carry.
 - Decide the minimum workflow path and simplest adequate artifact layout.
 - Do the first research and source-inspection pass yourself. Use that to identify the work lanes, larger plan, and obvious non-overlap boundaries.
 - Decide what additional research is needed during implementation and what gaps should be recorded.
-- Decide where runtime guidance, references, provenance, and maintenance contract belong.
+- Decide where runtime guidance, references, provenance, and maintenance contract belong by lookup question, not by track name.
 - Decide the sequential task order for track/task additions without prescribing one reference file per track.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
+- For every planned routed reference, define the lookup question, when to open it, and the evidence it must contain before it is useful.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
 
@@ -109,10 +114,25 @@ Return JSON:
   "summary": "Short authoring plan summary.",
   "workflow": ["Ordered workflow step"],
   "researchPlan": ["Research or inspection step"],
+  "sourceDecisions": [
+    {"source": "Source or inspected context", "decision": "Decision made from it", "implication": "How it changes the final skill"}
+  ],
+  "lookupQuestions": [
+    {
+      "question": "Lookup question the reference or inline section must answer",
+      "openWhen": "When the runtime agent should open or use it",
+      "requiredEvidence": ["Evidence or example this lookup must include"],
+      "candidatePaths": ["references/example.md"]
+    }
+  ],
+  "qualityBar": ["Concrete depth requirement for the writer and reviewer"],
   "artifactPlan": ["Expected artifact or layout decision"],
   "validationPlan": ["Validation step"],
   "risks": ["Known risk"],
-  "missingInputs": ["Missing input, if any"]
+  "missingInputs": ["Missing input, if any"],
+  "externalSources": [
+    {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed the plan"}
+  ]
 }
 </instructions>`;
 }
@@ -138,11 +158,13 @@ ${wardenSkillConstraints(args)}
 
 Use "tell them" discipline:
 - Use the authoring skill again, starting from its SKILL.md.
-- Follow the plan unless new evidence proves the plan is wrong.
+- Treat the authoring plan as the source/depth brief. Follow it unless new evidence proves the plan is wrong.
 - Return a complete file map for every generated artifact that should exist.
 - Include SKILL.md. Add references/ only for routed runtime lookup leaves. Add SPEC.md, EVAL.md, scripts/, assets/, or SOURCES.md only when they add concrete runtime, maintenance, validation, reusable-example, or external-source value.
 - If the outline has many tracks, build the baseline router/shared structure first; later track/task passes may add or refine focused runtime guidance without forcing a track directory.
 - Keep SKILL.md compact; put optional depth in routed references. Do not include authoring/provenance notes unless they describe real external sources or unresolved source gaps that future maintainers need.
+- Satisfy the plan's lookupQuestions and qualityBar. If a lookup question is too broad for one reference, split by lookup need. If it is too small for a reference, keep it inline.
+- Do not ship catalog-only references. A routed reference should help the runtime agent decide, do, or verify: exploit path or task path, false-positive controls, and remediation/example material where useful.
 - Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline, build pipeline, or no external research.
 - The externalSources array is only for concrete external sources you actually consulted. Do not count warden.yaml, the internal outline, generated tracks, or the authoring plan as external sources.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
@@ -198,8 +220,9 @@ Use "now tell them this part" discipline:
 - Treat the assigned track as a work lane. It may map to one reference, multiple references, a shared reference, or no new file.
 - Respect the track's owns/excludes boundaries. Do not duplicate sibling-track material already covered in the current file map.
 - Add or revise the smallest set of files needed for this track. Return only changed or new files, with full file contents.
-- If the current file map already covers this track well, return an empty files array and explain that in validationNotes.
+- If the current file map already covers this track well, return an empty files array and explain exactly where the current files satisfy the track's required evidence. Topic names or sink catalogs alone do not count as coverage.
 - Do not create \`references/tracks/\`. If adding references, use lookup-topic paths like \`references/authentication.md\` or \`references/injection.md\`.
+- Deepen weak shared references instead of adding a sibling file when the problem is missing exploit evidence, safe lookalikes, or remediation detail.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is only for concrete external sources you actually consulted during this task.
 
@@ -251,7 +274,8 @@ ${wardenSkillConstraints(args)}
 Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
-- Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
+- Check for over-broad topic-bucket references, catalog-only references, missing source depth, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
+- Set valid to false for concrete quality failures that need one writer pass: a routed reference that lacks a lookup question, missing exploit/task evidence, missing false-positive controls for a risky domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, or a long reference that needs navigation or splitting by lookup need.
 - Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
 - Set valid to false only when a concrete issue should trigger revision, not when you disagree with a reasonable layout choice.
@@ -312,6 +336,7 @@ Use "tell them again, but cleaner" discipline:
 - Return a complete file map for every generated artifact that should exist after revision.
 - Keep the simplest adequate layout. Do not add references just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good.
+- Fix shallow or catalog-only references by adding targeted evidence and examples, splitting by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is only for concrete external sources you actually consulted during revision.
 

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -37,6 +37,8 @@ function wardenSkillConstraints(args: {
 - The target skill root is \`${args.targetRootDir}\`.
 - The generated SKILL.md frontmatter name must be exactly \`${args.targetName}\`.
 - Generated artifacts must be normal Warden skill files. Do not overwrite warden.yaml or build-state.json.
+- Treat existing generated artifacts in the target root as stale unless you intentionally re-emit them in the returned file map.
+- Use the source material and internal outline as the source of truth for regeneration.
 - Choose the simplest adequate layout using the authoring skill's rules. Do not add files just to satisfy a template.
 - Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references. Inline or single-reference layouts are fine when they are genuinely enough.
 - References should answer one lookup question each. Avoid topic-bucket references that mix routing, examples, troubleshooting, source notes, and remediation.
@@ -185,8 +187,9 @@ Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
 - Check for over-broad topic-bucket references, stale gap/provenance language, missing routes, and custom output formats that conflict with Warden's JSON finding schema.
-- If fixes are needed, return a complete revised file map in files.
+- If fixes are needed, return a complete revised file map in files, including every referenced runtime file.
 - If no fixes are needed, omit files or return an empty files array.
+- Do not return placeholder files or empty file contents. Omit unchanged files instead.
 - Report only issues that remain after any revised files you return.
 - Set valid to true only when the generated or revised files are valid.
 - Treat deterministic validation issues as actionable unless the generated files were revised to fix them.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -59,8 +59,9 @@ function wardenSkillConstraints(args: {
 - Broad domain or ecosystem skills should use source discovery before claiming complete runtime guidance. If source coverage is too thin for the claimed scope, record the gap instead of filling with generic survey text.
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
-- Code-review style skills should include changed-line evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant to the requested domain.
-- Broad domain, ecosystem, or code-review style skills need a balanced source pack for the claimed scope: domain standards or prior art, failure modes, safe counterexamples, language/framework caveats, and remediation patterns, or an explicit blocking gap.
+- Every generated skill is a Warden review skill. It needs a finding proof model: changed-line evidence, boundary or invariant, source or cause, sink or operation, missing guard, impact, and fix.
+- Include domain-specific exclusions, safe lookalikes, false-positive controls, remediation examples, and severity/confidence calibration where relevant.
+- Broad skills need a balanced source pack for the claimed scope: standards or prior art, failure modes, safe counterexamples, language/framework caveats, and remediation patterns, or an explicit blocking gap.
 - Treat externalSources as the consulted-source ledger. If generating SOURCES.md, list only sources that also appear in externalSources as consulted; put useful but unconsulted source classes in missingInputs or an explicitly labeled gap/candidate section.
 - Do not claim complete source coverage or "no gaps" unless externalSources and missingInputs support that claim.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
@@ -141,7 +142,8 @@ Work like an in-process skill-writer session:
 - Decide the ordered track/task coverage plan without turning tracks into layout rules or separate artifact-edit passes.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
 - Include a reference usability bar in qualityBar / validationPlan when the likely shape is reference-backed: references should be focused lookup leaves, not giant mixed catalogs, and long leaves need a "## Contents" section or a clearer split.
-- For broad domain, ecosystem, or code-review style skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards or prior art, failure-mode examples, safe counterexamples, language or framework docs, and remediation examples.
+- Define the finding proof model the runtime agent must satisfy before reporting, plus exclusions and false-positive controls that suppress weak findings.
+- For broad skills, define source coverage needed before completion. Include source classes, not just source names: standards or prior art, failure-mode examples, safe counterexamples, language or framework docs, and remediation examples.
 - Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
@@ -208,10 +210,11 @@ Authoring behavior:
 - Preserve track owns/excludes boundaries so sibling topics do not duplicate findings, but merge, split, inline, or reference guidance according to the authoring skill.
 - Do not produce shallow placeholders on the assumption that later per-track passes will deepen them; no automatic track contribution passes will run.
 - Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
+- Include compact runtime guidance for proving a finding and deciding not to report. Add selective bad/safe examples when concrete code or config patterns are central.
 - Before finishing, run a reference usability self-check: every reference has a direct route, one dominant lookup need, and enough navigation or segmentation that the runtime agent can open only the relevant material. Split mixed references or add navigation when a leaf becomes hard to scan.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, outline tracks, the target skill root, local paths, or the authoring plan itself as external sources.
 - SOURCES.md is optional. If you create it, keep consulted-source claims aligned with externalSources. Do not list generic documentation buckets as consulted provenance unless you actually consulted and return a concrete source URL for them; record unconsulted but needed source classes as gaps instead.
-- For broad domain, ecosystem, or code-review style skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
+- For broad skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources or mark the gap in missingInputs.
 - If validation later needs a correction, the current target directory should be the complete draft to revise.
 
 Return JSON:
@@ -268,6 +271,7 @@ Review behavior:
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
 - Set valid to false for concrete quality failures that need a writer revision: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
 - Set valid to false when a track/task is represented only by a heading, topic name, or route entry without the evidence focus, safe counterpatterns, false-positive controls, and remediation guidance needed for runtime use.
+- Set valid to false when findings can be reported from category names or pattern hits alone. Require the proof model, exclusions, impact calibration, and fix guidance.
 - Set valid to false when reference-backed output uses oversized, mixed-purpose, or unnavigable references. This is runtime usability, not a taste-level layout preference. Accept any layout that stays focused and navigable; do not require one reference per topic. References over roughly 100 lines should have a "## Contents" section or be split when they contain multiple lookup needs.
 - Set valid to false when the skill claims broad domain coverage but the source base is too thin for that claim. Classification-only sources, a handful of generic sources, or provenance that omits failure-mode, safe-counterexample, and remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
 - Set valid to false when SOURCES.md claims sources were consulted but those sources do not appear in externalSources, or when it claims no source gaps despite thin or generic provenance.
@@ -340,6 +344,7 @@ Revision behavior:
 - Keep the simplest adequate layout according to the authoring skill. Do not add artifacts just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good, and make any missing track/task coverage complete in this revision pass.
 - Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
+- Fix proof-model gaps by adding the smallest adequate evidence chain, exclusions, false-positive controls, impact calibration, and fix guidance.
 - Fix oversized, mixed-purpose, or unnavigable references by adding concise navigation, splitting by lookup need, or moving short universal guidance back inline. Preserve layout freedom; the goal is runtime usability, not a required file count.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Fix source-provenance overclaims by removing unsupported consulted-source claims, moving unconsulted sources to missingInputs or an explicit candidate/gap section, or returning concrete externalSources for sources actually consulted.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -31,6 +31,10 @@ export function defaultValidationMaxTurns(): number {
   return VALIDATION_MAX_TURNS;
 }
 
+// Keep this wrapper contract narrow. Warden owns the generated skill goal,
+// runtime constraints, source-depth expectations, sequential coverage work,
+// and the qualitative review bar. The authoring skill owns layout, routing,
+// reference naming, and other skill-writer doctrine.
 function wardenSkillConstraints(args: {
   targetName: string;
   targetRootDir: string;
@@ -61,6 +65,9 @@ function contextPacket(args: {
   outline: SkillBuildOutline;
   source: SkillBuildSource;
 }): string {
+  // The outline is planning context: topics, tasks, source signals, and
+  // non-overlap boundaries. It is not a runnable skill and does not prescribe
+  // the final artifact tree.
   return `<source_material>
 ${sourceBlocks(args.source)}
 </source_material>

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -31,10 +31,10 @@ export function defaultValidationMaxTurns(): number {
   return VALIDATION_MAX_TURNS;
 }
 
-// Keep this wrapper contract narrow. Warden owns the generated skill goal,
-// runtime constraints, source-depth expectations, sequential coverage work,
-// and the qualitative review bar. The authoring skill owns layout, routing,
-// reference naming, and other skill-writer doctrine.
+// Keep this wrapper contract narrow and domain-agnostic. Warden owns the
+// generated skill goal, runtime constraints, source-depth expectations,
+// ordered coverage work, and qualitative review bar. The authoring skill owns
+// layout, routing, reference naming, and other skill-writer doctrine.
 function wardenSkillConstraints(args: {
   targetName: string;
   targetRootDir: string;
@@ -49,12 +49,13 @@ function wardenSkillConstraints(args: {
 - Use the source material and internal outline as the source of truth for regeneration.
 - Let the authoring skill decide the simplest adequate artifact layout and where guidance belongs. Warden supplies the goal, source packet, outline, runtime constraints, and quality bar.
 - Treat outline tracks/tasks as work lanes for coverage and sequencing, not as filesystem or artifact taxonomy.
+- The writer and reviewer must handle all track/task coverage in this authoring run. Warden will not run automatic per-track artifact edit passes after the implementation pass.
 - Treat guidance quality as evidence quality, not file count. Runtime guidance should help the later Warden run decide, verify, and fix issues with concrete evidence, false-positive controls, and remediation patterns where the domain warrants it.
 - Broad domain or ecosystem skills should use source discovery before claiming complete runtime guidance. If source coverage is too thin for the claimed scope, record the gap instead of filling with generic survey text.
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
 - Findings must anchor to changed lines and be concrete enough for Warden's normal report schema.
-- Security-review skills should include exploit-path evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant.
-- Broad security-review skills need a balanced source pack: taxonomy standards, exploit behavior, safe counterexamples, language/framework caveats, and remediation patterns across the claimed scope, or an explicit blocking gap.
+- Code-review style skills should include changed-line evidence, safe lookalikes or false-positive controls, remediation examples, and severity/confidence calibration where relevant to the requested domain.
+- Broad domain, ecosystem, or code-review style skills need a balanced source pack for the claimed scope: domain standards or prior art, failure modes, safe counterexamples, language/framework caveats, and remediation patterns, or an explicit blocking gap.
 - Preserve source provenance across passes. Keep external web/upstream sources in externalSources and local/provenance notes in whatever artifact the authoring skill chooses for that purpose.
 - Use Warden voice: brief, dry, direct. Avoid generated-artifact boilerplate such as "Generated Warden skill for outline".
 - Keep authoring decisions, build metadata, internal outline details, validation summaries, and future-work notes out of generated runtime artifacts.
@@ -105,9 +106,9 @@ Work like an in-process skill-writer session:
 - Decide the minimum skill-writer workflow path and artifact layout using the authoring skill's own guidance.
 - Do the first research and source-inspection pass yourself. Use that to identify the larger plan, coverage work lanes, and obvious non-overlap boundaries.
 - Decide what additional research is needed during implementation and what gaps should be recorded before the skill can be considered complete.
-- Decide the sequential task order for track/task additions without turning tracks into layout rules.
+- Decide the ordered track/task coverage plan without turning tracks into layout rules or separate artifact-edit passes.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
-- For broad security skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards/taxonomy, exploit examples, safe counterexamples, language or framework docs, and remediation examples.
+- For broad domain, ecosystem, or code-review style skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards or prior art, failure-mode examples, safe counterexamples, language or framework docs, and remediation examples.
 - Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
 The internal outline is supporting context only. If it conflicts with the source material or authoring skill, say how the implementation should resolve that in the plan.
@@ -165,9 +166,12 @@ Authoring behavior:
 - Return a complete file map for every generated artifact that should exist according to the authoring skill.
 - Include SKILL.md. Include every local artifact that SKILL.md or another returned artifact requires at runtime.
 - Satisfy the plan's lookupQuestions and qualityBar using the structure chosen by the authoring skill.
+- Treat the outline tracks/tasks as the coverage checklist for this single writer pass. Cover each track's goal, evidence focus, safe counterpatterns, and false-positive traps somewhere useful, or record the missing source/context that prevents that coverage.
+- Preserve track owns/excludes boundaries so sibling topics do not duplicate findings, but merge, split, inline, or reference guidance according to the authoring skill.
+- Do not produce shallow placeholders on the assumption that later per-track passes will deepen them; no automatic track contribution passes will run.
 - Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
-- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, generated tracks, the target skill root, local paths, or the authoring plan itself as external sources.
-- For broad security-review skills, do not present a complete multi-language skill from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
+- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, outline tracks, the target skill root, local paths, or the authoring plan itself as external sources.
+- For broad domain, ecosystem, or code-review style skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
 - If validation later needs a correction, it should be possible to rewrite the skill from this file map alone.
 
 Return JSON:
@@ -182,63 +186,6 @@ Return JSON:
   "missingInputs": ["Missing input, if any"],
   "externalSources": [
     {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed the skill"}
-  ]
-}
-</instructions>`;
-}
-
-export function buildAuthoringTrackContributionPrompt(args: {
-  outline: SkillBuildOutline;
-  source: SkillBuildSource;
-  authoringSkillRoot: string;
-  targetName: string;
-  targetRootDir: string;
-  plan: GeneratedSkillAuthoringPlan;
-  fileMap: GeneratedSkillFileMap;
-  track: SkillBuildOutline['tracks'][number];
-}): string {
-  return `${contextPacket(args)}
-
-<authoring_plan>
-${JSON.stringify(args.plan, null, 2)}
-</authoring_plan>
-
-<assigned_track>
-${JSON.stringify(args.track, null, 2)}
-</assigned_track>
-
-<current_file_map>
-${JSON.stringify(args.fileMap, null, 2)}
-</current_file_map>
-
-<instructions>
-Add this track/task's contribution to the generated Warden skill.
-
-${wardenSkillConstraints(args)}
-
-Contribution behavior:
-- Use the authoring skill again, starting from its SKILL.md.
-- Treat the assigned track as a bounded coverage work lane. Let the authoring skill decide where any resulting guidance belongs.
-- Respect the track's owns/excludes boundaries. Do not duplicate sibling-track material already covered in the current file map.
-- Add or revise the smallest set of files needed for this track. Return only changed or new files, with full file contents.
-- If the current file map already covers this track well, return an empty files array and explain exactly where the current files satisfy the track's required evidence. Topic names or sink catalogs alone do not count as coverage.
-- A compact SKILL.md taxonomy or routing table does not count as full coverage for a broad security track unless the required evidence, false-positive controls, and remediation guidance are present inline.
-- If the current file map routes this track to a missing local reference, return that reference file or revise the routing. Do not leave broken routes for the reviewer to discover.
-- Prefer deepening the existing chosen structure over adding parallel artifacts when the problem is missing exploit evidence, safe lookalikes, or remediation detail.
-- Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
-- The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the current file map still depends on and add concrete external sources consulted during this task.
-
-Return JSON:
-{
-  "version": 1,
-  "files": [
-    {"path": "references/example.md", "content": "Full changed or new file contents"}
-  ],
-  "summary": "What this task contributed.",
-  "validationNotes": ["Self-check note"],
-  "missingInputs": ["Missing input, if any"],
-  "externalSources": [
-    {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed this contribution"}
   ]
 }
 </instructions>`;
@@ -276,9 +223,11 @@ ${wardenSkillConstraints(args)}
 Review behavior:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
+- Check whether each outline track/task is covered with useful runtime guidance, merged into another section/reference with clear coverage, or explicitly recorded as missing input. Do not require one artifact per track.
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
-- Set valid to false for concrete quality failures that need one writer pass: missing exploit/task evidence, missing false-positive controls for a risky domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
-- Set valid to false when the skill claims broad security coverage but the source base is too thin for that claim. Taxonomy-only sources, a handful of generic sources, or provenance that omits exploit/safe-counterexample/remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
+- Set valid to false for concrete quality failures that need one writer pass: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
+- Set valid to false when a track/task is represented only by a heading, topic name, or route entry without the evidence focus, safe counterpatterns, false-positive controls, and remediation guidance needed for runtime use.
+- Set valid to false when the skill claims broad domain coverage but the source base is too thin for that claim. Classification-only sources, a handful of generic sources, or provenance that omits failure-mode, safe-counterexample, and remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
 - Set valid to false for any missing local artifact needed by returned runtime guidance. That is a mechanical runnability failure, not a stylistic layout preference.
 - Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
@@ -340,7 +289,7 @@ Revision behavior:
 - Return a complete file map for every generated artifact that should exist after revision.
 - If review feedback identifies missing local artifacts, either include them with useful runtime content or remove the dependency and record the lost coverage as a missing input. Do not return knowingly broken local links.
 - Keep the simplest adequate layout according to the authoring skill. Do not add artifacts just to mirror tracks/tasks.
-- Preserve non-overlapping track/task guidance that is already good.
+- Preserve non-overlapping track/task guidance that is already good, and make any missing track/task coverage complete in this revision pass.
 - Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -1,7 +1,7 @@
 import type {
   GeneratedSkillAuthoringPlan,
   GeneratedSkillFileMap,
-  GeneratedSkillValidationResult,
+  GeneratedSkillReviewResult,
 } from './skill-contract.js';
 import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
 
@@ -261,7 +261,7 @@ Return JSON:
 {
   "version": 1,
   "valid": true,
-  "summary": "Validation summary.",
+  "summary": "Review summary.",
   "issues": [
     {"severity": "error", "path": "SKILL.md", "message": "Problem", "suggestedFix": "Fix"}
   ],
@@ -278,7 +278,7 @@ export function buildAuthoringRevisionPrompt(args: {
   targetRootDir: string;
   plan: GeneratedSkillAuthoringPlan;
   fileMap: GeneratedSkillFileMap;
-  review: GeneratedSkillValidationResult;
+  review: GeneratedSkillReviewResult;
   deterministicIssues: string[];
 }): string {
   return `${contextPacket(args)}

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -1,4 +1,8 @@
-import type { GeneratedSkillAuthoringPlan, GeneratedSkillFileMap } from './skill-contract.js';
+import type {
+  GeneratedSkillAuthoringPlan,
+  GeneratedSkillFileMap,
+  GeneratedSkillValidationResult,
+} from './skill-contract.js';
 import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
 
 const GENERIC_SKILL_BUILD_MAX_TURNS = 16;
@@ -240,7 +244,7 @@ ${JSON.stringify(args.deterministicIssues, null, 2)}
 </rough_validation_issues>
 
 <instructions>
-Roughly validate the generated Warden skill.
+Review the generated Warden skill and return standards feedback only.
 
 ${wardenSkillConstraints(args)}
 
@@ -248,11 +252,9 @@ Use "remind them what you told them" discipline:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated files followed the plan, the authoring skill, and Warden constraints.
 - Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes, and custom output/report formats that conflict with Warden's injected report schema.
-- If clear fixes are needed, return a complete revised file map in files, including every referenced runtime file.
-- If no fixes are needed, omit files or return an empty files array.
-- Do not return placeholder files or empty file contents. Omit unchanged files instead.
-- Report only issues that remain after any revised files you return.
-- Set valid to false only when the generated or revised files are unusable, not when you disagree with a reasonable layout choice.
+- Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
+- Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
+- Set valid to false only when a concrete issue should trigger revision, not when you disagree with a reasonable layout choice.
 - Treat rough validation issues as advisory signals. Fix concrete broken references or malformed artifacts, but do not hard-block on taste-level layout preferences.
 
 Return JSON:
@@ -263,10 +265,69 @@ Return JSON:
   "issues": [
     {"severity": "error", "path": "SKILL.md", "message": "Problem", "suggestedFix": "Fix"}
   ],
-  "files": [
-    {"path": "SKILL.md", "content": "Full revised file contents"}
-  ],
   "missingInputs": ["Missing input, if any"]
+}
+</instructions>`;
+}
+
+export function buildAuthoringRevisionPrompt(args: {
+  outline: SkillBuildOutline;
+  source: SkillBuildSource;
+  authoringSkillRoot: string;
+  targetName: string;
+  targetRootDir: string;
+  plan: GeneratedSkillAuthoringPlan;
+  fileMap: GeneratedSkillFileMap;
+  review: GeneratedSkillValidationResult;
+  deterministicIssues: string[];
+}): string {
+  return `${contextPacket(args)}
+
+<authoring_plan>
+${JSON.stringify(args.plan, null, 2)}
+</authoring_plan>
+
+<current_file_map>
+${JSON.stringify(args.fileMap, null, 2)}
+</current_file_map>
+
+<standards_review>
+${JSON.stringify(args.review, null, 2)}
+</standards_review>
+
+<rough_validation_issues>
+${JSON.stringify(args.deterministicIssues, null, 2)}
+</rough_validation_issues>
+
+<instructions>
+Revise the generated Warden skill artifacts from standards-review feedback.
+
+${wardenSkillConstraints(args)}
+
+Use "tell them again, but cleaner" discipline:
+- Use the authoring skill again, starting from its SKILL.md.
+- Treat the current file map as the draft to improve, not as disposable scaffolding.
+- Apply concrete review feedback and rough validation signals when they identify broken references, malformed artifacts, authoring metadata, custom output schemas, or missing runtime guidance.
+- If feedback is only stylistic or conflicts with the authoring skill, keep the existing structure and explain why in validationNotes.
+- Return a complete file map for every generated artifact that should exist after revision.
+- Keep the simplest adequate layout. Do not add references just to mirror tracks/tasks.
+- Preserve non-overlapping track/task guidance that is already good.
+- Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
+- The externalSources array is only for concrete external sources you actually consulted during revision.
+
+Return JSON:
+{
+  "version": 1,
+  "name": "${args.targetName}",
+  "files": [
+    {"path": "SKILL.md", "content": "Full file contents"}
+  ],
+  "summary": "What was revised.",
+  "validationNotes": ["Self-check note"],
+  "missingInputs": ["Missing input, if any"],
+  "externalSources": [
+    {"title": "Source title", "url": "https://example.com", "reason": "Why this source informed the revision"}
+  ]
 }
 </instructions>`;
 }

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -53,6 +53,7 @@ function wardenSkillConstraints(args: {
 - Let the authoring skill decide the simplest adequate artifact layout and where guidance belongs. Warden supplies the goal, source packet, outline, runtime constraints, and quality bar.
 - Treat outline tracks/tasks as work lanes for coverage and sequencing, not as filesystem or artifact taxonomy.
 - The writer and reviewer must handle all track/task coverage in this authoring run. Warden will not run automatic per-track artifact edit passes after the implementation pass.
+- If using references, keep them usable as lookup leaves: each reference should answer a dominant lookup question, have a direct open-when route from SKILL.md, and either stay short enough to scan or include navigation / split into clearer leaves.
 - Treat guidance quality as evidence quality, not file count. Runtime guidance should help the later Warden run decide, verify, and fix issues with concrete evidence, false-positive controls, and remediation patterns where the domain warrants it.
 - Broad domain or ecosystem skills should use source discovery before claiming complete runtime guidance. If source coverage is too thin for the claimed scope, record the gap instead of filling with generic survey text.
 - Warden runs skills on changed hunks and injects the report schema separately. Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections.
@@ -111,6 +112,7 @@ Work like an in-process skill-writer session:
 - Decide what additional research is needed during implementation and what gaps should be recorded before the skill can be considered complete.
 - Decide the ordered track/task coverage plan without turning tracks into layout rules or separate artifact-edit passes.
 - Decide how Warden and the authoring skill should roughly validate the output without turning stylistic preferences into hard blockers.
+- Include a reference usability bar in qualityBar / validationPlan when the likely shape is reference-backed: references should be focused lookup leaves, not giant mixed catalogs, and long leaves need navigation or a clearer split.
 - For broad domain, ecosystem, or code-review style skills, define the source coverage needed before the skill can be considered complete. Include source classes, not just source names: standards or prior art, failure-mode examples, safe counterexamples, language or framework docs, and remediation examples.
 - Carry forward external sources from the internal outline when the plan relies on them. Add new source-discovery targets when the outline sources are too thin for the claimed breadth.
 
@@ -169,10 +171,11 @@ Authoring behavior:
 - Edit files directly under the target skill root. Do not modify warden.yaml or build-state.json.
 - Write SKILL.md and every local artifact that SKILL.md or another runtime artifact requires.
 - Satisfy the plan's lookupQuestions and qualityBar using the structure chosen by the authoring skill.
-- Treat the outline tracks/tasks as the coverage checklist for this single writer pass. Cover each track's goal, evidence focus, safe counterpatterns, and false-positive traps somewhere useful, or record the missing source/context that prevents that coverage.
+- Treat the outline tracks/tasks as the coverage checklist for this authoring run. Cover each track's goal, evidence focus, safe counterpatterns, and false-positive traps somewhere useful, or record the missing source/context that prevents that coverage.
 - Preserve track owns/excludes boundaries so sibling topics do not duplicate findings, but merge, split, inline, or reference guidance according to the authoring skill.
 - Do not produce shallow placeholders on the assumption that later per-track passes will deepen them; no automatic track contribution passes will run.
 - Do not ship catalog-only runtime guidance. The generated skill should help the runtime agent decide, verify, and fix, not just recognize topic names or APIs.
+- Before finishing, run a reference usability self-check: every reference has a direct route, one dominant lookup need, and enough navigation or segmentation that the runtime agent can open only the relevant material. Split mixed references or add navigation when a leaf becomes hard to scan.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Include concrete outline sources, plan sources, and newly consulted sources that the generated skill depends on. Do not count warden.yaml, the authoring skill, outline tracks, the target skill root, local paths, or the authoring plan itself as external sources.
 - For broad domain, ecosystem, or code-review style skills, do not present complete multi-language or multi-framework coverage from thin source coverage. Either consult enough authoritative sources to support the breadth or mark the source coverage gap clearly in missingInputs so the reviewer can block completion.
 - If validation later needs a correction, the current target directory should be the complete draft to revise.
@@ -224,13 +227,15 @@ Review behavior:
 - Check whether the generated artifacts on disk followed the plan, the authoring skill, and Warden constraints.
 - Check whether each outline track/task is covered with useful runtime guidance, merged into another section/reference with clear coverage, or explicitly recorded as missing input. Do not require one artifact per track.
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
-- Set valid to false for concrete quality failures that need one writer pass: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
+- Set valid to false for concrete quality failures that need a writer revision: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
 - Set valid to false when a track/task is represented only by a heading, topic name, or route entry without the evidence focus, safe counterpatterns, false-positive controls, and remediation guidance needed for runtime use.
+- Set valid to false when reference-backed output uses oversized, mixed-purpose, or unnavigable references. This is runtime usability, not a taste-level layout preference. Accept any layout that stays focused and navigable; do not require one reference per topic.
 - Set valid to false when the skill claims broad domain coverage but the source base is too thin for that claim. Classification-only sources, a handful of generic sources, or provenance that omits failure-mode, safe-counterexample, and remediation evidence are not enough unless the gap is explicitly recorded as incomplete work.
 - Set valid to false for any missing local artifact needed by returned runtime guidance. That is a mechanical runnability failure, not a stylistic layout preference.
-- Do not rewrite files in this review pass. Give concrete feedback; the writer revision pass will decide how to apply it.
+- Do not rewrite files in this review pass. Give concrete feedback; a bounded writer revision round will decide how to apply it.
 - Report only issues that need another writer pass. Do not report taste-level layout preferences as issues.
 - Set valid to false only when a concrete issue should trigger revision, not when you disagree with a reasonable layout choice.
+- Do not block on maintenance-document template details such as SPEC.md heading names unless the issue affects runtime usability, source provenance, or future maintenance in a concrete way.
 - Treat rough validation issues as advisory signals. Fix concrete broken references or malformed artifacts, but do not hard-block on taste-level layout preferences.
 
 Return JSON:
@@ -290,6 +295,7 @@ Revision behavior:
 - Keep the simplest adequate layout according to the authoring skill. Do not add artifacts just to mirror tracks/tasks.
 - Preserve non-overlapping track/task guidance that is already good, and make any missing track/task coverage complete in this revision pass.
 - Fix shallow or catalog-only runtime guidance by adding targeted evidence and examples, restructuring by lookup need, or moving small guidance inline. Do not add bulk just to look deeper.
+- Fix oversized, mixed-purpose, or unnavigable references by adding concise navigation, splitting by lookup need, or moving short universal guidance back inline. Preserve layout freedom; the goal is runtime usability, not a required file count.
 - Fix source-depth failures by adding or preserving the source evidence the artifact actually depends on. If enough source discovery cannot be completed, keep the artifact incomplete and state the missing coverage instead of claiming a finished broad skill.
 - Keep generated runtime artifacts free of authoring metadata, validation summaries, and custom output/report schemas.
 - The externalSources array is cumulative evidence for the final artifact, but only for external web/upstream sources. Preserve external sources the revised artifacts still depend on and add concrete external sources consulted during revision.

--- a/src/skill-builder/skill-prompts.ts
+++ b/src/skill-builder/skill-prompts.ts
@@ -1,5 +1,6 @@
 import type {
   GeneratedSkillAuthoringPlan,
+  GeneratedSkillAuthoringMode,
   GeneratedSkillReviewResult,
   SkillBuildExternalSource,
 } from './skill-contract.js';
@@ -83,6 +84,27 @@ ${JSON.stringify(args.outline, null, 2)}
 </internal_outline>`;
 }
 
+function authoringIntent(args: {
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
+}): string {
+  const mode = args.mode ?? 'build';
+  if (mode === 'improve') {
+    return `<authoring_intent>
+Mode: improve
+Improve the existing generated skill from the improvement brief and current artifacts. Preserve useful existing behavior that the brief and reviewer do not call into question. Use the same planner, writer, reviewer, and revision standards as a build run.
+
+Improvement brief:
+${args.improvementPrompt?.trim() || '(No improvement brief supplied.)'}
+</authoring_intent>`;
+  }
+
+  return `<authoring_intent>
+Mode: build
+Create or refresh the generated skill from the source material and internal outline.
+</authoring_intent>`;
+}
+
 export function authoringSystemPrompt(): string {
   return `You are Warden's generated-skill authoring harness.
 
@@ -97,8 +119,12 @@ export function buildAuthoringPlanPrompt(args: {
   authoringSkillRoot: string;
   targetName: string;
   targetRootDir: string;
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
 }): string {
   return `${contextPacket(args)}
+
+${authoringIntent(args)}
 
 <instructions>
 Plan one generated Warden skill authoring run.
@@ -108,6 +134,7 @@ ${wardenSkillConstraints(args)}
 Work like an in-process skill-writer session:
 - Read and use the authoring skill.
 - Build the authoring brief first: goal, runtime use, depth bar, sources or source gaps, and the kind of evidence the final skill must carry.
+- In improve mode, make the improvement brief and current artifacts part of that brief: identify what should change, what should be preserved, and what needs reviewer verification.
 - Decide the minimum skill-writer workflow path and artifact layout using the authoring skill's own guidance.
 - Do the first research and source-inspection pass yourself. Use that to identify the larger plan, coverage work lanes, and obvious non-overlap boundaries.
 - Decide what additional research is needed during implementation and what gaps should be recorded before the skill can be considered complete.
@@ -154,8 +181,12 @@ export function buildAuthoringImplementationPrompt(args: {
   targetName: string;
   targetRootDir: string;
   plan: GeneratedSkillAuthoringPlan;
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
 }): string {
   return `${contextPacket(args)}
+
+${authoringIntent(args)}
 
 <authoring_plan>
 ${JSON.stringify(args.plan, null, 2)}
@@ -169,6 +200,7 @@ ${wardenSkillConstraints(args)}
 Authoring behavior:
 - Use the authoring skill again, starting from its SKILL.md.
 - Treat the authoring plan as the source/depth brief. Follow it unless new evidence proves the plan is wrong.
+- In improve mode, treat the current target directory as the draft to improve. Preserve useful existing behavior outside the improvement brief and reviewer feedback.
 - Edit files directly under the target skill root. Do not modify warden.yaml or build-state.json.
 - Write SKILL.md and every local artifact that SKILL.md or another runtime artifact requires.
 - Satisfy the plan's lookupQuestions and qualityBar using the structure chosen by the authoring skill.
@@ -204,8 +236,12 @@ export function buildAuthoringValidationPrompt(args: {
   plan: GeneratedSkillAuthoringPlan;
   artifact: GeneratedSkillArtifactSnapshot;
   deterministicIssues: string[];
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
 }): string {
   return `${contextPacket(args)}
+
+${authoringIntent(args)}
 
 <authoring_plan>
 ${JSON.stringify(args.plan, null, 2)}
@@ -227,6 +263,7 @@ ${wardenSkillConstraints(args)}
 Review behavior:
 - Use the authoring skill again as the validation anchor.
 - Check whether the generated artifacts on disk followed the plan, the authoring skill, and Warden constraints.
+- In improve mode, check whether the improvement brief was addressed without regressing useful existing behavior outside that brief.
 - Check whether each outline track/task is covered with useful runtime guidance, merged into another section/reference with clear coverage, or explicitly recorded as missing input. Do not require one artifact per track.
 - Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth, stale gap/provenance language, generated-skill metadata, missing local artifacts, and custom output/report formats that conflict with Warden's injected report schema.
 - Set valid to false for concrete quality failures that need a writer revision: missing task evidence, missing false-positive controls for the requested domain, missing remediation/examples where the plan required them, broad ecosystem output with no sources or recorded gaps, broken local artifact links, or a structure that the authoring skill would reject.
@@ -264,8 +301,12 @@ export function buildAuthoringRevisionPrompt(args: {
   artifact: GeneratedSkillArtifactSnapshot;
   review: GeneratedSkillReviewResult;
   deterministicIssues: string[];
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
 }): string {
   return `${contextPacket(args)}
+
+${authoringIntent(args)}
 
 <authoring_plan>
 ${JSON.stringify(args.plan, null, 2)}
@@ -291,6 +332,7 @@ ${wardenSkillConstraints(args)}
 Revision behavior:
 - Use the authoring skill again, starting from its SKILL.md.
 - Treat the current target directory as the draft to improve, not as disposable scaffolding.
+- In improve mode, apply the improvement brief and reviewer feedback while preserving useful existing behavior outside the requested change.
 - Apply concrete review feedback and rough validation signals when they identify broken references, malformed artifacts, authoring metadata, custom output schemas, or missing runtime guidance.
 - If feedback is only stylistic or conflicts with the authoring skill, keep the existing structure and explain why in validationNotes.
 - Edit files directly under the target skill root. Do not modify warden.yaml or build-state.json.

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -719,7 +719,7 @@ Read \`references/missing.md\` before reporting.
       regenerate: true,
     });
 
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(/^---\nname: "wrdn-security"\n/);
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(/^---\nname: wrdn-security\n/);
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.deterministicWarnings).toContain(
@@ -806,8 +806,9 @@ Read \`references/missing.md\` before reporting.
       regenerate: true,
     });
 
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(
-      /^---\nname: "wrdn-security"\ndescription: "Use when reviewing code changes for security concerns\."/,
+    const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
+    expect(writtenSkill).toMatch(
+      /^---\nname: wrdn-security\ndescription: Use when reviewing code changes for security concerns\.\nallowed-tools: Read Grep Glob Bash\n---/,
     );
   });
 

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Runtime, SkillRunRequest, SkillRunResponse } from '../sdk/runtimes/index.js';
 import { buildGeneratedSkill } from './skill.js';
+import { GeneratedSkillReviewResultSchema } from './skill-contract.js';
 import { resolveAuthoringProvider } from './authoring-provider.js';
 import {
   getBuildStatePath,
@@ -508,6 +509,19 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(runSkill).not.toHaveBeenCalled();
   });
 
+  it('rejects review output that tries to rewrite files', () => {
+    const result = GeneratedSkillReviewResultSchema.safeParse({
+      version: 1,
+      valid: true,
+      summary: 'Review passed.',
+      issues: [],
+      files: [{ path: 'SKILL.md', content: skillMd() }],
+      missingInputs: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('feeds standards feedback to a revision writer', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -648,104 +662,6 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(state?.artifact?.validationIssues).toEqual([]);
   });
 
-  it('ignores empty placeholder files returned by validation', async () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
-    tempDirs.push(tempDir);
-    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
-    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
-    mkdirSync(rootDir, { recursive: true });
-    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
-    const buildOutline = outline();
-    writeInitialState(rootDir, buildOutline);
-
-    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
-      if (request.skillName.endsWith(':authoring-plan')) {
-        return {
-          result: {
-            status: 'success',
-            text: JSON.stringify({
-              version: 1,
-              summary: 'Plan.',
-              workflow: ['Read the authoring skill'],
-              researchPlan: [],
-              artifactPlan: ['Create SKILL.md'],
-              validationPlan: ['Validate output'],
-              risks: [],
-              missingInputs: [],
-            }),
-            errors: [],
-            usage: usage(),
-          },
-        };
-      }
-      if (request.skillName.endsWith(':authoring-implementation')) {
-        return {
-          result: {
-            status: 'success',
-            text: JSON.stringify({
-              version: 1,
-              name: 'wrdn-security',
-              files: [
-                { path: 'SKILL.md', content: skillMd() },
-                {
-                  path: 'references/security.md',
-                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
-                },
-              ],
-              summary: 'Generated.',
-              validationNotes: [],
-              missingInputs: [],
-              externalSources: [],
-            }),
-            errors: [],
-            usage: usage(),
-          },
-        };
-      }
-      return {
-        result: {
-          status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'The generated skill is valid; no revised files are needed.',
-            issues: [],
-            files: [
-              { path: 'SKILL.md', content: '' },
-              {
-                path: 'references/security.md',
-                content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
-              },
-            ],
-            missingInputs: [],
-          }),
-          errors: [],
-          usage: usage(),
-        },
-      };
-    });
-
-    await buildGeneratedSkill({
-      outline: buildOutline,
-      source: source(),
-      rootDir,
-      runtime: {
-        name: 'claude',
-        runSkill,
-        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
-        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
-      },
-      repoPath: tempDir,
-      authoringSkillRoot,
-      regenerate: true,
-    });
-
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain(
-      'Review changed hunks for exploitable security issues.',
-    );
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8').trim()).not.toBe('');
-  });
-
   it('applies revision writer output after review feedback', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -874,7 +790,6 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     });
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
-    expect(existsSync(join(rootDir, 'references', 'placeholder.md'))).toBe(false);
   });
 
   it('backfills routed references added by revision writer output', async () => {

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -142,6 +142,17 @@ Review changed hunks for exploitable security issues.
 `;
 }
 
+function skillMdWithDescription(description: string, name = 'wrdn-security'): string {
+  return `---
+name: ${name}
+description: ${JSON.stringify(description)}
+allowed-tools: Read Grep Glob Bash
+---
+
+Review changed hunks for exploitable security issues.
+`;
+}
+
 function indexedSkillMd(name = 'wrdn-security'): string {
   return `---
 name: ${name}
@@ -536,7 +547,7 @@ describe('buildGeneratedSkill', () => {
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8').trim()).not.toBe('');
   });
 
-  it('ignores incomplete replacement file maps returned by validation', async () => {
+  it('merges and backfills partial replacement file maps returned by validation', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -630,8 +641,9 @@ Read \`references/missing.md\` before reporting.
     });
 
     const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
-    expect(writtenSkill).toContain('references/security.md');
-    expect(writtenSkill).not.toContain('references/missing.md');
+    expect(writtenSkill).toContain('references/missing.md');
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'missing.md'))).toBe(true);
   });
 
   it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
@@ -809,6 +821,91 @@ Read \`references/missing.md\` before reporting.
     const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
     expect(writtenSkill).toMatch(
       /^---\nname: wrdn-security\ndescription: Use when reviewing code changes for security concerns\.\nallowed-tools: Read Grep Glob Bash\n---/,
+    );
+  });
+
+  it('preserves legitimate runtime descriptions that mention generated code', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+    const description = 'Use when reviewing generated configuration files for security issues.';
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: skillMdWithDescription(description) }],
+              summary: 'Generated configuration review.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain(
+      `description: ${JSON.stringify(description)}`,
     );
   });
 

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -282,7 +282,6 @@ describe('buildGeneratedSkill', () => {
     expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
     expect(planPrompt).toContain('Let the authoring skill decide the simplest adequate artifact layout');
     expect(planPrompt).toContain('Treat outline tracks/tasks as work lanes for coverage and sequencing');
-    expect(planPrompt).not.toContain('references/tracks/');
     expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
     expect(planPrompt).toContain('Build the authoring brief first');
     expect(planPrompt).toContain('without turning tracks into layout rules');
@@ -302,7 +301,7 @@ describe('buildGeneratedSkill', () => {
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.version).toBe(4);
+    expect(state?.artifact?.version).toBe(5);
     expect(state?.artifact?.authoringProvider.rootDir).toBe(authoringSkillRoot);
     expect(state?.artifact?.fileManifest.map((file) => file.path).sort()).toEqual([
       'SKILL.md',
@@ -315,7 +314,7 @@ describe('buildGeneratedSkill', () => {
     }]);
   });
 
-  it('runs sequential track contributions without turning tracks into directories', async () => {
+  it('runs sequential track contributions without turning tracks into artifact layout', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -388,7 +387,7 @@ describe('buildGeneratedSkill', () => {
             text: JSON.stringify({
               version: 1,
               files: [{
-                path: 'references/tracks/security.md',
+                path: 'references/security.md',
                 content: '# Security Review\n\nTrace attacker-controlled input before reporting.\n',
               }],
               summary: 'Added security checks.',
@@ -413,12 +412,12 @@ describe('buildGeneratedSkill', () => {
                   content: `${inlineSkillMd()}
 ## References
 
-Read \`references/tracks/security.md\` for general exploitability checks.
-Read \`references/tracks/authentication.md\` for login and session changes.
+Read \`references/security.md\` for general exploitability checks.
+Read \`references/authentication.md\` for login and session changes.
 `,
                 },
                 {
-                  path: 'references/tracks/authentication.md',
+                  path: 'references/authentication.md',
                   content: '# Authentication Review\n\nTrace identity checks and session state before reporting.\n',
                 },
               ],
@@ -470,19 +469,16 @@ Read \`references/tracks/authentication.md\` for login and session changes.
       'wrdn-security:authoring-track-authentication',
       'wrdn-security:authoring-validation',
     ]);
-    expect(existsSync(join(rootDir, 'references', 'tracks'))).toBe(false);
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     expect(existsSync(join(rootDir, 'references', 'authentication.md'))).toBe(true);
     const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
     expect(writtenSkill).toContain('references/security.md');
     expect(writtenSkill).toContain('references/authentication.md');
-    expect(writtenSkill).not.toContain('references/tracks/');
 
     const trackPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(trackPrompt).toContain('Treat the assigned track as a bounded coverage work lane');
     expect(trackPrompt).toContain('Let the authoring skill decide where any resulting guidance belongs');
     expect(trackPrompt).toContain('Topic names or sink catalogs alone do not count as coverage');
-    expect(trackPrompt).not.toContain('references/tracks/');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {
@@ -555,7 +551,6 @@ Read \`references/tracks/authentication.md\` for login and session changes.
         question: 'How do I prove command injection in changed code?',
         openWhen: 'The hunk builds process commands from external input.',
         requiredEvidence: ['source-to-shell dataflow', 'safe argv counterexample'],
-        candidatePaths: ['references/command-execution.md'],
       }],
       qualityBar: ['Reject catalog-only references without exploit and fix examples.'],
       artifactPlan: ['Use a compact SKILL.md router plus focused references'],
@@ -708,11 +703,6 @@ Read \`references/tracks/authentication.md\` for login and session changes.
       'wrdn-security:authoring-revision',
       'wrdn-security:authoring-validation',
     ]);
-    expect(runSkill.mock.calls[2]![0].userPrompt).not.toContain(
-      'Flattened generated reference path(s)',
-    );
-    const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.validationIssues).toEqual([]);
   });
 
   it('applies revision writer output after review feedback', async () => {
@@ -1659,7 +1649,6 @@ Read \`references/output-format.md\` before changing output behavior.
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.fileManifest.some((file) => file.path === 'references/security.md'))
       .toBe(true);
-    expect(state?.artifact?.validationIssues).toEqual([]);
   });
 
   it('does not rewrite routed reference content based on filename heuristics', async () => {
@@ -1870,7 +1859,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       identity: {},
       outline: buildOutline,
       artifact: {
-        version: 4,
+        version: 5,
         sourceHash: source().hash,
         outlineHash: outlineHash(buildOutline),
         buildVersion: buildOutline.buildVersion,
@@ -1878,7 +1867,6 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
         name: 'wrdn-security',
         fileManifest: [{ path: 'SKILL.md', bytes: cachedBytes }],
         deterministicWarnings: [],
-        validationIssues: [],
         bytes: cachedBytes,
         durationMs: 10,
         usage: usage(),

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -1195,6 +1195,94 @@ See \`SPEC.md\` for maintenance details.
     expect(existsSync(join(rootDir, 'SPEC.md'))).toBe(false);
   });
 
+  it('backfills routed references before stripping output contract sections', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const skillWithStrippedRoute = `${inlineSkillMd()}
+## Output Format
+
+Read \`references/output-format.md\` before changing output behavior.
+`;
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: skillWithStrippedRoute }],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).not.toContain('Output Format');
+    expect(existsSync(join(rootDir, 'references', 'output-format.md'))).toBe(true);
+  });
+
   it('preserves legitimate runtime descriptions that mention generated code', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -1,10 +1,14 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Runtime, SkillRunRequest, SkillRunResponse } from '../sdk/runtimes/index.js';
 import { buildGeneratedSkill } from './skill.js';
-import { GeneratedSkillAuthoringPlanSchema, GeneratedSkillReviewResultSchema } from './skill-contract.js';
+import {
+  GeneratedSkillAuthoringPlanSchema,
+  GeneratedSkillReviewResultSchema,
+  GeneratedSkillWriterResultSchema,
+} from './skill-contract.js';
 import { resolveAuthoringProvider } from './authoring-provider.js';
 import {
   getBuildStatePath,
@@ -169,6 +173,55 @@ Read \`references/checklist.md\` first. It routes to the detailed reference file
 `;
 }
 
+function writeGeneratedFiles(rootDir: string, files: { path: string; content: string }[]): void {
+  for (const file of files) {
+    const target = join(rootDir, file.path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, file.content, 'utf-8');
+  }
+}
+
+function diskWriterRunSkill(rootDir: string, runSkill: Runtime['runSkill']): Runtime['runSkill'] {
+  return async (request) => {
+    const response = await runSkill(request);
+    if (
+      !request.skillName.endsWith(':authoring-implementation') &&
+      !request.skillName.endsWith(':authoring-revision')
+    ) {
+      return response;
+    }
+
+    const result = response.result;
+    if (!result || result.status !== 'success') {
+      return response;
+    }
+
+    const parsed = JSON.parse(result.text) as {
+      files?: { path: string; content: string }[];
+      summary?: string;
+      validationNotes?: string[];
+      missingInputs?: string[];
+      externalSources?: { title: string; url: string; reason: string }[];
+    };
+    if (parsed.files) {
+      writeGeneratedFiles(rootDir, parsed.files);
+    }
+    return {
+      ...response,
+      result: {
+        ...result,
+        text: JSON.stringify({
+          version: 1,
+          summary: parsed.summary ?? 'Writer updated skill artifacts.',
+          validationNotes: parsed.validationNotes ?? [],
+          missingInputs: parsed.missingInputs ?? [],
+          externalSources: parsed.externalSources ?? [],
+        }),
+      },
+    };
+  };
+}
+
 describe('buildGeneratedSkill', () => {
   const tempDirs: string[] = [];
 
@@ -179,7 +232,7 @@ describe('buildGeneratedSkill', () => {
     tempDirs.length = 0;
   });
 
-  it('writes provider-driven file maps without hardcoded template artifacts', async () => {
+  it('lets the writer persist artifacts without hardcoded template files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -227,10 +280,6 @@ describe('buildGeneratedSkill', () => {
                   path: 'references/security.md',
                   content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
                 },
-                {
-                  path: 'SOURCES.md',
-                  content: '# Sources\n\n- Generated from the prompt and authoring provider.\n',
-                },
               ],
               summary: 'Generated a reference-backed skill.',
               validationNotes: ['Self-check passed'],
@@ -264,7 +313,7 @@ describe('buildGeneratedSkill', () => {
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -288,13 +337,18 @@ describe('buildGeneratedSkill', () => {
     expect(planPrompt).toContain('define the source coverage needed before the skill can be considered complete');
 
     const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
-    expect(implementationPrompt).toContain('Include every local artifact that SKILL.md or another returned artifact requires at runtime');
+    expect(implementationPrompt).toContain('Edit files directly under the target skill root');
+    expect(implementationPrompt).toContain('Write SKILL.md and every local artifact that SKILL.md or another runtime artifact requires');
     expect(implementationPrompt).toContain('Satisfy the plan\'s lookupQuestions and qualityBar');
     expect(implementationPrompt).toContain('Do not ship catalog-only runtime guidance');
     expect(implementationPrompt).toContain('externalSources array is cumulative evidence for the final artifact');
+    expect(runSkill.mock.calls[1]![0].repoPath).toBe(rootDir);
+    expect(runSkill.mock.calls[1]![0].allowMutatingTools).toBe(true);
+    expect(runSkill.mock.calls[1]![0].tools?.allowed).toEqual(expect.arrayContaining(['Write', 'Edit', 'Bash']));
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(validationPrompt).toContain('Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth');
+    expect(validationPrompt).toContain('generated artifacts on disk');
     expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
     expect(validationPrompt).toContain('claims broad domain coverage but the source base is too thin');
     expect(validationPrompt).toContain('Set valid to false for any missing local artifact needed by returned runtime guidance');
@@ -423,7 +477,7 @@ Read \`references/authentication.md\` for login and session changes.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -484,7 +538,7 @@ Read \`references/authentication.md\` for login and session changes.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -509,6 +563,24 @@ Read \`references/authentication.md\` for login and session changes.
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('accepts writer metadata even when provider includes legacy file-map fields', () => {
+    const result = GeneratedSkillWriterResultSchema.safeParse({
+      version: 1,
+      name: 'wrdn-security',
+      files: [{ path: 'SKILL.md', content: '' }],
+      summary: 'Writer updated files on disk.',
+      validationNotes: [],
+      missingInputs: [],
+      externalSources: [],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('expected writer metadata to parse');
+    }
+    expect(result.data).not.toHaveProperty('files');
   });
 
   it('accepts source-depth details in authoring plans', () => {
@@ -661,7 +733,7 @@ Read \`references/authentication.md\` for login and session changes.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -798,7 +870,7 @@ Read \`references/authentication.md\` for login and session changes.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -810,7 +882,7 @@ Read \`references/authentication.md\` for login and session changes.
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
   });
 
-  it('fails instead of writing artifacts when revision leaves routed references missing', async () => {
+  it('fails and preserves the revision draft when routed references are still missing', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -931,7 +1003,7 @@ Read \`references/missing.md\` before reporting.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -942,13 +1014,14 @@ Read \`references/missing.md\` before reporting.
       /Generated skill failed final review for wrdn-security:[\s\S]*references\/missing\.md/,
     );
 
-    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(incompleteSkill);
     expect(existsSync(join(rootDir, 'references', 'missing.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact).toBeUndefined();
   });
 
-  it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
+  it('fails mechanical review when the writer leaves SKILL.md malformed and preserves the draft', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1018,30 +1091,30 @@ Read \`references/missing.md\` before reporting.
       };
     });
 
-    await buildGeneratedSkill({
+    await expect(buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    });
+    })).rejects.toThrow(
+      /Generated skill failed final review for wrdn-security:[\s\S]*SKILL\.md must start with YAML frontmatter/,
+    );
 
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(/^---\nname: wrdn-security\n/);
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(skillMdWithoutFrontmatter());
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.deterministicWarnings).toContain(
-      'warning: SKILL.md does not route runtime reference references/security.md',
-    );
+    expect(state?.artifact).toBeUndefined();
   });
 
-  it('repairs generated frontmatter descriptions that contain authoring metadata', async () => {
+  it('feeds authoring-metadata descriptions to reviewer and revision writer', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1051,6 +1124,15 @@ Read \`references/missing.md\` before reporting.
     const buildOutline = outline();
     writeInitialState(rootDir, buildOutline);
 
+    const revisedSkill = `---
+name: wrdn-security
+description: Use when reviewing code changes for security concerns.
+allowed-tools: Read Grep Glob Bash
+---
+
+Review changed hunks for exploitable security issues.
+`;
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -1089,16 +1171,47 @@ Read \`references/missing.md\` before reporting.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: revisedSkill }],
+              summary: 'Revised the trigger description.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Validated.',
-            issues: [],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Description contains authoring metadata.',
+              issues: [{
+                severity: 'error',
+                path: 'SKILL.md',
+                message: 'Description should be runtime trigger language, not build metadata.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Description is runtime-facing.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -1111,7 +1224,7 @@ Read \`references/missing.md\` before reporting.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1126,7 +1239,7 @@ Read \`references/missing.md\` before reporting.
     );
   });
 
-  it('omits generated metadata artifacts and strips output contract sections', async () => {
+  it('uses revision writer to remove metadata artifacts and output contract sections', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1143,6 +1256,7 @@ Use Warden's JSON finding schema.
 
 See \`SPEC.md\` for maintenance details.
 `;
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -1191,16 +1305,53 @@ See \`SPEC.md\` for maintenance details.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        rmSync(join(rootDir, 'SOURCES.md'), { force: true });
+        rmSync(join(rootDir, 'SPEC.md'), { force: true });
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
+              summary: 'Removed output contract and build metadata.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Validated.',
-            issues: [],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Runtime artifacts contain output-contract and build metadata.',
+              issues: [{
+                severity: 'error',
+                path: 'SKILL.md',
+                message: 'Remove custom output contract sections from runtime guidance.',
+              }, {
+                severity: 'error',
+                path: 'SOURCES.md',
+                message: 'Remove build metadata unless it documents real external sources.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Metadata artifacts were removed.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -1213,7 +1364,7 @@ See \`SPEC.md\` for maintenance details.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1310,7 +1461,7 @@ See \`SPEC.md\` for maintenance details.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1324,7 +1475,7 @@ See \`SPEC.md\` for maintenance details.
     );
   });
 
-  it('does not synthesize references from stripped output contract sections', async () => {
+  it('uses revision writer to remove output-contract routes instead of synthesizing references', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1339,6 +1490,7 @@ See \`SPEC.md\` for maintenance details.
 
 Read \`references/output-format.md\` before changing output behavior.
 `;
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -1377,16 +1529,47 @@ Read \`references/output-format.md\` before changing output behavior.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
+              summary: 'Removed output-format route.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Validated.',
-            issues: [],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Output-format route should be removed.',
+              issues: [{
+                severity: 'error',
+                path: 'SKILL.md',
+                message: 'Remove custom output-format runtime guidance.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Output-format route was removed.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -1399,7 +1582,7 @@ Read \`references/output-format.md\` before changing output behavior.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1483,7 +1666,7 @@ Read \`references/output-format.md\` before changing output behavior.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1578,11 +1761,11 @@ Read \`references/output-format.md\` before changing output behavior.
             ? {
               version: 1,
               valid: false,
-              summary: 'Provider saw the original file map as incomplete.',
+              summary: 'Provider saw the original draft as incomplete.',
               issues: [{
                 severity: 'error',
-                path: 'generated_file_map',
-                message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
+                path: 'SKILL.md',
+                message: 'SKILL.md routes reference files that are not included on disk.',
               }, {
                 severity: 'error',
                 path: 'references/',
@@ -1609,7 +1792,7 @@ Read \`references/output-format.md\` before changing output behavior.
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1709,7 +1892,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1724,7 +1907,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(state?.artifact?.deterministicWarnings).toEqual([]);
   });
 
-  it('fails instead of writing artifacts when a generated reference index routes missing files', async () => {
+  it('fails and preserves the draft when a generated reference index routes missing files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1800,7 +1983,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1811,7 +1994,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       /Generated skill failed final review for wrdn-security:[\s\S]*references\/security\.md/,
     );
 
-    expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(true);
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(false);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact).toBeUndefined();
@@ -1918,7 +2101,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -1931,7 +2114,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
   });
 
-  it('fails instead of writing artifacts when final provider review still reports issues', async () => {
+  it('fails and preserves the draft when final provider review still reports issues', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -2035,7 +2218,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -2046,12 +2229,12 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       /Generated skill failed final review for wrdn-security:[\s\S]*Reference is 140 lines/,
     );
 
-    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact).toBeUndefined();
   });
 
-  it('fails instead of writing artifacts when final provider review remains invalid', async () => {
+  it('fails and preserves the writer draft when final provider review remains invalid', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -2144,7 +2327,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       rootDir,
       runtime: {
         name: 'claude',
-        runSkill,
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
         runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
         runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
       },
@@ -2155,7 +2338,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       /Generated skill failed final review for wrdn-security:[\s\S]*Runtime instructions are too shallow/,
     );
 
-    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe('previous artifact\n');
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(inlineSkillMd());
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact).toBeUndefined();
   });

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -348,6 +348,132 @@ describe('buildGeneratedSkill', () => {
     }]);
   });
 
+  it('improves existing artifacts without clearing the target before reviewer revisions', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(join(rootDir, 'references'), { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    writeFileSync(join(rootDir, 'SKILL.md'), skillMd(), 'utf-8');
+    writeFileSync(
+      join(rootDir, 'references', 'security.md'),
+      '# Security Reference\n\nExisting guidance that should survive a focused improvement.\n',
+      'utf-8',
+    );
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    let validationCalls = 0;
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan a focused improvement.',
+              workflow: ['Read the current skill', 'Improve only the requested behavior'],
+              researchPlan: ['Use current artifacts and improvement brief'],
+              artifactPlan: ['Keep existing routed references unless the writer changes them'],
+              validationPlan: ['Reviewer verifies the improvement'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              files: [{ path: 'SKILL.md', content: skillMdWithDescription('Initial improved trigger language.') }],
+              summary: 'Improved the trigger language.',
+              validationNotes: ['Needs reviewer check'],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-validation')) {
+        validationCalls += 1;
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              valid: validationCalls > 1,
+              summary: validationCalls > 1 ? 'Improvement is complete.' : 'Needs one revision.',
+              issues: validationCalls > 1
+                ? []
+                : [{
+                  severity: 'error',
+                  path: 'SKILL.md',
+                  message: 'Trigger language is still too vague.',
+                  suggestedFix: 'Make the runtime trigger concrete.',
+                }],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              files: [{ path: 'SKILL.md', content: skillMdWithDescription('Use when changed code touches exploitable security boundaries.') }],
+              summary: 'Applied reviewer feedback.',
+              validationNotes: ['Reviewer feedback addressed'],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      throw new Error(`Unexpected skill run: ${request.skillName}`);
+    });
+
+    const artifact = await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill: diskWriterRunSkill(rootDir, runSkill),
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+      mode: 'improve',
+      improvementPrompt: 'Tighten trigger language without replacing the existing reference.',
+    });
+
+    expect(artifact.name).toBe('wrdn-security');
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain(
+      'Use when changed code touches exploitable security boundaries.',
+    );
+    expect(readFileSync(join(rootDir, 'references', 'security.md'), 'utf-8')).toContain(
+      'Existing guidance that should survive',
+    );
+    expect(runSkill.mock.calls.filter((call) => call[0].skillName.endsWith(':authoring-validation'))).toHaveLength(2);
+    expect(runSkill.mock.calls.some((call) => call[0].skillName.endsWith(':authoring-revision'))).toBe(true);
+  });
+
   it('uses outline tracks as single-writer coverage input without automatic track passes', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Runtime, SkillRunRequest, SkillRunResponse } from '../sdk/runtimes/index.js';
 import { buildGeneratedSkill } from './skill.js';
-import { GeneratedSkillReviewResultSchema } from './skill-contract.js';
+import { GeneratedSkillAuthoringPlanSchema, GeneratedSkillReviewResultSchema } from './skill-contract.js';
 import { resolveAuthoringProvider } from './authoring-provider.js';
 import {
   getBuildStatePath,
@@ -279,15 +279,19 @@ describe('buildGeneratedSkill', () => {
     expect(planPrompt).toContain('Tracks/tasks are planning work lanes, not filesystem taxonomy');
     expect(planPrompt).toContain('Do not create `references/tracks/`');
     expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
-    expect(planPrompt).toContain('Decide the minimum workflow path and simplest adequate artifact layout');
+    expect(planPrompt).toContain('Build the authoring brief first');
+    expect(planPrompt).toContain('For every planned routed reference, define the lookup question');
 
     const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
     expect(implementationPrompt).toContain('Add references/ only for routed runtime lookup leaves');
     expect(implementationPrompt).toContain('Keep SKILL.md compact; put optional depth in routed references');
+    expect(implementationPrompt).toContain('Satisfy the plan\'s lookupQuestions and qualityBar');
+    expect(implementationPrompt).toContain('Do not ship catalog-only references');
     expect(implementationPrompt).toContain('Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline');
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes');
+    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, catalog-only references, missing source depth');
+    expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
@@ -465,6 +469,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     const trackPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(trackPrompt).toContain('Treat the assigned track as a work lane');
     expect(trackPrompt).toContain('It may map to one reference, multiple references, a shared reference, or no new file');
+    expect(trackPrompt).toContain('Topic names or sink catalogs alone do not count as coverage');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {
@@ -520,6 +525,38 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('accepts source-depth details in authoring plans', () => {
+    const result = GeneratedSkillAuthoringPlanSchema.safeParse({
+      version: 1,
+      summary: 'Plan a source-backed skill.',
+      workflow: ['Read the authoring skill', 'Collect source depth', 'Write focused references'],
+      researchPlan: ['Inspect official docs and safe counterexamples'],
+      sourceDecisions: [{
+        source: 'OWASP command injection guidance',
+        decision: 'Require attacker-controlled input reaching a shell boundary.',
+        implication: 'Command references need exploit-path evidence and safe argv examples.',
+      }],
+      lookupQuestions: [{
+        question: 'How do I prove command injection in changed code?',
+        openWhen: 'The hunk builds process commands from external input.',
+        requiredEvidence: ['source-to-shell dataflow', 'safe argv counterexample'],
+        candidatePaths: ['references/command-execution.md'],
+      }],
+      qualityBar: ['Reject catalog-only references without exploit and fix examples.'],
+      artifactPlan: ['Use a compact SKILL.md router plus focused references'],
+      validationPlan: ['Reviewer checks source depth and lookup-question coverage'],
+      risks: [],
+      missingInputs: [],
+      externalSources: [{
+        title: 'OWASP Command Injection',
+        url: 'https://owasp.org/www-community/attacks/Command_Injection',
+        reason: 'Used to calibrate exploit evidence.',
+      }],
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it('feeds standards feedback to a revision writer', async () => {
@@ -795,7 +832,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
   });
 
-  it('backfills routed references added by revision writer output', async () => {
+  it('keeps missing routed references visible after revision output', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -928,7 +965,11 @@ Read \`references/missing.md\` before reporting.
     const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
     expect(writtenSkill).toContain('references/missing.md');
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
-    expect(existsSync(join(rootDir, 'references', 'missing.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'missing.md'))).toBe(false);
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.deterministicWarnings).toContain(
+      'warning: SKILL.md routes references/missing.md but the generated file map does not include it',
+    );
   });
 
   it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
@@ -1307,7 +1348,7 @@ See \`SPEC.md\` for maintenance details.
     );
   });
 
-  it('backfills routed references before stripping output contract sections', async () => {
+  it('does not synthesize references from stripped output contract sections', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1392,7 +1433,7 @@ Read \`references/output-format.md\` before changing output behavior.
     });
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).not.toContain('Output Format');
-    expect(existsSync(join(rootDir, 'references', 'output-format.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'output-format.md'))).toBe(false);
   });
 
   it('preserves legitimate runtime descriptions that mention generated code', async () => {
@@ -1480,7 +1521,7 @@ Read \`references/output-format.md\` before changing output behavior.
     );
   });
 
-  it('backfills routed reference files missing from the generated file map', async () => {
+  it('feeds missing routed references to the reviewer and revision writer', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1536,8 +1577,14 @@ Read \`references/output-format.md\` before changing output behavior.
             text: JSON.stringify({
               version: 1,
               name: 'wrdn-security',
-              files: [{ path: 'SKILL.md', content: skillMd() }],
-              summary: 'Re-emitted the routed skill for reference backfill.',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nTrace data flow from changed lines before reporting.\n',
+                },
+              ],
+              summary: 'Added the routed reference explicitly.',
               validationNotes: [],
               missingInputs: [],
               externalSources: [],
@@ -1596,9 +1643,8 @@ Read \`references/output-format.md\` before changing output behavior.
     });
 
     const reference = readFileSync(join(rootDir, 'references', 'security.md'), 'utf-8');
-    expect(reference).toContain('# Security review');
-    expect(reference).toContain('trace data flow');
-    expect(reference).toContain('changed-line evidence');
+    expect(reference).toContain('# Security Reference');
+    expect(reference).toContain('Trace data flow');
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.fileManifest.some((file) => file.path === 'references/security.md'))
       .toBe(true);
@@ -1703,7 +1749,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(state?.artifact?.deterministicWarnings).toEqual([]);
   });
 
-  it('backfills files routed by a generated reference index', async () => {
+  it('records missing files routed by a generated reference index', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1789,12 +1835,14 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     });
 
     expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(true);
-    const nestedReference = readFileSync(join(rootDir, 'references', 'security.md'), 'utf-8');
-    expect(nestedReference).toContain('# Security review');
-    expect(nestedReference).toContain('pattern-only claims');
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(false);
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.deterministicWarnings).toContain(
+      'warning: SKILL.md routes references/security.md but the generated file map does not include it',
+    );
   });
 
-  it('backfills cached artifacts with missing routed reference files', async () => {
+  it('regenerates cached artifacts with missing routed reference files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1904,8 +1952,8 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       authoringSkillRoot,
     });
 
-    expect(artifact.source).toBe('cache');
-    expect(runSkill).not.toHaveBeenCalled();
+    expect(artifact.source).toBe('generated');
+    expect(runSkill).toHaveBeenCalled();
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
   });
 

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -187,6 +187,11 @@ describe('buildGeneratedSkill', () => {
     mkdirSync(rootDir, { recursive: true });
     writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
     const buildOutline = outline();
+    buildOutline.build.externalSources = [{
+      title: 'OWASP Testing Guide',
+      url: 'https://owasp.org/www-project-web-security-testing-guide/',
+      reason: 'Security source carried from outline synthesis into artifact metadata.',
+    }];
     writeInitialState(rootDir, buildOutline);
 
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
@@ -281,6 +286,7 @@ describe('buildGeneratedSkill', () => {
     expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
     expect(planPrompt).toContain('Build the authoring brief first');
     expect(planPrompt).toContain('For every planned routed reference, define the lookup question');
+    expect(planPrompt).toContain('define the source coverage needed before the skill can be considered complete');
 
     const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
     expect(implementationPrompt).toContain('Add references/ only for routed runtime lookup leaves');
@@ -288,10 +294,13 @@ describe('buildGeneratedSkill', () => {
     expect(implementationPrompt).toContain('Satisfy the plan\'s lookupQuestions and qualityBar');
     expect(implementationPrompt).toContain('Do not ship catalog-only references');
     expect(implementationPrompt).toContain('Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline');
+    expect(implementationPrompt).toContain('externalSources array is cumulative evidence for the final artifact');
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(validationPrompt).toContain('Check for over-broad topic-bucket references, catalog-only references, missing source depth');
     expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
+    expect(validationPrompt).toContain('claims broad security coverage but the source base is too thin');
+    expect(validationPrompt).toContain('Set valid to false for any missing routed local file');
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
@@ -301,6 +310,11 @@ describe('buildGeneratedSkill', () => {
       'SKILL.md',
       'references/security.md',
     ].sort());
+    expect(artifact.externalSources).toEqual([{
+      title: 'OWASP Testing Guide',
+      url: 'https://owasp.org/www-project-web-security-testing-guide/',
+      reason: 'Security source carried from outline synthesis into artifact metadata.',
+    }]);
   });
 
   it('runs sequential track contributions without turning tracks into directories', async () => {
@@ -832,7 +846,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
   });
 
-  it('keeps missing routed references visible after revision output', async () => {
+  it('fails instead of writing artifacts when revision leaves routed references missing', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -947,7 +961,7 @@ Read \`references/missing.md\` before reporting.
       };
     });
 
-    await buildGeneratedSkill({
+    await expect(buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -960,16 +974,14 @@ Read \`references/missing.md\` before reporting.
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    });
+    })).rejects.toThrow(
+      /Generated skill failed final review for wrdn-security:[\s\S]*references\/missing\.md/,
+    );
 
-    const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
-    expect(writtenSkill).toContain('references/missing.md');
-    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
     expect(existsSync(join(rootDir, 'references', 'missing.md'))).toBe(false);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.deterministicWarnings).toContain(
-      'warning: SKILL.md routes references/missing.md but the generated file map does not include it',
-    );
+    expect(state?.artifact).toBeUndefined();
   });
 
   it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
@@ -1749,7 +1761,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(state?.artifact?.deterministicWarnings).toEqual([]);
   });
 
-  it('records missing files routed by a generated reference index', async () => {
+  it('fails instead of writing artifacts when a generated reference index routes missing files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1819,7 +1831,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       };
     });
 
-    await buildGeneratedSkill({
+    await expect(buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -1832,14 +1844,14 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    });
+    })).rejects.toThrow(
+      /Generated skill failed final review for wrdn-security:[\s\S]*references\/security\.md/,
+    );
 
-    expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(false);
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(false);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.deterministicWarnings).toContain(
-      'warning: SKILL.md routes references/security.md but the generated file map does not include it',
-    );
+    expect(state?.artifact).toBeUndefined();
   });
 
   it('regenerates cached artifacts with missing routed reference files', async () => {
@@ -1957,7 +1969,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
   });
 
-  it('writes generated artifacts when provider validation reports reference navigation errors', async () => {
+  it('fails instead of writing artifacts when final provider review still reports issues', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -2055,7 +2067,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       };
     });
 
-    const artifact = await buildGeneratedSkill({
+    await expect(buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -2068,25 +2080,23 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    });
+    })).rejects.toThrow(
+      /Generated skill failed final review for wrdn-security:[\s\S]*Reference is 140 lines/,
+    );
 
-    expect(artifact.source).toBe('generated');
-    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(false);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.validationIssues).toEqual([{
-      severity: 'warning',
-      path: 'references/security.md',
-      message: 'Reference is 140 lines without ## Contents section for navigation.',
-    }]);
+    expect(state?.artifact).toBeUndefined();
   });
 
-  it('records provider validation errors without blocking valid generated artifacts', async () => {
+  it('fails instead of writing artifacts when final provider review remains invalid', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
     const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
     mkdirSync(rootDir, { recursive: true });
     writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    writeFileSync(join(rootDir, 'SKILL.md'), 'previous artifact\n', 'utf-8');
     const buildOutline = outline();
     writeInitialState(rootDir, buildOutline);
 
@@ -2166,7 +2176,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       };
     });
 
-    const artifact = await buildGeneratedSkill({
+    await expect(buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -2179,15 +2189,12 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    });
+    })).rejects.toThrow(
+      /Generated skill failed final review for wrdn-security:[\s\S]*Runtime instructions are too shallow/,
+    );
 
-    expect(artifact.source).toBe('generated');
-    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(true);
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe('previous artifact\n');
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.validationIssues).toEqual([{
-      severity: 'warning',
-      path: 'SKILL.md',
-      message: 'Runtime instructions are too shallow.',
-    }]);
+    expect(state?.artifact).toBeUndefined();
   });
 });

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -327,34 +327,11 @@ describe('buildGeneratedSkill', () => {
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('references/security.md');
 
-    const planPrompt = runSkill.mock.calls[0]![0].userPrompt;
-    expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
-    expect(planPrompt).toContain('Let the authoring skill decide the simplest adequate artifact layout');
-    expect(planPrompt).toContain('Treat outline tracks/tasks as work lanes for coverage and sequencing');
-    expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
-    expect(planPrompt).toContain('Build the authoring brief first');
-    expect(planPrompt).toContain('without turning tracks into layout rules');
-    expect(planPrompt).toContain('define the source coverage needed before the skill can be considered complete');
-
-    const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
-    expect(implementationPrompt).toContain('Edit files directly under the target skill root');
-    expect(implementationPrompt).toContain('Write SKILL.md and every local artifact that SKILL.md or another runtime artifact requires');
-    expect(implementationPrompt).toContain('Satisfy the plan\'s lookupQuestions and qualityBar');
-    expect(implementationPrompt).toContain('Do not ship catalog-only runtime guidance');
-    expect(implementationPrompt).toContain('externalSources array is cumulative evidence for the final artifact');
     expect(runSkill.mock.calls[1]![0].repoPath).toBe(rootDir);
     expect(runSkill.mock.calls[1]![0].allowMutatingTools).toBe(true);
     expect(runSkill.mock.calls[1]![0].tools?.allowed).toEqual(expect.arrayContaining(['Write', 'Edit', 'Bash']));
     expect(runSkill.mock.calls[0]![0].options.maxTurns).toBe(80);
     expect(runSkill.mock.calls[1]![0].options.maxTurns).toBe(80);
-
-    const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(validationPrompt).toContain('Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth');
-    expect(validationPrompt).toContain('generated artifacts on disk');
-    expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
-    expect(validationPrompt).toContain('claims broad domain coverage but the source base is too thin');
-    expect(validationPrompt).toContain('Set valid to false for any missing local artifact needed by returned runtime guidance');
-    expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
     expect(runSkill.mock.calls[2]![0].options.maxTurns).toBe(8);
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
@@ -502,15 +479,6 @@ Read \`references/authentication.md\` for login and session changes.
     expect(writtenSkill).toContain('references/security.md');
     expect(writtenSkill).toContain('references/authentication.md');
 
-    const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
-    expect(implementationPrompt).toContain('coverage checklist for this single writer pass');
-    expect(implementationPrompt).toContain('no automatic track contribution passes will run');
-    expect(implementationPrompt).toContain('Preserve track owns/excludes boundaries');
-
-    const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(validationPrompt).toContain('each outline track/task is covered');
-    expect(validationPrompt).toContain('Do not require one artifact per track');
-    expect(validationPrompt).toContain('represented only by a heading, topic name, or route entry');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {
@@ -1014,7 +982,7 @@ Read \`references/missing.md\` before reporting.
       authoringSkillRoot,
       regenerate: true,
     })).rejects.toThrow(
-      /Generated skill failed final review for wrdn-security:[\s\S]*references\/missing\.md/,
+      /Generated skill failed mechanical validation for wrdn-security:[\s\S]*references\/missing\.md/,
     );
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(incompleteSkill);
@@ -1108,7 +1076,7 @@ Read \`references/missing.md\` before reporting.
       authoringSkillRoot,
       regenerate: true,
     })).rejects.toThrow(
-      /Generated skill failed final review for wrdn-security:[\s\S]*SKILL\.md must start with YAML frontmatter/,
+      /Generated skill failed mechanical validation for wrdn-security:[\s\S]*SKILL\.md must start with YAML frontmatter/,
     );
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(skillMdWithoutFrontmatter());
@@ -1994,7 +1962,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       authoringSkillRoot,
       regenerate: true,
     })).rejects.toThrow(
-      /Generated skill failed final review for wrdn-security:[\s\S]*references\/security\.md/,
+      /Generated skill failed mechanical validation for wrdn-security:[\s\S]*references\/security\.md/,
     );
 
     expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(true);
@@ -2033,6 +2001,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
         usage: usage(),
         externalSources: [],
         missingInputs: [],
+        authoringWarnings: [],
         generatedAt: '2026-05-01T00:00:00.000Z',
       },
       updatedAt: '2026-05-01T00:00:00.000Z',
@@ -2117,7 +2086,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
   });
 
-  it('fails and preserves the draft when final provider review still reports issues', async () => {
+  it('warns and preserves the draft when provider review still reports issues after the loop cap', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -2215,7 +2184,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       };
     });
 
-    await expect(buildGeneratedSkill({
+    const artifact = await buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -2228,16 +2197,21 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    })).rejects.toThrow(
-      /Generated skill failed final review for wrdn-security:[\s\S]*Reference is 140 lines/,
-    );
+    });
 
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    expect(artifact.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('Authoring reviewer still requested changes after 3 revision passes'),
+      expect.stringContaining('Reference is 140 lines'),
+    ]));
+    expect(runSkill.mock.calls.filter((call) =>
+      call[0].skillName.endsWith(':authoring-revision')
+    )).toHaveLength(3);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact).toBeUndefined();
+    expect(state?.artifact?.authoringWarnings).toEqual(artifact.warnings);
   });
 
-  it('fails and preserves the writer draft when final provider review remains invalid', async () => {
+  it('records warnings and keeps the writer draft when final provider review remains invalid', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -2324,7 +2298,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       };
     });
 
-    await expect(buildGeneratedSkill({
+    const artifact = await buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -2337,12 +2311,17 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    })).rejects.toThrow(
-      /Generated skill failed final review for wrdn-security:[\s\S]*Runtime instructions are too shallow/,
-    );
+    });
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toBe(inlineSkillMd());
+    expect(artifact.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('Authoring reviewer still requested changes after 3 revision passes'),
+      expect.stringContaining('Runtime instructions are too shallow'),
+    ]));
+    expect(runSkill.mock.calls.filter((call) =>
+      call[0].skillName.endsWith(':authoring-revision')
+    )).toHaveLength(3);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact).toBeUndefined();
+    expect(state?.artifact?.authoringWarnings).toEqual(artifact.warnings);
   });
 });

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -276,22 +276,22 @@ describe('buildGeneratedSkill', () => {
     expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
     expect(planPrompt).toContain('Choose the simplest adequate layout using the authoring skill\'s rules');
     expect(planPrompt).toContain('Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references');
-    expect(planPrompt).toContain('Do not create a custom plaintext output format');
+    expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
     expect(planPrompt).toContain('Decide the minimum workflow path and simplest adequate artifact layout');
 
     const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
-    expect(implementationPrompt).toContain('Add SPEC.md, SOURCES.md, EVAL.md, references/, scripts/, or assets/ only when they add runtime, provenance, maintenance, validation, or reusable-example value');
+    expect(implementationPrompt).toContain('Add references/ only for routed runtime lookup leaves');
     expect(implementationPrompt).toContain('Keep SKILL.md compact; put optional depth in routed references');
+    expect(implementationPrompt).toContain('Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline');
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, stale gap/provenance language, missing routes, and custom output formats');
+    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.version).toBe(4);
     expect(state?.artifact?.authoringProvider.rootDir).toBe(authoringSkillRoot);
     expect(state?.artifact?.fileManifest.map((file) => file.path).sort()).toEqual([
       'SKILL.md',
-      'SOURCES.md',
       'references/security.md',
     ].sort());
   });
@@ -545,6 +545,103 @@ describe('buildGeneratedSkill', () => {
       'Review changed hunks for exploitable security issues.',
     );
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8').trim()).not.toBe('');
+  });
+
+  it('applies validation revisions while ignoring empty placeholder files', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const revisedSkill = skillMd().replace(
+      'Review changed hunks for exploitable security issues.',
+      'Review changed hunks for exploitable security issues. Trace before reporting.',
+    );
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Revised the runtime instruction.',
+            issues: [],
+            files: [
+              { path: 'SKILL.md', content: revisedSkill },
+              { path: 'references/placeholder.md', content: '' },
+            ],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
+    expect(existsSync(join(rootDir, 'references', 'placeholder.md'))).toBe(false);
   });
 
   it('merges and backfills partial replacement file maps returned by validation', async () => {
@@ -824,6 +921,110 @@ Read \`references/missing.md\` before reporting.
     );
   });
 
+  it('omits generated metadata artifacts and strips output contract sections', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const skillWithOutputContract = `${inlineSkillMd()}
+## Output Format
+
+Use Warden's JSON finding schema.
+
+See \`SPEC.md\` for maintenance details.
+`;
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillWithOutputContract },
+                {
+                  path: 'SOURCES.md',
+                  content: '# Sources\n\n## Authoring Decisions\n\nGenerated from the internal outline and build pipeline.\n',
+                },
+                {
+                  path: 'SPEC.md',
+                  content: '# Spec\n\n## Output Contract\n\nUse Warden report fields.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
+    expect(writtenSkill).not.toContain('Output Format');
+    expect(writtenSkill).not.toContain('JSON finding schema');
+    expect(writtenSkill).not.toContain('SPEC.md');
+    expect(existsSync(join(rootDir, 'SOURCES.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'SPEC.md'))).toBe(false);
+  });
+
   it('preserves legitimate runtime descriptions that mention generated code', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -1012,6 +1213,107 @@ Read \`references/missing.md\` before reporting.
       path: 'references/',
       message: 'Missing all reference files that SKILL.md routes to.',
     }]);
+  });
+
+  it('repairs routed reference files whose content does not match their path', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const skill = `---
+name: wrdn-security
+description: Use when asked to review code for exploitable security issues.
+---
+
+Read \`references/authentication.md\` when reviewing login, session, or JWT changes.
+`;
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and one routed reference'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skill },
+                {
+                  path: 'references/authentication.md',
+                  content: '# SQL Injection\n\nTrace database query construction and shell command execution.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    const reference = readFileSync(join(rootDir, 'references', 'authentication.md'), 'utf-8');
+    expect(reference).toContain('# Authentication');
+    expect(reference).not.toContain('SQL Injection');
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.deterministicWarnings).not.toContain(
+      'references/authentication.md content does not match its routed reference path',
+    );
   });
 
   it('backfills files routed by a generated reference index', async () => {

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -427,6 +427,202 @@ describe('buildGeneratedSkill', () => {
     }]);
   });
 
+  it('ignores empty placeholder files returned by validation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'The generated skill is valid; no revised files are needed.',
+            issues: [],
+            files: [
+              { path: 'SKILL.md', content: '' },
+              {
+                path: 'references/security.md',
+                content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+              },
+            ],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain(
+      'Review changed hunks for exploitable security issues.',
+    );
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8').trim()).not.toBe('');
+  });
+
+  it('ignores incomplete replacement file maps returned by validation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const incompleteSkill = `---
+name: wrdn-security
+description: Use when asked to review code for exploitable security issues.
+---
+
+Read \`references/missing.md\` before reporting.
+`;
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'The generated skill is valid; revised files are included.',
+            issues: [],
+            files: [{ path: 'SKILL.md', content: incompleteSkill }],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
+    expect(writtenSkill).toContain('references/security.md');
+    expect(writtenSkill).not.toContain('references/missing.md');
+  });
+
   it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -252,7 +252,17 @@ describe('buildGeneratedSkill', () => {
 
     const planPrompt = runSkill.mock.calls[0]![0].userPrompt;
     expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
-    expect(planPrompt).toContain('clear review tasks, routing cues, evidence requirements');
+    expect(planPrompt).toContain('Choose the simplest adequate layout using the authoring skill\'s rules');
+    expect(planPrompt).toContain('Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references');
+    expect(planPrompt).toContain('Do not create a custom plaintext output format');
+    expect(planPrompt).toContain('Decide the minimum workflow path and simplest adequate artifact layout');
+
+    const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
+    expect(implementationPrompt).toContain('Add SPEC.md, SOURCES.md, EVAL.md, references/, scripts/, or assets/ only when they add runtime, provenance, maintenance, validation, or reusable-example value');
+    expect(implementationPrompt).toContain('Keep SKILL.md compact; put optional depth in routed references');
+
+    const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
+    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, stale gap/provenance language, missing routes, and custom output formats');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.version).toBe(4);

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -345,6 +345,8 @@ describe('buildGeneratedSkill', () => {
     expect(runSkill.mock.calls[1]![0].repoPath).toBe(rootDir);
     expect(runSkill.mock.calls[1]![0].allowMutatingTools).toBe(true);
     expect(runSkill.mock.calls[1]![0].tools?.allowed).toEqual(expect.arrayContaining(['Write', 'Edit', 'Bash']));
+    expect(runSkill.mock.calls[0]![0].options.maxTurns).toBe(80);
+    expect(runSkill.mock.calls[1]![0].options.maxTurns).toBe(80);
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(validationPrompt).toContain('Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth');
@@ -353,6 +355,7 @@ describe('buildGeneratedSkill', () => {
     expect(validationPrompt).toContain('claims broad domain coverage but the source base is too thin');
     expect(validationPrompt).toContain('Set valid to false for any missing local artifact needed by returned runtime guidance');
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
+    expect(runSkill.mock.calls[2]![0].options.maxTurns).toBe(8);
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.version).toBe(5);

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -275,7 +275,8 @@ describe('buildGeneratedSkill', () => {
     const planPrompt = runSkill.mock.calls[0]![0].userPrompt;
     expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
     expect(planPrompt).toContain('Choose the simplest adequate layout using the authoring skill\'s rules');
-    expect(planPrompt).toContain('Broad or multi-track skills usually need SKILL.md as a compact router plus focused routed references');
+    expect(planPrompt).toContain('Tracks/tasks are planning work lanes, not filesystem taxonomy');
+    expect(planPrompt).toContain('Do not create `references/tracks/`');
     expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
     expect(planPrompt).toContain('Decide the minimum workflow path and simplest adequate artifact layout');
 
@@ -286,6 +287,7 @@ describe('buildGeneratedSkill', () => {
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(validationPrompt).toContain('Check for over-broad topic-bucket references, stale gap/provenance language, generated-skill metadata, missing routes');
+    expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.version).toBe(4);
@@ -294,6 +296,174 @@ describe('buildGeneratedSkill', () => {
       'SKILL.md',
       'references/security.md',
     ].sort());
+  });
+
+  it('runs sequential track contributions without turning tracks into directories', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    buildOutline.tracks = [
+      buildOutline.tracks[0]!,
+      {
+        id: 'authentication',
+        title: 'Authentication review',
+        goal: 'Find authentication bypass issues.',
+        rationale: 'Authentication-sensitive changes need a separate work lane.',
+        sourceSignals: ['login and session prompts'],
+        owns: ['authentication bypass'],
+        excludes: ['generic injection'],
+        relevanceSignals: ['login or session changes'],
+        evidenceFocus: ['changed-line authentication decision'],
+        checks: ['trace identity checks'],
+        safeCounterpatterns: ['centralized auth middleware still enforced'],
+        falsePositiveTraps: ['confusing authorization with authentication'],
+        researchHints: [],
+      },
+    ];
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan sequential work lanes.',
+              workflow: ['Read the authoring skill', 'Create a baseline router', 'Add each work lane'],
+              researchPlan: ['Use prompt and track boundaries'],
+              artifactPlan: ['Use focused references only where needed'],
+              validationPlan: ['Run rough validation'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
+              summary: 'Created baseline skill.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-track-security')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              files: [{
+                path: 'references/tracks/security.md',
+                content: '# Security Review\n\nTrace attacker-controlled input before reporting.\n',
+              }],
+              summary: 'Added security checks.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-track-authentication')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              files: [
+                {
+                  path: 'SKILL.md',
+                  content: `${inlineSkillMd()}
+## References
+
+Read \`references/tracks/security.md\` for general exploitability checks.
+Read \`references/tracks/authentication.md\` for login and session changes.
+`,
+                },
+                {
+                  path: 'references/tracks/authentication.md',
+                  content: '# Authentication Review\n\nTrace identity checks and session state before reporting.\n',
+                },
+              ],
+              summary: 'Added authentication guidance.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(runSkill.mock.calls.map((call) => call[0].skillName)).toEqual([
+      'wrdn-security:authoring-plan',
+      'wrdn-security:authoring-implementation',
+      'wrdn-security:authoring-track-security',
+      'wrdn-security:authoring-track-authentication',
+      'wrdn-security:authoring-validation',
+    ]);
+    expect(existsSync(join(rootDir, 'references', 'tracks'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    expect(existsSync(join(rootDir, 'references', 'authentication.md'))).toBe(true);
+    const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
+    expect(writtenSkill).toContain('references/security.md');
+    expect(writtenSkill).toContain('references/authentication.md');
+    expect(writtenSkill).not.toContain('references/tracks/');
+
+    const trackPrompt = runSkill.mock.calls[2]![0].userPrompt;
+    expect(trackPrompt).toContain('Treat the assigned track as a work lane');
+    expect(trackPrompt).toContain('It may map to one reference, multiple references, a shared reference, or no new file');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {
@@ -832,7 +1002,7 @@ Read \`references/missing.md\` before reporting.
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.deterministicWarnings).toContain(
-      'SKILL.md does not route runtime reference references/security.md',
+      'warning: SKILL.md does not route runtime reference references/security.md',
     );
   });
 
@@ -1215,7 +1385,7 @@ See \`SPEC.md\` for maintenance details.
     }]);
   });
 
-  it('repairs routed reference files whose content does not match their path', async () => {
+  it('does not rewrite routed reference content based on filename heuristics', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1308,12 +1478,9 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     });
 
     const reference = readFileSync(join(rootDir, 'references', 'authentication.md'), 'utf-8');
-    expect(reference).toContain('# Authentication');
-    expect(reference).not.toContain('SQL Injection');
+    expect(reference).toContain('# SQL Injection');
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.deterministicWarnings).not.toContain(
-      'references/authentication.md content does not match its routed reference path',
-    );
+    expect(state?.artifact?.deterministicWarnings).toEqual([]);
   });
 
   it('backfills files routed by a generated reference index', async () => {
@@ -1407,7 +1574,7 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
     expect(nestedReference).toContain('pattern-only claims');
   });
 
-  it('does not reuse cached artifacts with missing routed reference files', async () => {
+  it('backfills cached artifacts with missing routed reference files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1517,8 +1684,8 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
       authoringSkillRoot,
     });
 
-    expect(artifact.source).toBe('generated');
-    expect(runSkill).toHaveBeenCalled();
+    expect(artifact.source).toBe('cache');
+    expect(runSkill).not.toHaveBeenCalled();
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
   });
 

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Runtime, SkillRunRequest, SkillRunResponse } from '../sdk/runtimes/index.js';
 import { buildGeneratedSkill } from './skill.js';
+import { resolveAuthoringProvider } from './authoring-provider.js';
 import {
   getBuildStatePath,
   readSkillBuildState,
@@ -11,7 +12,7 @@ import {
   SKILL_BUILD_STATE_SCHEMA_VERSION,
   writeSkillBuildState,
 } from './outline-state.js';
-import type { SkillBuildOutline, SkillBuildSource } from './outline-contract.js';
+import { outlineHash, type SkillBuildOutline, type SkillBuildSource } from './outline-contract.js';
 
 function usage() {
   return { inputTokens: 1, outputTokens: 1, costUSD: 0 };
@@ -109,6 +110,39 @@ Review changed hunks for exploitable security issues.
 ## What to Report
 
 - Concrete exploitable security findings anchored to changed lines.
+`;
+}
+
+function inlineSkillMd(name = 'wrdn-security'): string {
+  return `---
+name: ${name}
+description: Use when asked to review code for exploitable security issues.
+allowed-tools: Read Grep Glob Bash
+---
+
+Review changed hunks for exploitable security issues.
+`;
+}
+
+function skillMdWithoutFrontmatter(): string {
+  return `# Security Review
+
+Review changed hunks for exploitable security issues.
+`;
+}
+
+function indexedSkillMd(name = 'wrdn-security'): string {
+  return `---
+name: ${name}
+description: Use when asked to review code for exploitable security issues.
+allowed-tools: Read Grep Glob Bash
+---
+
+Review changed hunks for exploitable security issues.
+
+## References
+
+Read \`references/checklist.md\` first. It routes to the detailed reference files.
 `;
 }
 
@@ -230,6 +264,48 @@ describe('buildGeneratedSkill', () => {
     ].sort());
   });
 
+  it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(join(rootDir, 'references'), { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    writeFileSync(join(rootDir, 'SKILL.md'), indexedSkillMd(), 'utf-8');
+    writeFileSync(
+      join(rootDir, 'references', 'checklist.md'),
+      '# Checklist\n\n| When | Read |\n|------|------|\n| Security-sensitive hunk | `references/security.md` |\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(rootDir, 'references', 'security.md'),
+      '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+      'utf-8',
+    );
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+    const runSkill = vi.fn<Runtime['runSkill']>();
+
+    const artifact = await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+    });
+
+    expect(artifact.source).toBe('cache');
+    expect(artifact.name).toBe('wrdn-security');
+    expect(artifact.bytes).toBeGreaterThan(0);
+    expect(runSkill).not.toHaveBeenCalled();
+  });
+
   it('lets the validation pass return revised files', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -341,6 +417,384 @@ describe('buildGeneratedSkill', () => {
     }]);
   });
 
+  it('writes generated artifacts when frontmatter is missing and references are not routed', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and references'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMdWithoutFrontmatter() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Review code for exploitable security issues.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(/^---\nname: "wrdn-security"\n/);
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.deterministicWarnings).toContain(
+      'SKILL.md does not route runtime reference references/security.md',
+    );
+  });
+
+  it('fails when SKILL.md routes reference files missing from the file map', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and one routed reference'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: skillMd() }],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await expect(buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    })).rejects.toThrow('SKILL.md routes references/security.md but the generated file map does not include it');
+
+    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+  });
+
+  it('fails when a routed index references missing files', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and a routed checklist'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: indexedSkillMd() },
+                {
+                  path: 'references/checklist.md',
+                  content: '# Checklist\n\n| When | Read |\n|------|------|\n| Security-sensitive hunk | `references/security.md` |\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await expect(buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    })).rejects.toThrow('SKILL.md routes references/security.md but the generated file map does not include it');
+
+    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+  });
+
+  it('does not reuse cached artifacts with missing routed reference files', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const cachedSkill = skillMd();
+    writeFileSync(join(rootDir, 'SKILL.md'), cachedSkill, 'utf-8');
+    const buildOutline = outline();
+    const cachedBytes = Buffer.byteLength(cachedSkill, 'utf-8');
+    writeSkillBuildState(getBuildStatePath(rootDir), {
+      version: SKILL_BUILD_STATE_SCHEMA_VERSION,
+      kind: SKILL_BUILD_STATE_KIND,
+      identity: {},
+      outline: buildOutline,
+      artifact: {
+        version: 4,
+        sourceHash: source().hash,
+        outlineHash: outlineHash(buildOutline),
+        buildVersion: buildOutline.buildVersion,
+        authoringProvider: resolveAuthoringProvider({ authoringSkillRoot }),
+        name: 'wrdn-security',
+        fileManifest: [{ path: 'SKILL.md', bytes: cachedBytes }],
+        deterministicWarnings: [],
+        validationIssues: [],
+        bytes: cachedBytes,
+        durationMs: 10,
+        usage: usage(),
+        externalSources: [],
+        missingInputs: [],
+        generatedAt: '2026-05-01T00:00:00.000Z',
+      },
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and one routed reference'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    const artifact = await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+    });
+
+    expect(artifact.source).toBe('generated');
+    expect(runSkill).toHaveBeenCalled();
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+  });
+
   it('fails when provider validation reports unresolved errors', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -378,7 +832,7 @@ describe('buildGeneratedSkill', () => {
             text: JSON.stringify({
               version: 1,
               name: 'wrdn-security',
-              files: [{ path: 'SKILL.md', content: skillMd() }],
+              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
               summary: 'Generated.',
               validationNotes: [],
               missingInputs: [],

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -658,6 +658,9 @@ Read \`references/tracks/authentication.md\` for login and session changes.
       'wrdn-security:authoring-revision',
       'wrdn-security:authoring-validation',
     ]);
+    expect(runSkill.mock.calls[2]![0].userPrompt).not.toContain(
+      'Flattened generated reference path(s)',
+    );
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.validationIssues).toEqual([]);
   });
@@ -1208,6 +1211,100 @@ See \`SPEC.md\` for maintenance details.
     expect(writtenSkill).not.toContain('SPEC.md');
     expect(existsSync(join(rootDir, 'SOURCES.md'))).toBe(false);
     expect(existsSync(join(rootDir, 'SPEC.md'))).toBe(false);
+  });
+
+  it('keeps sources files that document real external sources', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: inlineSkillMd() },
+                {
+                  path: 'SOURCES.md',
+                  content: '# Sources\n\n- [OWASP CI/CD Security](https://owasp.org/www-project-top-10-ci-cd-security-risks/): build pipeline threat model.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [{
+                title: 'OWASP CI/CD Security',
+                url: 'https://owasp.org/www-project-top-10-ci-cd-security-risks/',
+                reason: 'Used to scope build pipeline security guidance.',
+              }],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SOURCES.md'), 'utf-8')).toContain(
+      'https://owasp.org/www-project-top-10-ci-cd-security-risks/',
+    );
   });
 
   it('backfills routed references before stripping output contract sections', async () => {

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -296,7 +296,7 @@ describe('buildGeneratedSkill', () => {
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
     expect(validationPrompt).toContain('Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth');
     expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
-    expect(validationPrompt).toContain('claims broad security coverage but the source base is too thin');
+    expect(validationPrompt).toContain('claims broad domain coverage but the source base is too thin');
     expect(validationPrompt).toContain('Set valid to false for any missing local artifact needed by returned runtime guidance');
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
@@ -314,7 +314,7 @@ describe('buildGeneratedSkill', () => {
     }]);
   });
 
-  it('runs sequential track contributions without turning tracks into artifact layout', async () => {
+  it('uses outline tracks as single-writer coverage input without automatic track passes', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -349,8 +349,8 @@ describe('buildGeneratedSkill', () => {
             status: 'success',
             text: JSON.stringify({
               version: 1,
-              summary: 'Plan sequential work lanes.',
-              workflow: ['Read the authoring skill', 'Create a baseline router', 'Add each work lane'],
+              summary: 'Plan ordered work lanes.',
+              workflow: ['Read the authoring skill', 'Create one complete skill draft'],
               researchPlan: ['Use prompt and track boundaries'],
               artifactPlan: ['Use focused references only where needed'],
               validationPlan: ['Run rough validation'],
@@ -369,43 +369,6 @@ describe('buildGeneratedSkill', () => {
             text: JSON.stringify({
               version: 1,
               name: 'wrdn-security',
-              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
-              summary: 'Created baseline skill.',
-              validationNotes: [],
-              missingInputs: [],
-              externalSources: [],
-            }),
-            errors: [],
-            usage: usage(),
-          },
-        };
-      }
-      if (request.skillName.endsWith(':authoring-track-security')) {
-        return {
-          result: {
-            status: 'success',
-            text: JSON.stringify({
-              version: 1,
-              files: [{
-                path: 'references/security.md',
-                content: '# Security Review\n\nTrace attacker-controlled input before reporting.\n',
-              }],
-              summary: 'Added security checks.',
-              validationNotes: [],
-              missingInputs: [],
-              externalSources: [],
-            }),
-            errors: [],
-            usage: usage(),
-          },
-        };
-      }
-      if (request.skillName.endsWith(':authoring-track-authentication')) {
-        return {
-          result: {
-            status: 'success',
-            text: JSON.stringify({
-              version: 1,
               files: [
                 {
                   path: 'SKILL.md',
@@ -417,11 +380,15 @@ Read \`references/authentication.md\` for login and session changes.
 `,
                 },
                 {
+                  path: 'references/security.md',
+                  content: '# Security Review\n\nTrace attacker-controlled input before reporting.\n',
+                },
+                {
                   path: 'references/authentication.md',
                   content: '# Authentication Review\n\nTrace identity checks and session state before reporting.\n',
                 },
               ],
-              summary: 'Added authentication guidance.',
+              summary: 'Created a complete skill draft from the outline tracks.',
               validationNotes: [],
               missingInputs: [],
               externalSources: [],
@@ -431,20 +398,23 @@ Read \`references/authentication.md\` for login and session changes.
           },
         };
       }
-      return {
-        result: {
-          status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Validated.',
-            issues: [],
-            missingInputs: [],
-          }),
-          errors: [],
-          usage: usage(),
-        },
-      };
+      if (request.skillName.endsWith(':authoring-validation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              valid: true,
+              summary: 'Validated all outline track coverage.',
+              issues: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      throw new Error(`Unexpected skill builder request: ${request.skillName}`);
     });
 
     await buildGeneratedSkill({
@@ -465,20 +435,25 @@ Read \`references/authentication.md\` for login and session changes.
     expect(runSkill.mock.calls.map((call) => call[0].skillName)).toEqual([
       'wrdn-security:authoring-plan',
       'wrdn-security:authoring-implementation',
-      'wrdn-security:authoring-track-security',
-      'wrdn-security:authoring-track-authentication',
       'wrdn-security:authoring-validation',
     ]);
+    expect(runSkill.mock.calls.some((call) => call[0].skillName.includes(':authoring-track-')))
+      .toBe(false);
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
     expect(existsSync(join(rootDir, 'references', 'authentication.md'))).toBe(true);
     const writtenSkill = readFileSync(join(rootDir, 'SKILL.md'), 'utf-8');
     expect(writtenSkill).toContain('references/security.md');
     expect(writtenSkill).toContain('references/authentication.md');
 
-    const trackPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(trackPrompt).toContain('Treat the assigned track as a bounded coverage work lane');
-    expect(trackPrompt).toContain('Let the authoring skill decide where any resulting guidance belongs');
-    expect(trackPrompt).toContain('Topic names or sink catalogs alone do not count as coverage');
+    const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
+    expect(implementationPrompt).toContain('coverage checklist for this single writer pass');
+    expect(implementationPrompt).toContain('no automatic track contribution passes will run');
+    expect(implementationPrompt).toContain('Preserve track owns/excludes boundaries');
+
+    const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
+    expect(validationPrompt).toContain('each outline track/task is covered');
+    expect(validationPrompt).toContain('Do not require one artifact per track');
+    expect(validationPrompt).toContain('represented only by a heading, topic name, or route entry');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -131,6 +131,17 @@ Review changed hunks for exploitable security issues.
 `;
 }
 
+function skillMdWithAuthoringDescription(name = 'wrdn-security'): string {
+  return `---
+name: ${name}
+description: "Generated wrdn-security skill with reference-backed-expert architecture: SKILL.md router and focused references."
+allowed-tools: Read Grep Glob Bash
+---
+
+Review changed hunks for exploitable security issues.
+`;
+}
+
 function indexedSkillMd(name = 'wrdn-security'): string {
   return `---
 name: ${name}
@@ -716,6 +727,90 @@ Read \`references/missing.md\` before reporting.
     );
   });
 
+  it('repairs generated frontmatter descriptions that contain authoring metadata', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: skillMdWithAuthoringDescription() }],
+              summary: 'Generated wrdn-security skill with reference-backed-expert architecture.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: true,
+            summary: 'Validated.',
+            issues: [],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toMatch(
+      /^---\nname: "wrdn-security"\ndescription: "Use when reviewing code changes for security concerns\."/,
+    );
+  });
+
   it('backfills routed reference files missing from the generated file map', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
@@ -769,9 +864,17 @@ Read \`references/missing.md\` before reporting.
           status: 'success',
           text: JSON.stringify({
             version: 1,
-            valid: true,
-            summary: 'Validated.',
-            issues: [],
+            valid: false,
+            summary: 'Provider saw the original file map as incomplete.',
+            issues: [{
+              severity: 'error',
+              path: 'generated_file_map',
+              message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
+            }, {
+              severity: 'error',
+              path: 'references/',
+              message: 'Missing all reference files that SKILL.md routes to.',
+            }],
             missingInputs: [],
           }),
           errors: [],
@@ -802,6 +905,15 @@ Read \`references/missing.md\` before reporting.
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.fileManifest.some((file) => file.path === 'references/security.md'))
       .toBe(true);
+    expect(state?.artifact?.validationIssues).toEqual([{
+      severity: 'warning',
+      path: 'generated_file_map',
+      message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
+    }, {
+      severity: 'warning',
+      path: 'references/',
+      message: 'Missing all reference files that SKILL.md routes to.',
+    }]);
   });
 
   it('backfills files routed by a generated reference index', async () => {
@@ -1109,7 +1221,7 @@ Read \`references/missing.md\` before reporting.
     }]);
   });
 
-  it('fails when provider validation reports unresolved errors', async () => {
+  it('records provider validation errors without blocking valid generated artifacts', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -1177,7 +1289,7 @@ Read \`references/missing.md\` before reporting.
       };
     });
 
-    await expect(buildGeneratedSkill({
+    const artifact = await buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -1190,8 +1302,15 @@ Read \`references/missing.md\` before reporting.
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    })).rejects.toThrow('failed provider validation');
+    });
 
-    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+    expect(artifact.source).toBe('generated');
+    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(true);
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.validationIssues).toEqual([{
+      severity: 'warning',
+      path: 'SKILL.md',
+      message: 'Runtime instructions are too shallow.',
+    }]);
   });
 });

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -508,7 +508,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(runSkill).not.toHaveBeenCalled();
   });
 
-  it('lets the validation pass return revised files', async () => {
+  it('feeds standards feedback to a revision writer', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -522,6 +522,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
       'Review changed hunks for exploitable security issues.',
       'Review changed hunks for exploitable security issues. Trace before reporting.',
     );
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -566,28 +567,54 @@ Read \`references/tracks/authentication.md\` for login and session changes.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: revisedSkill },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Revised the runtime instruction.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Revised the runtime instruction.',
-            issues: [{
-              severity: 'warning',
-              path: 'SKILL.md',
-              message: 'Runtime instruction should be more explicit.',
-              suggestedFix: 'Add trace guidance.',
-            }],
-            files: [
-              { path: 'SKILL.md', content: revisedSkill },
-              {
-                path: 'references/security.md',
-                content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
-              },
-            ],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Runtime instruction should be more explicit.',
+              issues: [{
+                severity: 'warning',
+                path: 'SKILL.md',
+                message: 'Runtime instruction should be more explicit.',
+                suggestedFix: 'Add trace guidance.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Revised skill passes standards.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -610,13 +637,15 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     });
 
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8')).toContain('Trace before reporting.');
+    expect(runSkill.mock.calls.map((call) => call[0].skillName)).toEqual([
+      'wrdn-security:authoring-plan',
+      'wrdn-security:authoring-implementation',
+      'wrdn-security:authoring-validation',
+      'wrdn-security:authoring-revision',
+      'wrdn-security:authoring-validation',
+    ]);
     const state = readSkillBuildState(getBuildStatePath(rootDir));
-    expect(state?.artifact?.validationIssues).toEqual([{
-      severity: 'warning',
-      path: 'SKILL.md',
-      message: 'Runtime instruction should be more explicit.',
-      suggestedFix: 'Add trace guidance.',
-    }]);
+    expect(state?.artifact?.validationIssues).toEqual([]);
   });
 
   it('ignores empty placeholder files returned by validation', async () => {
@@ -717,7 +746,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(readFileSync(join(rootDir, 'SKILL.md'), 'utf-8').trim()).not.toBe('');
   });
 
-  it('applies validation revisions while ignoring empty placeholder files', async () => {
+  it('applies revision writer output after review feedback', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -731,6 +760,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
       'Review changed hunks for exploitable security issues.',
       'Review changed hunks for exploitable security issues. Trace before reporting.',
     );
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -775,20 +805,53 @@ Read \`references/tracks/authentication.md\` for login and session changes.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: revisedSkill },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Applied review feedback.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'Revised the runtime instruction.',
-            issues: [],
-            files: [
-              { path: 'SKILL.md', content: revisedSkill },
-              { path: 'references/placeholder.md', content: '' },
-            ],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Needs a more explicit runtime instruction.',
+              issues: [{
+                severity: 'warning',
+                path: 'SKILL.md',
+                message: 'Runtime instruction should be more explicit.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Revised skill passes standards.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -814,7 +877,7 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(existsSync(join(rootDir, 'references', 'placeholder.md'))).toBe(false);
   });
 
-  it('merges and backfills partial replacement file maps returned by validation', async () => {
+  it('backfills routed references added by revision writer output', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -831,6 +894,7 @@ description: Use when asked to review code for exploitable security issues.
 
 Read \`references/missing.md\` before reporting.
 `;
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -875,17 +939,53 @@ Read \`references/missing.md\` before reporting.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: incompleteSkill },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Added missing route guidance.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: true,
-            summary: 'The generated skill is valid; revised files are included.',
-            issues: [],
-            files: [{ path: 'SKILL.md', content: incompleteSkill }],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'A route should be added for the missing reference.',
+              issues: [{
+                severity: 'warning',
+                path: 'SKILL.md',
+                message: 'Add the missing route.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Revised skill passes standards.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -1378,6 +1478,7 @@ Read \`references/output-format.md\` before changing output behavior.
     const buildOutline = outline();
     writeInitialState(rootDir, buildOutline);
 
+    let reviewCalls = 0;
     const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
       if (request.skillName.endsWith(':authoring-plan')) {
         return {
@@ -1416,24 +1517,51 @@ Read \`references/output-format.md\` before changing output behavior.
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: skillMd() }],
+              summary: 'Re-emitted the routed skill for reference backfill.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      reviewCalls += 1;
       return {
         result: {
           status: 'success',
-          text: JSON.stringify({
-            version: 1,
-            valid: false,
-            summary: 'Provider saw the original file map as incomplete.',
-            issues: [{
-              severity: 'error',
-              path: 'generated_file_map',
-              message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
-            }, {
-              severity: 'error',
-              path: 'references/',
-              message: 'Missing all reference files that SKILL.md routes to.',
-            }],
-            missingInputs: [],
-          }),
+          text: JSON.stringify(reviewCalls === 1
+            ? {
+              version: 1,
+              valid: false,
+              summary: 'Provider saw the original file map as incomplete.',
+              issues: [{
+                severity: 'error',
+                path: 'generated_file_map',
+                message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
+              }, {
+                severity: 'error',
+                path: 'references/',
+                message: 'Missing all reference files that SKILL.md routes to.',
+              }],
+              missingInputs: [],
+            }
+            : {
+              version: 1,
+              valid: true,
+              summary: 'Revised skill passes standards.',
+              issues: [],
+              missingInputs: [],
+            }),
           errors: [],
           usage: usage(),
         },
@@ -1462,15 +1590,7 @@ Read \`references/output-format.md\` before changing output behavior.
     const state = readSkillBuildState(getBuildStatePath(rootDir));
     expect(state?.artifact?.fileManifest.some((file) => file.path === 'references/security.md'))
       .toBe(true);
-    expect(state?.artifact?.validationIssues).toEqual([{
-      severity: 'warning',
-      path: 'generated_file_map',
-      message: 'Files array only contains SKILL.md but SKILL.md routes reference files that are not included.',
-    }, {
-      severity: 'warning',
-      path: 'references/',
-      message: 'Missing all reference files that SKILL.md routes to.',
-    }]);
+    expect(state?.artifact?.validationIssues).toEqual([]);
   });
 
   it('does not rewrite routed reference content based on filename heuristics', async () => {
@@ -1831,6 +1951,30 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
           },
         };
       }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Kept the current layout after review.',
+              validationNotes: ['Navigation warning remains advisory.'],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
       return {
         result: {
           status: 'success',
@@ -1916,6 +2060,24 @@ Read \`references/authentication.md\` when reviewing login, session, or JWT chan
               files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
               summary: 'Generated.',
               validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-revision')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [{ path: 'SKILL.md', content: inlineSkillMd() }],
+              summary: 'Kept the current runtime guidance after review.',
+              validationNotes: ['Reviewer still considers the skill shallow.'],
               missingInputs: [],
               externalSources: [],
             }),

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -280,27 +280,25 @@ describe('buildGeneratedSkill', () => {
 
     const planPrompt = runSkill.mock.calls[0]![0].userPrompt;
     expect(planPrompt).toContain(`Use the full authoring skill at \`${authoringSkillRoot}\``);
-    expect(planPrompt).toContain('Choose the simplest adequate layout using the authoring skill\'s rules');
-    expect(planPrompt).toContain('Tracks/tasks are planning work lanes, not filesystem taxonomy');
-    expect(planPrompt).toContain('Do not create `references/tracks/`');
+    expect(planPrompt).toContain('Let the authoring skill decide the simplest adequate artifact layout');
+    expect(planPrompt).toContain('Treat outline tracks/tasks as work lanes for coverage and sequencing');
+    expect(planPrompt).not.toContain('references/tracks/');
     expect(planPrompt).toContain('Do not include Output Format, Output Contract, Response Format, or custom reporting schema sections');
     expect(planPrompt).toContain('Build the authoring brief first');
-    expect(planPrompt).toContain('For every planned routed reference, define the lookup question');
+    expect(planPrompt).toContain('without turning tracks into layout rules');
     expect(planPrompt).toContain('define the source coverage needed before the skill can be considered complete');
 
     const implementationPrompt = runSkill.mock.calls[1]![0].userPrompt;
-    expect(implementationPrompt).toContain('Add references/ only for routed runtime lookup leaves');
-    expect(implementationPrompt).toContain('Keep SKILL.md compact; put optional depth in routed references');
+    expect(implementationPrompt).toContain('Include every local artifact that SKILL.md or another returned artifact requires at runtime');
     expect(implementationPrompt).toContain('Satisfy the plan\'s lookupQuestions and qualityBar');
-    expect(implementationPrompt).toContain('Do not ship catalog-only references');
-    expect(implementationPrompt).toContain('Prefer no SOURCES.md over a SOURCES.md that says the skill came from the internal outline');
+    expect(implementationPrompt).toContain('Do not ship catalog-only runtime guidance');
     expect(implementationPrompt).toContain('externalSources array is cumulative evidence for the final artifact');
 
     const validationPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(validationPrompt).toContain('Check for over-broad topic-bucket references, catalog-only references, missing source depth');
+    expect(validationPrompt).toContain('Check for over-broad topic buckets, catalog-only runtime guidance, missing source depth');
     expect(validationPrompt).toContain('Set valid to false for concrete quality failures');
     expect(validationPrompt).toContain('claims broad security coverage but the source base is too thin');
-    expect(validationPrompt).toContain('Set valid to false for any missing routed local file');
+    expect(validationPrompt).toContain('Set valid to false for any missing local artifact needed by returned runtime guidance');
     expect(validationPrompt).toContain('Treat rough validation issues as advisory signals');
 
     const state = readSkillBuildState(getBuildStatePath(rootDir));
@@ -481,9 +479,10 @@ Read \`references/tracks/authentication.md\` for login and session changes.
     expect(writtenSkill).not.toContain('references/tracks/');
 
     const trackPrompt = runSkill.mock.calls[2]![0].userPrompt;
-    expect(trackPrompt).toContain('Treat the assigned track as a work lane');
-    expect(trackPrompt).toContain('It may map to one reference, multiple references, a shared reference, or no new file');
+    expect(trackPrompt).toContain('Treat the assigned track as a bounded coverage work lane');
+    expect(trackPrompt).toContain('Let the authoring skill decide where any resulting guidance belongs');
     expect(trackPrompt).toContain('Topic names or sink catalogs alone do not count as coverage');
+    expect(trackPrompt).not.toContain('references/tracks/');
   });
 
   it('reuses valid existing artifacts when artifact metadata is missing or legacy', async () => {

--- a/src/skill-builder/skill.test.ts
+++ b/src/skill-builder/skill.test.ts
@@ -716,7 +716,7 @@ Read \`references/missing.md\` before reporting.
     );
   });
 
-  it('fails when SKILL.md routes reference files missing from the file map', async () => {
+  it('backfills routed reference files missing from the generated file map', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -780,7 +780,7 @@ Read \`references/missing.md\` before reporting.
       };
     });
 
-    await expect(buildGeneratedSkill({
+    await buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -793,12 +793,18 @@ Read \`references/missing.md\` before reporting.
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    })).rejects.toThrow('SKILL.md routes references/security.md but the generated file map does not include it');
+    });
 
-    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+    const reference = readFileSync(join(rootDir, 'references', 'security.md'), 'utf-8');
+    expect(reference).toContain('# Security review');
+    expect(reference).toContain('trace data flow');
+    expect(reference).toContain('changed-line evidence');
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.fileManifest.some((file) => file.path === 'references/security.md'))
+      .toBe(true);
   });
 
-  it('fails when a routed index references missing files', async () => {
+  it('backfills files routed by a generated reference index', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
     tempDirs.push(tempDir);
     const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
@@ -868,7 +874,7 @@ Read \`references/missing.md\` before reporting.
       };
     });
 
-    await expect(buildGeneratedSkill({
+    await buildGeneratedSkill({
       outline: buildOutline,
       source: source(),
       rootDir,
@@ -881,9 +887,12 @@ Read \`references/missing.md\` before reporting.
       repoPath: tempDir,
       authoringSkillRoot,
       regenerate: true,
-    })).rejects.toThrow('SKILL.md routes references/security.md but the generated file map does not include it');
+    });
 
-    expect(existsSync(join(rootDir, 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(rootDir, 'references', 'checklist.md'))).toBe(true);
+    const nestedReference = readFileSync(join(rootDir, 'references', 'security.md'), 'utf-8');
+    expect(nestedReference).toContain('# Security review');
+    expect(nestedReference).toContain('pattern-only claims');
   });
 
   it('does not reuse cached artifacts with missing routed reference files', async () => {
@@ -999,6 +1008,105 @@ Read \`references/missing.md\` before reporting.
     expect(artifact.source).toBe('generated');
     expect(runSkill).toHaveBeenCalled();
     expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+  });
+
+  it('writes generated artifacts when provider validation reports reference navigation errors', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-skill-build-'));
+    tempDirs.push(tempDir);
+    const rootDir = join(tempDir, '.warden', 'skills', 'wrdn-security');
+    const authoringSkillRoot = createAuthoringSkillRoot(tempDir);
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'warden.yaml'), source().files[0]!.content, 'utf-8');
+    const buildOutline = outline();
+    writeInitialState(rootDir, buildOutline);
+
+    const runSkill = vi.fn<Runtime['runSkill']>(async (request: SkillRunRequest): Promise<SkillRunResponse> => {
+      if (request.skillName.endsWith(':authoring-plan')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              summary: 'Plan.',
+              workflow: ['Read the authoring skill'],
+              researchPlan: [],
+              artifactPlan: ['Create SKILL.md and one routed reference'],
+              validationPlan: ['Validate output'],
+              risks: [],
+              missingInputs: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      if (request.skillName.endsWith(':authoring-implementation')) {
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({
+              version: 1,
+              name: 'wrdn-security',
+              files: [
+                { path: 'SKILL.md', content: skillMd() },
+                {
+                  path: 'references/security.md',
+                  content: '# Security Reference\n\nUse this when the hunk touches authentication or user-controlled input.\n',
+                },
+              ],
+              summary: 'Generated.',
+              validationNotes: [],
+              missingInputs: [],
+              externalSources: [],
+            }),
+            errors: [],
+            usage: usage(),
+          },
+        };
+      }
+      return {
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            version: 1,
+            valid: false,
+            summary: 'The generated skill has non-blocking warnings.',
+            issues: [{
+              severity: 'error',
+              path: 'references/security.md',
+              message: 'Reference is 140 lines without ## Contents section for navigation.',
+            }],
+            missingInputs: [],
+          }),
+          errors: [],
+          usage: usage(),
+        },
+      };
+    });
+
+    const artifact = await buildGeneratedSkill({
+      outline: buildOutline,
+      source: source(),
+      rootDir,
+      runtime: {
+        name: 'claude',
+        runSkill,
+        runAuxiliary: async () => ({ success: false, error: 'unused', usage: usage() }),
+        runSynthesis: async () => ({ success: false, error: 'unused', usage: usage() }),
+      },
+      repoPath: tempDir,
+      authoringSkillRoot,
+      regenerate: true,
+    });
+
+    expect(artifact.source).toBe('generated');
+    expect(existsSync(join(rootDir, 'references', 'security.md'))).toBe(true);
+    const state = readSkillBuildState(getBuildStatePath(rootDir));
+    expect(state?.artifact?.validationIssues).toEqual([{
+      severity: 'warning',
+      path: 'references/security.md',
+      message: 'Reference is 140 lines without ## Contents section for navigation.',
+    }]);
   });
 
   it('fails when provider validation reports unresolved errors', async () => {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -40,6 +40,7 @@ import {
 
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
 const LONG_REFERENCE_LINE_LIMIT = 100;
+const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 function artifactFiles(rootDir: string): {
   path: string;
@@ -97,18 +98,16 @@ function fileManifest(files: { path: string; content: string }[]): {
 }
 
 function normalizeFileContent(content: string): string {
-  return content.endsWith('\n') ? content : `${content}\n`;
+  const normalized = content.replace(/\r\n/g, '\n');
+  return normalized.endsWith('\n') ? normalized : `${normalized}\n`;
 }
 
 function skillFrontmatter(content: string): Record<string, unknown> | undefined {
-  if (!content.startsWith('---\n')) {
+  const match = content.match(SKILL_FRONTMATTER_PATTERN);
+  const frontmatter = match?.[1];
+  if (!frontmatter) {
     return undefined;
   }
-  const end = content.indexOf('\n---', 4);
-  if (end < 0) {
-    return undefined;
-  }
-  const frontmatter = content.slice(4, end);
   try {
     const parsed = parseYaml(frontmatter);
     return parsed && typeof parsed === 'object'
@@ -117,6 +116,49 @@ function skillFrontmatter(content: string): Record<string, unknown> | undefined 
   } catch {
     return undefined;
   }
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function yamlQuoted(value: string): string {
+  return JSON.stringify(value);
+}
+
+function fallbackDescription(fileMap: GeneratedSkillFileMap, targetName: string): string {
+  const summary = oneLine(fileMap.summary);
+  if (summary) {
+    return summary;
+  }
+  return `Use when running the generated ${targetName} Warden skill.`;
+}
+
+function ensureSkillFrontmatter(args: {
+  content: string;
+  fileMap: GeneratedSkillFileMap;
+  targetName: string;
+}): string {
+  if (SKILL_FRONTMATTER_PATTERN.test(args.content)) {
+    return args.content;
+  }
+  return `---
+name: ${yamlQuoted(args.targetName)}
+description: ${yamlQuoted(fallbackDescription(args.fileMap, args.targetName))}
+---
+
+${args.content.trimStart()}`;
+}
+
+function referencedSkillPaths(content: string): string[] {
+  const paths = new Set<string>();
+  for (const match of content.matchAll(/references\/[a-zA-Z0-9][a-zA-Z0-9._/-]*/g)) {
+    const path = match[0].replace(/[.,;:!?]+$/g, '');
+    if (/[a-zA-Z0-9]$/.test(path)) {
+      paths.add(path);
+    }
+  }
+  return [...paths].sort();
 }
 
 function deterministicValidation(args: {
@@ -153,9 +195,19 @@ function deterministicValidation(args: {
   }
 
   const referenceFiles = args.fileMap.files.filter((file) => file.path.startsWith('references/'));
+  const routedReferenceFiles = referenceFiles.filter((file) => skillMd.includes(file.path));
+  const routeDocuments = [
+    skillMd,
+    ...routedReferenceFiles.map((file) => file.content),
+  ];
+  for (const path of [...new Set(routeDocuments.flatMap(referencedSkillPaths))].sort()) {
+    if (!files.has(path)) {
+      errors.push(`SKILL.md routes ${path} but the generated file map does not include it`);
+    }
+  }
   for (const reference of referenceFiles) {
-    if (!skillMd.includes(reference.path)) {
-      errors.push(`SKILL.md must directly route runtime reference ${reference.path}`);
+    if (!routeDocuments.some((content) => content.includes(reference.path))) {
+      warnings.push(`SKILL.md does not route runtime reference ${reference.path}`);
     }
     const lineCount = reference.content.split('\n').length;
     if (lineCount > LONG_REFERENCE_LINE_LIMIT && !/^## Contents$/m.test(reference.content)) {
@@ -229,6 +281,47 @@ function summarizeTurns(turns: (number | undefined)[]): number | undefined {
   return values.reduce((sum, value) => sum + value, 0);
 }
 
+function zeroUsage(): UsageStats {
+  return { inputTokens: 0, outputTokens: 0, costUSD: 0 };
+}
+
+function loadExistingArtifact(args: {
+  rootDir: string;
+  files: {
+    path: string;
+    content: string;
+  }[];
+  name: string;
+}): GeneratedSkillArtifact | undefined {
+  const validation = deterministicValidation({
+    fileMap: {
+      version: 1,
+      name: args.name,
+      files: args.files.map((file) => ({ path: file.path, content: file.content })),
+      summary: 'Existing generated artifact',
+      validationNotes: [],
+      missingInputs: [],
+      externalSources: [],
+    },
+    targetName: args.name,
+  });
+  if (validation.errors.length > 0) {
+    return undefined;
+  }
+
+  return {
+    kind: 'generated-skill',
+    source: 'cache',
+    name: args.name,
+    path: args.rootDir,
+    bytes: filesByteLength(args.files),
+    durationMs: 0,
+    usage: zeroUsage(),
+    externalSources: [],
+    missingInputs: [],
+  };
+}
+
 function loadCachedArtifact(args: {
   rootDir: string;
   outline: SkillBuildOutline;
@@ -239,13 +332,17 @@ function loadCachedArtifact(args: {
     return undefined;
   }
 
+  const files = artifactFiles(args.rootDir);
   const state = readSkillBuildState(getBuildStatePath(args.rootDir));
   const metadata = state?.artifact;
   if (!metadata) {
-    return undefined;
+    return loadExistingArtifact({
+      rootDir: args.rootDir,
+      files,
+      name: args.outline.skill,
+    });
   }
 
-  const files = artifactFiles(args.rootDir);
   const manifest = fileManifest(files);
   const bytes = filesByteLength(files);
   if (
@@ -257,6 +354,22 @@ function loadCachedArtifact(args: {
     JSON.stringify(metadata.fileManifest) !== JSON.stringify(manifest) ||
     metadata.bytes !== bytes
   ) {
+    return undefined;
+  }
+
+  const validation = deterministicValidation({
+    fileMap: {
+      version: 1,
+      name: metadata.name,
+      files: files.map((file) => ({ path: file.path, content: file.content })),
+      summary: 'Cached generated artifact',
+      validationNotes: [],
+      missingInputs: [],
+      externalSources: [],
+    },
+    targetName: metadata.name,
+  });
+  if (validation.errors.length > 0) {
     return undefined;
   }
 
@@ -310,13 +423,22 @@ function writeGeneratedArtifact(args: {
   };
 }
 
-function normalizeGeneratedFileMap(fileMap: GeneratedSkillFileMap): GeneratedSkillFileMap {
+function normalizeGeneratedFileMap(
+  fileMap: GeneratedSkillFileMap,
+  targetName = fileMap.name,
+): GeneratedSkillFileMap {
   return {
     ...fileMap,
     files: [...fileMap.files]
       .map((file) => ({
         path: file.path,
-        content: normalizeFileContent(file.content),
+        content: normalizeFileContent(file.path === 'SKILL.md'
+          ? ensureSkillFrontmatter({
+            content: file.content,
+            fileMap,
+            targetName,
+          })
+          : file.content),
       }))
       .sort((a, b) => a.path.localeCompare(b.path)),
   };
@@ -418,7 +540,7 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    const initialFileMap = normalizeGeneratedFileMap(implementation.data);
+    const initialFileMap = normalizeGeneratedFileMap(implementation.data, args.outline.skill);
     const initialDeterministic = deterministicValidation({
       fileMap: initialFileMap,
       targetName: args.outline.skill,
@@ -450,7 +572,7 @@ export async function buildGeneratedSkill(args: {
     const fileMap = normalizeGeneratedFileMap(applyValidationResult({
       original: initialFileMap,
       validation: validation.data,
-    }));
+    }), args.outline.skill);
     const finalDeterministic = deterministicValidation({
       fileMap,
       targetName: args.outline.skill,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -130,9 +130,80 @@ function isAuthoringMetadataDescription(value: string): boolean {
   const normalized = value.replace(/\s+/g, ' ').trim();
   return (
     /\b(SKILL\.md|SPEC\.md|SOURCES\.md|reference-backed|focused references?)\b/i.test(normalized) ||
-    /^generated\b/i.test(normalized) &&
+    (
+      /^generated\b/i.test(normalized) &&
       /\b(skill|architecture|router|references?|wrdn-[a-z0-9-]+)\b/i.test(normalized)
+    )
   );
+}
+
+function containsAuthoringMetadata(content: string): boolean {
+  return /^##\s+(Future Research Needs|Validation Sources|Authoring Decisions)\b/im.test(content) ||
+    /\b(internal outline|build pipeline|build phases|source collection|scope profiling|track identification|coverage validation|authoring decisions|no external research performed)\b/i.test(content);
+}
+
+function containsOutputContract(content: string): boolean {
+  return /^##\s+(Output Format|Output Contract|Response Format|Report Format)\b/im.test(content) ||
+    /\bWarden'?s JSON finding schema\b/i.test(content);
+}
+
+function stripOutputContractSections(content: string): string {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const kept: string[] = [];
+  let skippingUntilLevel: number | undefined;
+
+  for (const line of lines) {
+    const heading = /^(#{2,6})\s+(Output Format|Output Contract|Response Format|Report Format)\b/i.exec(line);
+    const anyHeading = /^(#{1,6})\s+\S/.exec(line);
+    const headingMarker = heading?.[1];
+    const anyHeadingMarker = anyHeading?.[1];
+    if (headingMarker) {
+      skippingUntilLevel = headingMarker.length;
+      continue;
+    }
+    if (skippingUntilLevel !== undefined) {
+      if (anyHeadingMarker && anyHeadingMarker.length <= skippingUntilLevel) {
+        skippingUntilLevel = undefined;
+      } else {
+        continue;
+      }
+    }
+    kept.push(line);
+  }
+
+  return kept.join('\n').trimEnd();
+}
+
+function stripUnavailableArtifactReferences(content: string, availablePaths: Set<string>): string {
+  const missingPaths = referencedArtifactPaths(content)
+    .filter((path) => !availablePaths.has(path));
+  if (missingPaths.length === 0) {
+    return content;
+  }
+  const stripped = content.replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((line) => !missingPaths.some((path) => line.includes(path)))
+    .join('\n');
+  return stripped.replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+function shouldOmitGeneratedArtifact(fileMap: GeneratedSkillFileMap, file: {
+  path: string;
+  content: string;
+}): boolean {
+  if (
+    file.path === 'SOURCES.md' &&
+    (fileMap.externalSources.length === 0 || containsAuthoringMetadata(file.content))
+  ) {
+    return true;
+  }
+  if (
+    file.path === 'SPEC.md' &&
+    (containsOutputContract(file.content) || containsAuthoringMetadata(file.content))
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function fallbackDescription(fileMap: GeneratedSkillFileMap, targetName: string): string {
@@ -185,6 +256,14 @@ function referencedSkillPaths(content: string): string[] {
   return [...paths].sort();
 }
 
+function referencedArtifactPaths(content: string): string[] {
+  const paths = new Set<string>();
+  for (const match of content.matchAll(/\b(?:SPEC|SOURCES|EVAL)\.md\b/g)) {
+    paths.add(match[0]);
+  }
+  return [...paths].sort();
+}
+
 function words(value: string): string[] {
   return value
     .toLowerCase()
@@ -197,11 +276,21 @@ function expandedReferenceWords(path: string): string[] {
   const aliases: Record<string, string[]> = {
     authn: ['authentication', 'identity', 'session', 'credential', 'secret'],
     authz: ['authorization', 'access', 'control', 'permission'],
+    authentication: ['authn', 'login', 'identity', 'session', 'credential', 'password', 'jwt'],
+    authorization: ['authz', 'access', 'control', 'permission', 'role'],
+    android: ['intent', 'webview', 'keystore', 'manifest', 'mobile'],
+    concurrency: ['race', 'condition', 'thread', 'lock', 'atomic'],
     csrf: ['cross', 'site', 'request', 'forgery', 'client', 'web'],
     crypto: ['cryptographic', 'encryption', 'secret', 'token', 'key'],
+    deserialization: ['deserialize', 'serialized', 'unserialize', 'pickle', 'marshal'],
+    ios: ['swift', 'objective', 'keychain', 'uikit', 'wkwebview', 'mobile'],
     rce: ['remote', 'code', 'execution', 'command'],
+    rust: ['unsafe', 'ffi', 'transmute', 'soundness'],
+    secrets: ['secret', 'credential', 'password', 'token', 'key'],
+    session: ['cookie', 'csrf', 'fixation'],
     ssrf: ['server', 'side', 'request', 'forgery'],
     tls: ['cryptographic', 'certificate', 'transport', 'encryption'],
+    upload: ['file', 'content', 'type'],
     xss: ['cross', 'site', 'scripting', 'client', 'web', 'injection'],
     xxe: ['xml', 'external', 'entity'],
   };
@@ -221,6 +310,54 @@ function expandedReferenceWords(path: string): string[] {
     set.add('safety');
   }
   return [...set];
+}
+
+function distinctiveReferenceWords(path: string): string[] {
+  const generic = new Set([
+    'bug',
+    'bugs',
+    'check',
+    'checks',
+    'code',
+    'guide',
+    'review',
+    'safety',
+    'security',
+    'vulnerabilities',
+    'vulnerability',
+  ]);
+  return expandedReferenceWords(path)
+    .filter((word) => word.length > 2 && !generic.has(word));
+}
+
+function referenceContentMatchesPath(path: string, content: string): boolean {
+  const base = path.split('/').at(-1) ?? path;
+  const baseWords = words(base)
+    .filter((word) => distinctiveReferenceWords(word).includes(word));
+  const expandedWords = distinctiveReferenceWords(path);
+  if (expandedWords.length === 0) {
+    return true;
+  }
+  const normalized = content.toLowerCase();
+  const baseMatches = baseWords.reduce(
+    (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(normalized) ? 1 : 0),
+    0,
+  );
+  if (baseWords.length === 1 && baseMatches === 1) {
+    return true;
+  }
+  if (baseWords.length > 1 && baseMatches === baseWords.length) {
+    return true;
+  }
+  const aliasWords = expandedWords.filter((word) => !baseWords.includes(word));
+  const aliasMatches = aliasWords.reduce(
+    (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(normalized) ? 1 : 0),
+    0,
+  );
+  if (baseMatches > 0) {
+    return aliasMatches >= 1;
+  }
+  return aliasMatches >= 2;
 }
 
 function trackText(track: SkillBuildOutline['tracks'][number]): string {
@@ -389,6 +526,42 @@ function backfillMissingRoutedReferences(
   };
 }
 
+function repairMismatchedRoutedReferences(
+  fileMap: GeneratedSkillFileMap,
+  outline: SkillBuildOutline,
+): GeneratedSkillFileMap {
+  const replaced: string[] = [];
+  const files = fileMap.files.map((file) => {
+    if (
+      !file.path.startsWith('references/') ||
+      referenceContentMatchesPath(file.path, file.content)
+    ) {
+      return file;
+    }
+    replaced.push(file.path);
+    return {
+      path: file.path,
+      content: fallbackReferenceContent({
+        outline,
+        path: file.path,
+      }),
+    };
+  });
+
+  if (replaced.length === 0) {
+    return fileMap;
+  }
+
+  return {
+    ...fileMap,
+    files,
+    validationNotes: [
+      ...fileMap.validationNotes,
+      `Repaired mismatched routed reference file(s): ${replaced.sort().join(', ')}`,
+    ],
+  };
+}
+
 function deterministicValidation(args: {
   fileMap: GeneratedSkillFileMap;
   targetName: string;
@@ -422,6 +595,18 @@ function deterministicValidation(args: {
     warnings.push('SKILL.md contains generated-template boilerplate');
   }
 
+  for (const file of args.fileMap.files) {
+    if (!file.path.endsWith('.md')) {
+      continue;
+    }
+    if (containsOutputContract(file.content)) {
+      warnings.push(`${file.path} defines output or report format; Warden injects report schema separately`);
+    }
+    if (containsAuthoringMetadata(file.content)) {
+      warnings.push(`${file.path} contains generated-skill authoring metadata instead of runtime guidance`);
+    }
+  }
+
   const referenceFiles = args.fileMap.files.filter((file) => file.path.startsWith('references/'));
   const routedReferenceFiles = referenceFiles.filter((file) => skillMd.includes(file.path));
   const routeDocuments = [
@@ -433,9 +618,17 @@ function deterministicValidation(args: {
       errors.push(`SKILL.md routes ${path} but the generated file map does not include it`);
     }
   }
+  for (const path of referencedArtifactPaths(skillMd)) {
+    if (!files.has(path)) {
+      errors.push(`SKILL.md references ${path} but the generated file map does not include it`);
+    }
+  }
   for (const reference of referenceFiles) {
     if (!routeDocuments.some((content) => content.includes(reference.path))) {
       warnings.push(`SKILL.md does not route runtime reference ${reference.path}`);
+    }
+    if (!referenceContentMatchesPath(reference.path, reference.content)) {
+      warnings.push(`${reference.path} content does not match its routed reference path`);
     }
     const lineCount = reference.content.split('\n').length;
     if (lineCount > LONG_REFERENCE_LINE_LIMIT && !/^## Contents$/m.test(reference.content)) {
@@ -458,6 +651,14 @@ function deterministicValidation(args: {
   return { errors, warnings };
 }
 
+function hasReferenceMismatchWarning(validation: {
+  warnings: string[];
+}): boolean {
+  return validation.warnings.some((warning) =>
+    warning.includes('content does not match its routed reference path'),
+  );
+}
+
 function formatDeterministicIssues(validation: {
   errors: string[];
   warnings: string[];
@@ -477,13 +678,10 @@ function applyValidationResult(args: {
   if (!args.validation.files || args.validation.files.length === 0) {
     return args.original;
   }
-  if (
-    !args.validation.files.some((file) => file.path === 'SKILL.md') ||
-    args.validation.files.some((file) => file.content.trim().length === 0)
-  ) {
+  const replacementFiles = args.validation.files.filter((file) => file.content.trim().length > 0);
+  if (!replacementFiles.some((file) => file.path === 'SKILL.md')) {
     return args.original;
   }
-  const replacementFiles = args.validation.files;
   const candidate = {
     ...args.original,
     files: [
@@ -503,7 +701,10 @@ function applyValidationResult(args: {
     ],
   };
   const fileMap = backfillMissingRoutedReferences(
-    normalizeGeneratedFileMap(candidate, args.targetName),
+    repairMismatchedRoutedReferences(
+      normalizeGeneratedFileMap(candidate, args.targetName),
+      args.outline,
+    ),
     args.outline,
   );
   const validation = deterministicValidation({
@@ -576,7 +777,7 @@ function loadExistingArtifact(args: {
     },
     targetName: args.name,
   });
-  if (validation.errors.length > 0) {
+  if (validation.errors.length > 0 || hasReferenceMismatchWarning(validation)) {
     return undefined;
   }
 
@@ -635,13 +836,59 @@ function loadCachedArtifact(args: {
       files: files.map((file) => ({ path: file.path, content: file.content })),
       summary: 'Cached generated artifact',
       validationNotes: [],
-      missingInputs: [],
-      externalSources: [],
+      missingInputs: metadata.missingInputs,
+      externalSources: metadata.externalSources,
     },
     targetName: metadata.name,
   });
-  if (validation.errors.length > 0) {
-    return undefined;
+  if (validation.errors.length > 0 || hasReferenceMismatchWarning(validation)) {
+    const normalizedFileMap = normalizeGeneratedFileMap({
+      version: 1,
+      name: metadata.name,
+      files: files.map((file) => ({ path: file.path, content: file.content })),
+      summary: 'Cached generated artifact',
+      validationNotes: [],
+      missingInputs: metadata.missingInputs,
+      externalSources: metadata.externalSources,
+    }, metadata.name);
+    const normalizedValidation = deterministicValidation({
+      fileMap: normalizedFileMap,
+      targetName: metadata.name,
+    });
+    if (
+      normalizedValidation.errors.length > 0 ||
+      hasReferenceMismatchWarning(normalizedValidation)
+    ) {
+      return undefined;
+    }
+
+    const artifact = writeGeneratedArtifact({
+      rootDir: args.rootDir,
+      fileMap: normalizedFileMap,
+      durationMs: metadata.durationMs,
+      usage: metadata.usage,
+      responseModel: metadata.responseModel,
+      numTurns: metadata.numTurns,
+    });
+    const writtenFiles = artifactFiles(args.rootDir);
+    writeSkillBuildState(getBuildStatePath(args.rootDir), {
+      ...state,
+      artifact: {
+        ...metadata,
+        fileManifest: fileManifest(writtenFiles),
+        deterministicWarnings: normalizedValidation.warnings,
+        bytes: artifact.bytes,
+        generatedAt: new Date().toISOString(),
+      },
+      updatedAt: new Date().toISOString(),
+    });
+
+    return {
+      ...artifact,
+      source: 'cache',
+      externalSources: metadata.externalSources,
+      missingInputs: metadata.missingInputs,
+    };
   }
 
   return {
@@ -698,14 +945,20 @@ function normalizeGeneratedFileMap(
   fileMap: GeneratedSkillFileMap,
   targetName = fileMap.name,
 ): GeneratedSkillFileMap {
+  const retainedFiles = fileMap.files
+    .filter((file) => !shouldOmitGeneratedArtifact(fileMap, file));
+  const retainedPaths = new Set(retainedFiles.map((file) => file.path));
   return {
     ...fileMap,
-    files: [...fileMap.files]
+    files: retainedFiles
       .map((file) => ({
         path: file.path,
         content: normalizeFileContent(file.path === 'SKILL.md'
           ? ensureSkillFrontmatter({
-            content: file.content,
+            content: stripUnavailableArtifactReferences(
+              stripOutputContractSections(file.content),
+              retainedPaths,
+            ),
             fileMap,
             targetName,
           })
@@ -811,8 +1064,11 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    const initialFileMap = backfillMissingRoutedReferences(
-      normalizeGeneratedFileMap(implementation.data, args.outline.skill),
+    const initialFileMap = repairMismatchedRoutedReferences(
+      backfillMissingRoutedReferences(
+        normalizeGeneratedFileMap(implementation.data, args.outline.skill),
+        args.outline,
+      ),
       args.outline,
     );
     const initialDeterministic = deterministicValidation({
@@ -843,13 +1099,16 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
-    const fileMap = backfillMissingRoutedReferences(
-      normalizeGeneratedFileMap(applyValidationResult({
-        original: initialFileMap,
-        validation: validation.data,
-        targetName: args.outline.skill,
-        outline: args.outline,
-      }), args.outline.skill),
+    const fileMap = repairMismatchedRoutedReferences(
+      backfillMissingRoutedReferences(
+        normalizeGeneratedFileMap(applyValidationResult({
+          original: initialFileMap,
+          validation: validation.data,
+          targetName: args.outline.skill,
+          outline: args.outline,
+        }), args.outline.skill),
+        args.outline,
+      ),
       args.outline,
     );
     const finalDeterministic = deterministicValidation({

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -45,7 +45,6 @@ import {
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
 const MAX_SKILL_REVISION_ATTEMPTS = 1;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
-type GeneratedSkillReviewIssue = GeneratedSkillReviewResult['issues'][number];
 
 interface SkillBuilderStepMetrics {
   usage: UsageStats;
@@ -449,28 +448,67 @@ function hasCanonicalPathChanges(files: { path: string }[]): boolean {
   return files.some((file) => canonicalGeneratedArtifactPath(file.path) !== file.path);
 }
 
-function advisoryProviderIssues(
-  review: GeneratedSkillReviewResult,
-): GeneratedSkillReviewIssue[] {
-  const issues = review.issues.map((issue) => ({
-    ...issue,
-    severity: 'warning' as const,
-  }));
-  if (!review.valid && issues.length === 0) {
-    issues.push({
-      severity: 'warning',
-      message: 'Authoring provider marked the generated skill invalid without issue details.',
-    });
-  }
-  return issues;
-}
-
 function reviewNeedsRevision(review: GeneratedSkillReviewResult): boolean {
   return !review.valid || review.issues.length > 0;
 }
 
+function formatReviewIssue(issue: GeneratedSkillReviewResult['issues'][number]): string {
+  const location = issue.path ? `${issue.path}: ` : '';
+  const fix = issue.suggestedFix ? ` Suggested fix: ${issue.suggestedFix}` : '';
+  return `${location}${issue.message}${fix}`;
+}
+
+function finalBlockingIssues(args: {
+  deterministic: {
+    errors: string[];
+    warnings: string[];
+  };
+  review?: GeneratedSkillReviewResult;
+}): string[] {
+  const issues: string[] = [];
+  issues.push(...args.deterministic.errors);
+  if (hasMissingGeneratedFileWarning(args.deterministic)) {
+    issues.push(...args.deterministic.warnings.filter((warning) =>
+      warning.includes('generated file map does not include it')
+    ));
+  }
+  if (args.review && reviewNeedsRevision(args.review)) {
+    if (args.review.issues.length === 0) {
+      issues.push('Authoring reviewer marked the generated skill invalid without issue details');
+    } else {
+      issues.push(...args.review.issues.map(formatReviewIssue));
+    }
+  }
+  return uniqueStrings(issues);
+}
+
+function throwIfFinalReviewFailed(args: {
+  targetName: string;
+  deterministic: {
+    errors: string[];
+    warnings: string[];
+  };
+  review?: GeneratedSkillReviewResult;
+}): void {
+  const issues = finalBlockingIssues({
+    deterministic: args.deterministic,
+    review: args.review,
+  });
+  if (issues.length === 0) {
+    return;
+  }
+  throw new GeneratedSkillBuildError(
+    `Generated skill failed final review for ${args.targetName}:\n` +
+    issues.map((issue) => `- ${issue}`).join('\n'),
+  );
+}
+
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)].filter((value) => value.trim().length > 0);
+}
+
+function isExternalSourceUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
 }
 
 function mergeExternalSources(
@@ -479,6 +517,9 @@ function mergeExternalSources(
   const sources = new Map<string, GeneratedSkillFileMap['externalSources'][number]>();
   for (const sourceSet of sourceSets) {
     for (const source of sourceSet) {
+      if (!isExternalSourceUrl(source.url)) {
+        continue;
+      }
       sources.set(`${source.title}\n${source.url}`, source);
     }
   }
@@ -982,6 +1023,7 @@ export async function buildGeneratedSkill(args: {
     const fileMap: GeneratedSkillFileMap = {
       ...workingFileMap,
       externalSources: mergeExternalSources(
+        args.outline.build.externalSources ?? [],
         plan.data.externalSources,
         workingFileMap.externalSources,
       ),
@@ -999,7 +1041,11 @@ export async function buildGeneratedSkill(args: {
         `Generated skill build did not produce SKILL.md for ${args.outline.skill}`,
       );
     }
-    const providerIssues = latestReview ? advisoryProviderIssues(latestReview) : [];
+    throwIfFinalReviewFailed({
+      targetName: args.outline.skill,
+      deterministic: finalDeterministic,
+      review: latestReview,
+    });
 
     const usage = aggregateUsage([
       plan.usage,
@@ -1043,7 +1089,7 @@ export async function buildGeneratedSkill(args: {
         name: artifact.name,
         fileManifest: fileManifest(writtenFiles),
         deterministicWarnings: formatDeterministicIssues(finalDeterministic),
-        validationIssues: providerIssues,
+        validationIssues: [],
         bytes: artifact.bytes,
         durationMs: artifact.durationMs,
         usage: artifact.usage,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
-import { parse as parseYaml } from 'yaml';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { aggregateUsage } from '../sdk/usage.js';
 import type { Runtime } from '../sdk/runtimes/index.js';
 import { runStructuredSkillBuilderAgent, StructuredSkillBuilderAgentError } from './agentic.js';
@@ -123,10 +123,6 @@ function oneLine(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
-function yamlQuoted(value: string): string {
-  return JSON.stringify(value);
-}
-
 function targetSubject(targetName: string): string {
   return targetName
     .replace(/^wrdn-/, '')
@@ -163,9 +159,16 @@ function ensureSkillFrontmatter(args: {
     return args.content;
   }
   const body = args.content.replace(SKILL_FRONTMATTER_PATTERN, '').trimStart();
+  const preserved = frontmatter && typeof frontmatter === 'object' ? frontmatter : {};
+  const repairedFrontmatter = stringifyYaml({
+    name: args.targetName,
+    description: fallbackDescription(args.fileMap, args.targetName),
+    ...Object.fromEntries(
+      Object.entries(preserved).filter(([key]) => key !== 'name' && key !== 'description'),
+    ),
+  }).trimEnd();
   return `---
-name: ${yamlQuoted(args.targetName)}
-description: ${yamlQuoted(fallbackDescription(args.fileMap, args.targetName))}
+${repairedFrontmatter}
 ---
 
 ${body}`;
@@ -503,25 +506,11 @@ function applyValidationResult(args: {
   return candidate;
 }
 
-function normalizeProviderIssue(
-  issue: GeneratedSkillValidationIssue,
-): GeneratedSkillValidationIssue {
-  if (
-    issue.severity === 'error' &&
-    issue.path?.startsWith('references/') &&
-    /\breference is \d+ lines\b/i.test(issue.message) &&
-    /\bcontents\b/i.test(issue.message)
-  ) {
-    return { ...issue, severity: 'warning' };
-  }
-  return issue;
-}
-
 function advisoryProviderIssues(
   validation: GeneratedSkillValidationResult,
 ): GeneratedSkillValidationIssue[] {
   const issues = validation.issues.map((issue) => ({
-    ...normalizeProviderIssue(issue),
+    ...issue,
     severity: 'warning' as const,
   }));
   if (!validation.valid && issues.length === 0) {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -138,41 +138,51 @@ function rewriteGeneratedArtifactPathReferences(content: string, pathMap: Map<st
 
 function canonicalizeGeneratedFileMapPaths(fileMap: GeneratedSkillFileMap): GeneratedSkillFileMap {
   const pathMap = new Map<string, string>();
+  const changedPaths: [string, string][] = [];
   for (const file of fileMap.files) {
     const canonicalPath = canonicalGeneratedArtifactPath(file.path);
     pathMap.set(file.path, canonicalPath);
+    if (file.path !== canonicalPath) {
+      changedPaths.push([file.path, canonicalPath]);
+    }
     if (canonicalPath.startsWith('references/')) {
       pathMap.set(`references/tracks/${canonicalPath.slice('references/'.length)}`, canonicalPath);
     }
-  }
-  const changedPaths = [...pathMap.entries()].filter(([from, to]) => from !== to);
-  if (changedPaths.length === 0) {
-    return fileMap;
   }
 
   const files = new Map<string, {
     path: string;
     content: string;
   }>();
+  let contentChanged = false;
   for (const file of fileMap.files) {
     const path = pathMap.get(file.path) ?? file.path;
     const content = rewriteGeneratedArtifactPathReferences(file.content, pathMap);
+    contentChanged ||= content !== file.content;
     const existing = files.get(path);
     if (!existing || content.length > existing.content.length) {
       files.set(path, { path, content });
     }
   }
 
-  return {
-    ...fileMap,
-    files: [...files.values()].sort((a, b) => a.path.localeCompare(b.path)),
-    validationNotes: [
-      ...fileMap.validationNotes,
+  if (changedPaths.length === 0 && !contentChanged) {
+    return fileMap;
+  }
+
+  const validationNotes = [...fileMap.validationNotes];
+  if (changedPaths.length > 0) {
+    validationNotes.push(
       `Flattened generated reference path(s): ${changedPaths
         .map(([from, to]) => `${from} -> ${to}`)
         .sort()
         .join(', ')}`,
-    ],
+    );
+  }
+
+  return {
+    ...fileMap,
+    files: [...files.values()].sort((a, b) => a.path.localeCompare(b.path)),
+    validationNotes,
   };
 }
 
@@ -260,15 +270,22 @@ function stripUnavailableArtifactReferences(content: string, availablePaths: Set
   return stripped.replace(/\n{3,}/g, '\n\n').trimEnd();
 }
 
+function documentsExternalSources(fileMap: GeneratedSkillFileMap, content: string): boolean {
+  return fileMap.externalSources.some((source) =>
+    content.includes(source.title) || content.includes(source.url)
+  );
+}
+
 function shouldOmitGeneratedArtifact(fileMap: GeneratedSkillFileMap, file: {
   path: string;
   content: string;
 }): boolean {
-  if (
-    file.path === 'SOURCES.md' &&
-    (fileMap.externalSources.length === 0 || containsAuthoringMetadata(file.content))
-  ) {
-    return true;
+  if (file.path === 'SOURCES.md') {
+    if (fileMap.externalSources.length === 0) {
+      return true;
+    }
+    return containsAuthoringMetadata(file.content) &&
+      !documentsExternalSources(fileMap, file.content);
   }
   if (
     file.path === 'SPEC.md' &&

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -119,10 +119,6 @@ function skillFrontmatter(content: string): Record<string, unknown> | undefined 
   }
 }
 
-function oneLine(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
-}
-
 function targetSubject(targetName: string): string {
   return targetName
     .replace(/^wrdn-/, '')
@@ -131,12 +127,16 @@ function targetSubject(targetName: string): string {
 }
 
 function isAuthoringMetadataDescription(value: string): boolean {
-  return /\b(generated|architecture|router|focused references|authoring|SKILL\.md|SPEC\.md|SOURCES\.md)\b/i
-    .test(value);
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return (
+    /\b(SKILL\.md|SPEC\.md|SOURCES\.md|reference-backed|focused references?)\b/i.test(normalized) ||
+    /^generated\b/i.test(normalized) &&
+      /\b(skill|architecture|router|references?|wrdn-[a-z0-9-]+)\b/i.test(normalized)
+  );
 }
 
 function fallbackDescription(fileMap: GeneratedSkillFileMap, targetName: string): string {
-  const summary = oneLine(fileMap.summary);
+  const summary = fileMap.summary.replace(/\s+/g, ' ').trim();
   if (summary && !isAuthoringMetadataDescription(summary)) {
     return summary;
   }
@@ -472,6 +472,7 @@ function applyValidationResult(args: {
   original: GeneratedSkillFileMap;
   validation: GeneratedSkillValidationResult;
   targetName: string;
+  outline: SkillBuildOutline;
 }): GeneratedSkillFileMap {
   if (!args.validation.files || args.validation.files.length === 0) {
     return args.original;
@@ -482,9 +483,15 @@ function applyValidationResult(args: {
   ) {
     return args.original;
   }
+  const replacementFiles = args.validation.files;
   const candidate = {
     ...args.original,
-    files: args.validation.files,
+    files: [
+      ...args.original.files.filter(
+        (file) => !replacementFiles.some((replacement) => replacement.path === file.path),
+      ),
+      ...replacementFiles,
+    ],
     validationNotes: [
       ...args.original.validationNotes,
       args.validation.summary,
@@ -495,15 +502,19 @@ function applyValidationResult(args: {
       ...args.validation.missingInputs,
     ],
   };
+  const fileMap = backfillMissingRoutedReferences(
+    normalizeGeneratedFileMap(candidate, args.targetName),
+    args.outline,
+  );
   const validation = deterministicValidation({
-    fileMap: normalizeGeneratedFileMap(candidate, args.targetName),
+    fileMap,
     targetName: args.targetName,
   });
   if (validation.errors.length > 0) {
     return args.original;
   }
 
-  return candidate;
+  return fileMap;
 }
 
 function advisoryProviderIssues(
@@ -837,6 +848,7 @@ export async function buildGeneratedSkill(args: {
         original: initialFileMap,
         validation: validation.data,
         targetName: args.outline.skill,
+        outline: args.outline,
       }), args.outline.skill),
       args.outline,
     );

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -369,6 +369,10 @@ function deterministicValidation(args: {
   errors: string[];
   warnings: string[];
 } {
+  // Deterministic validation is intentionally mechanical. It protects the
+  // filesystem and catches non-runnable local references; depth, segmentation,
+  // source adequacy, and skill-writer compliance belong to the qualitative
+  // reviewer.
   const errors: string[] = [];
   const warnings: string[] = [];
   const files = new Map(args.fileMap.files.map((file) => [file.path, file.content]));
@@ -465,6 +469,9 @@ function finalBlockingIssues(args: {
   };
   review?: GeneratedSkillReviewResult;
 }): string[] {
+  // Final blocking combines mechanical runnability with the reviewer verdict.
+  // Do not add deterministic taste checks here; make the authoring reviewer own
+  // qualitative depth and layout feedback.
   const issues: string[] = [];
   issues.push(...args.deterministic.errors);
   if (hasMissingGeneratedFileWarning(args.deterministic)) {
@@ -909,6 +916,8 @@ export async function buildGeneratedSkill(args: {
     const contributionResults: SkillBuilderStepMetrics[] = [];
 
     if (args.outline.tracks.length > 1) {
+      // Tracks are sequential coverage work lanes. They help the writer deepen
+      // topics without overlap, but they must not imply one file per track.
       for (const track of args.outline.tracks) {
         args.onStatus?.(`Adding ${track.title}`);
         const contribution = await runStructuredSkillBuilderAgent({
@@ -951,6 +960,9 @@ export async function buildGeneratedSkill(args: {
         targetName: args.outline.skill,
       });
 
+      // The reviewer is the quality gate: it judges whether the generated skill
+      // satisfies skill-writer, the source-depth plan, and Warden's runtime bar.
+      // The deterministic notes below are only rough mechanical signals.
       args.onStatus?.(reviewRound === 0
         ? 'Reviewing generated skill'
         : 'Reviewing revised skill');

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -539,6 +539,21 @@ function backfillMissingRoutedReferences(
   };
 }
 
+function prepareGeneratedFileMap(
+  fileMap: GeneratedSkillFileMap,
+  targetName: string,
+  outline: SkillBuildOutline,
+): GeneratedSkillFileMap {
+  const prefilled = backfillMissingRoutedReferences(
+    canonicalizeGeneratedFileMapPaths(fileMap),
+    outline,
+  );
+  return backfillMissingRoutedReferences(
+    normalizeGeneratedFileMap(prefilled, targetName),
+    outline,
+  );
+}
+
 function deterministicValidation(args: {
   fileMap: GeneratedSkillFileMap;
   targetName: string;
@@ -678,10 +693,7 @@ function applyValidationResult(args: {
       ...args.validation.missingInputs,
     ],
   };
-  const fileMap = backfillMissingRoutedReferences(
-    normalizeGeneratedFileMap(candidate, args.targetName),
-    args.outline,
-  );
+  const fileMap = prepareGeneratedFileMap(candidate, args.targetName, args.outline);
   const validation = deterministicValidation({
     fileMap,
     targetName: args.targetName,
@@ -757,10 +769,7 @@ function applyContributionResult(args: {
     ),
   };
 
-  return backfillMissingRoutedReferences(
-    normalizeGeneratedFileMap(candidate, args.targetName),
-    args.outline,
-  );
+  return prepareGeneratedFileMap(candidate, args.targetName, args.outline);
 }
 
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
@@ -879,8 +888,8 @@ function loadCachedArtifact(args: {
     hasMissingGeneratedFileWarning(validation) ||
     hasCanonicalPathChanges(files)
   ) {
-    const normalizedFileMap = backfillMissingRoutedReferences(
-      normalizeGeneratedFileMap({
+    const normalizedFileMap = prepareGeneratedFileMap(
+      {
         version: 1,
         name: metadata.name,
         files: files.map((file) => ({ path: file.path, content: file.content })),
@@ -888,7 +897,8 @@ function loadCachedArtifact(args: {
         validationNotes: [],
         missingInputs: metadata.missingInputs,
         externalSources: metadata.externalSources,
-      }, metadata.name),
+      },
+      metadata.name,
       args.outline,
     );
     const normalizedValidation = deterministicValidation({
@@ -1105,8 +1115,9 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    let workingFileMap = backfillMissingRoutedReferences(
-      normalizeGeneratedFileMap(implementation.data, args.outline.skill),
+    let workingFileMap = prepareGeneratedFileMap(
+      implementation.data,
+      args.outline.skill,
       args.outline,
     );
     const contributionResults: {
@@ -1178,13 +1189,14 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
-    const fileMap = backfillMissingRoutedReferences(
-      normalizeGeneratedFileMap(applyValidationResult({
+    const fileMap = prepareGeneratedFileMap(
+      applyValidationResult({
         original: initialFileMap,
         validation: validation.data,
         targetName: args.outline.skill,
         outline: args.outline,
-      }), args.outline.skill),
+      }),
+      args.outline.skill,
       args.outline,
     );
     const finalDeterministic = deterministicValidation({

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -1,7 +1,7 @@
-import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
-import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { parse as parseYaml } from 'yaml';
 import { aggregateUsage } from '../sdk/usage.js';
 import type { Runtime } from '../sdk/runtimes/index.js';
 import { runStructuredSkillBuilderAgent, StructuredSkillBuilderAgentError } from './agentic.js';
@@ -21,12 +21,13 @@ import {
 import {
   GeneratedSkillAuthoringPlanSchema,
   GeneratedSkillBuildError,
-  GeneratedSkillFileMapSchema,
+  GeneratedSkillWriterResultSchema,
   GeneratedSkillReviewResultSchema,
   type GeneratedSkillArtifact,
-  type GeneratedSkillFileMap,
   type GeneratedSkillReviewResult,
+  type GeneratedSkillWriterResult,
   type SkillBuildAuthoringProvider,
+  type SkillBuildExternalSource,
 } from './skill-contract.js';
 export { GeneratedSkillBuildError } from './skill-contract.js';
 import {
@@ -51,6 +52,20 @@ interface SkillBuilderStepMetrics {
 
 interface SkillBuilderReviewResult extends SkillBuilderStepMetrics {
   data: GeneratedSkillReviewResult;
+}
+
+interface GeneratedSkillArtifactFile {
+  path: string;
+  content: string;
+  bytes?: number;
+}
+
+interface GeneratedSkillArtifactSnapshot {
+  summary: string;
+  files: GeneratedSkillArtifactFile[];
+  validationNotes: string[];
+  missingInputs: string[];
+  externalSources: SkillBuildExternalSource[];
 }
 
 function artifactFiles(rootDir: string): {
@@ -108,11 +123,6 @@ function fileManifest(files: { path: string; content: string }[]): {
   })).sort((a, b) => a.path.localeCompare(b.path));
 }
 
-function normalizeFileContent(content: string): string {
-  const normalized = content.replace(/\r\n/g, '\n');
-  return normalized.endsWith('\n') ? normalized : `${normalized}\n`;
-}
-
 function skillFrontmatter(content: string): Record<string, unknown> | undefined {
   const match = content.match(SKILL_FRONTMATTER_PATTERN);
   const frontmatter = match?.[1];
@@ -127,139 +137,6 @@ function skillFrontmatter(content: string): Record<string, unknown> | undefined 
   } catch {
     return undefined;
   }
-}
-
-function targetSubject(targetName: string): string {
-  return targetName
-    .replace(/^wrdn-/, '')
-    .replace(/[-_]+/g, ' ')
-    .trim() || targetName;
-}
-
-function isAuthoringMetadataDescription(value: string): boolean {
-  const normalized = value.replace(/\s+/g, ' ').trim();
-  return (
-    /\b(SKILL\.md|SPEC\.md|SOURCES\.md|reference-backed|focused references?)\b/i.test(normalized) ||
-    (
-      /^generated\b/i.test(normalized) &&
-      /\b(skill|architecture|router|references?|wrdn-[a-z0-9-]+)\b/i.test(normalized)
-    )
-  );
-}
-
-function containsAuthoringMetadata(content: string): boolean {
-  return /^##\s+(Future Research Needs|Validation Sources|Authoring Decisions)\b/im.test(content) ||
-    /\b(internal outline|build pipeline|build phases|source collection|scope profiling|track identification|coverage validation|authoring decisions|no external research performed)\b/i.test(content);
-}
-
-function containsOutputContract(content: string): boolean {
-  return /^##\s+(Output Format|Output Contract|Response Format|Report Format)\b/im.test(content) ||
-    /\bWarden'?s JSON finding schema\b/i.test(content);
-}
-
-function stripOutputContractSections(content: string): string {
-  const lines = content.replace(/\r\n/g, '\n').split('\n');
-  const kept: string[] = [];
-  let skippingUntilLevel: number | undefined;
-
-  for (const line of lines) {
-    const heading = /^(#{2,6})\s+(Output Format|Output Contract|Response Format|Report Format)\b/i.exec(line);
-    const anyHeading = /^(#{1,6})\s+\S/.exec(line);
-    const headingMarker = heading?.[1];
-    const anyHeadingMarker = anyHeading?.[1];
-    if (headingMarker) {
-      skippingUntilLevel = headingMarker.length;
-      continue;
-    }
-    if (skippingUntilLevel !== undefined) {
-      if (anyHeadingMarker && anyHeadingMarker.length <= skippingUntilLevel) {
-        skippingUntilLevel = undefined;
-      } else {
-        continue;
-      }
-    }
-    kept.push(line);
-  }
-
-  return kept.join('\n').trimEnd();
-}
-
-function stripUnavailableArtifactReferences(content: string, availablePaths: Set<string>): string {
-  const missingPaths = referencedArtifactPaths(content)
-    .filter((path) => !availablePaths.has(path));
-  if (missingPaths.length === 0) {
-    return content;
-  }
-  const stripped = content.replace(/\r\n/g, '\n')
-    .split('\n')
-    .filter((line) => !missingPaths.some((path) => line.includes(path)))
-    .join('\n');
-  return stripped.replace(/\n{3,}/g, '\n\n').trimEnd();
-}
-
-function documentsExternalSources(fileMap: GeneratedSkillFileMap, content: string): boolean {
-  return fileMap.externalSources.some((source) =>
-    content.includes(source.title) || content.includes(source.url)
-  );
-}
-
-function shouldOmitGeneratedArtifact(fileMap: GeneratedSkillFileMap, file: {
-  path: string;
-  content: string;
-}): boolean {
-  if (file.path === 'SOURCES.md') {
-    if (fileMap.externalSources.length === 0) {
-      return true;
-    }
-    return containsAuthoringMetadata(file.content) &&
-      !documentsExternalSources(fileMap, file.content);
-  }
-  if (
-    file.path === 'SPEC.md' &&
-    (containsOutputContract(file.content) || containsAuthoringMetadata(file.content))
-  ) {
-    return true;
-  }
-  return false;
-}
-
-function fallbackDescription(fileMap: GeneratedSkillFileMap, targetName: string): string {
-  const summary = fileMap.summary.replace(/\s+/g, ' ').trim();
-  if (summary && !isAuthoringMetadataDescription(summary)) {
-    return summary;
-  }
-  return `Use when reviewing code changes for ${targetSubject(targetName)} concerns.`;
-}
-
-function ensureSkillFrontmatter(args: {
-  content: string;
-  fileMap: GeneratedSkillFileMap;
-  targetName: string;
-}): string {
-  const frontmatter = skillFrontmatter(args.content);
-  const description = frontmatter?.['description'];
-  if (
-    frontmatter?.['name'] === args.targetName &&
-    typeof description === 'string' &&
-    description.trim() &&
-    !isAuthoringMetadataDescription(description)
-  ) {
-    return args.content;
-  }
-  const body = args.content.replace(SKILL_FRONTMATTER_PATTERN, '').trimStart();
-  const preserved = frontmatter && typeof frontmatter === 'object' ? frontmatter : {};
-  const repairedFrontmatter = stringifyYaml({
-    name: args.targetName,
-    description: fallbackDescription(args.fileMap, args.targetName),
-    ...Object.fromEntries(
-      Object.entries(preserved).filter(([key]) => key !== 'name' && key !== 'description'),
-    ),
-  }).trimEnd();
-  return `---
-${repairedFrontmatter}
----
-
-${body}`;
 }
 
 function referencedSkillPaths(content: string): string[] {
@@ -281,15 +158,11 @@ function referencedArtifactPaths(content: string): string[] {
   return [...paths].sort();
 }
 
-function prepareGeneratedFileMap(
-  fileMap: GeneratedSkillFileMap,
-  targetName: string,
-): GeneratedSkillFileMap {
-  return normalizeGeneratedFileMap(fileMap, targetName);
-}
-
 function deterministicValidation(args: {
-  fileMap: GeneratedSkillFileMap;
+  files: {
+    path: string;
+    content: string;
+  }[];
   targetName: string;
 }): {
   errors: string[];
@@ -301,11 +174,11 @@ function deterministicValidation(args: {
   // reviewer.
   const errors: string[] = [];
   const warnings: string[] = [];
-  const files = new Map(args.fileMap.files.map((file) => [file.path, file.content]));
+  const files = new Map(args.files.map((file) => [file.path, file.content]));
   const skillMd = files.get('SKILL.md');
 
   if (!skillMd) {
-    errors.push('Generated artifact file map must include SKILL.md');
+    errors.push('Generated skill artifacts must include SKILL.md');
     return { errors, warnings };
   }
 
@@ -321,7 +194,7 @@ function deterministicValidation(args: {
     }
   }
 
-  const referenceFiles = args.fileMap.files.filter((file) => file.path.startsWith('references/'));
+  const referenceFiles = args.files.filter((file) => file.path.startsWith('references/'));
   const routedReferenceFiles = referenceFiles.filter((file) => skillMd.includes(file.path));
   const routeDocuments = [
     skillMd,
@@ -329,12 +202,12 @@ function deterministicValidation(args: {
   ];
   for (const path of [...new Set(routeDocuments.flatMap(referencedSkillPaths))].sort()) {
     if (!files.has(path)) {
-      warnings.push(`SKILL.md routes ${path} but the generated file map does not include it`);
+      warnings.push(`SKILL.md routes ${path} but the generated artifacts do not include it`);
     }
   }
   for (const path of referencedArtifactPaths(skillMd)) {
     if (!files.has(path)) {
-      warnings.push(`SKILL.md references ${path} but the generated file map does not include it`);
+      warnings.push(`SKILL.md references ${path} but the generated artifacts do not include it`);
     }
   }
   for (const reference of referenceFiles) {
@@ -360,7 +233,7 @@ function hasMissingGeneratedFileWarning(validation: {
   warnings: string[];
 }): boolean {
   return validation.warnings.some((warning) =>
-    warning.includes('generated file map does not include it'),
+    warning.includes('generated artifacts do not include it'),
   );
 }
 
@@ -388,7 +261,7 @@ function finalBlockingIssues(args: {
   issues.push(...args.deterministic.errors);
   if (hasMissingGeneratedFileWarning(args.deterministic)) {
     issues.push(...args.deterministic.warnings.filter((warning) =>
-      warning.includes('generated file map does not include it')
+      warning.includes('generated artifacts do not include it')
     ));
   }
   if (args.review && reviewNeedsRevision(args.review)) {
@@ -431,9 +304,9 @@ function isExternalSourceUrl(url: string): boolean {
 }
 
 function mergeExternalSources(
-  ...sourceSets: GeneratedSkillFileMap['externalSources'][]
-): GeneratedSkillFileMap['externalSources'] {
-  const sources = new Map<string, GeneratedSkillFileMap['externalSources'][number]>();
+  ...sourceSets: SkillBuildExternalSource[][]
+): SkillBuildExternalSource[] {
+  const sources = new Map<string, SkillBuildExternalSource>();
   for (const sourceSet of sourceSets) {
     for (const source of sourceSet) {
       if (!isExternalSourceUrl(source.url)) {
@@ -477,15 +350,7 @@ function loadExistingArtifact(args: {
   name: string;
 }): GeneratedSkillArtifact | undefined {
   const validation = deterministicValidation({
-    fileMap: {
-      version: 1,
-      name: args.name,
-      files: args.files.map((file) => ({ path: file.path, content: file.content })),
-      summary: 'Existing generated artifact',
-      validationNotes: [],
-      missingInputs: [],
-      externalSources: [],
-    },
+    files: args.files,
     targetName: args.name,
   });
   if (
@@ -544,71 +409,14 @@ function loadCachedArtifact(args: {
   }
 
   const validation = deterministicValidation({
-    fileMap: {
-      version: 1,
-      name: metadata.name,
-      files: files.map((file) => ({ path: file.path, content: file.content })),
-      summary: 'Cached generated artifact',
-      validationNotes: [],
-      missingInputs: metadata.missingInputs,
-      externalSources: metadata.externalSources,
-    },
+    files,
     targetName: metadata.name,
   });
   if (
     validation.errors.length > 0 ||
     hasMissingGeneratedFileWarning(validation)
   ) {
-    const normalizedFileMap = prepareGeneratedFileMap(
-      {
-        version: 1,
-        name: metadata.name,
-        files: files.map((file) => ({ path: file.path, content: file.content })),
-        summary: 'Cached generated artifact',
-        validationNotes: [],
-        missingInputs: metadata.missingInputs,
-        externalSources: metadata.externalSources,
-      },
-      metadata.name,
-    );
-    const normalizedValidation = deterministicValidation({
-      fileMap: normalizedFileMap,
-      targetName: metadata.name,
-    });
-    if (
-      normalizedValidation.errors.length > 0 ||
-      hasMissingGeneratedFileWarning(normalizedValidation)
-    ) {
-      return undefined;
-    }
-
-    const artifact = writeGeneratedArtifact({
-      rootDir: args.rootDir,
-      fileMap: normalizedFileMap,
-      durationMs: metadata.durationMs,
-      usage: metadata.usage,
-      responseModel: metadata.responseModel,
-      numTurns: metadata.numTurns,
-    });
-    const writtenFiles = artifactFiles(args.rootDir);
-    writeSkillBuildState(getBuildStatePath(args.rootDir), {
-      ...state,
-      artifact: {
-        ...metadata,
-        fileManifest: fileManifest(writtenFiles),
-        deterministicWarnings: formatDeterministicIssues(normalizedValidation),
-        bytes: artifact.bytes,
-        generatedAt: new Date().toISOString(),
-      },
-      updatedAt: new Date().toISOString(),
-    });
-
-    return {
-      ...artifact,
-      source: 'cache',
-      externalSources: metadata.externalSources,
-      missingInputs: metadata.missingInputs,
-    };
+    return undefined;
   }
 
   return {
@@ -626,65 +434,42 @@ function loadCachedArtifact(args: {
   };
 }
 
-function writeGeneratedArtifact(args: {
+function readArtifactSnapshot(args: {
   rootDir: string;
-  fileMap: GeneratedSkillFileMap;
+  writer: GeneratedSkillWriterResult;
+}): GeneratedSkillArtifactSnapshot {
+  return {
+    summary: args.writer.summary,
+    files: artifactFiles(args.rootDir),
+    validationNotes: args.writer.validationNotes,
+    missingInputs: args.writer.missingInputs,
+    externalSources: args.writer.externalSources,
+  };
+}
+
+function artifactFromDisk(args: {
+  rootDir: string;
+  name: string;
   durationMs: number;
   usage: UsageStats;
+  externalSources: SkillBuildExternalSource[];
+  missingInputs: string[];
   responseModel?: string;
   numTurns?: number;
 }): GeneratedSkillArtifact {
-  clearGeneratedSkillArtifacts(args.rootDir);
-
-  const files = args.fileMap.files.map((file) => ({
-    path: file.path,
-    content: normalizeFileContent(file.content),
-  }));
-  for (const file of files) {
-    const path = join(args.rootDir, file.path);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, file.content, 'utf-8');
-  }
-
+  const files = artifactFiles(args.rootDir);
   return {
     kind: 'generated-skill',
     source: 'generated',
-    name: args.fileMap.name,
+    name: args.name,
     path: args.rootDir,
     bytes: filesByteLength(files),
     durationMs: args.durationMs,
     usage: args.usage,
-    externalSources: args.fileMap.externalSources,
-    missingInputs: args.fileMap.missingInputs,
+    externalSources: args.externalSources,
+    missingInputs: args.missingInputs,
     responseModel: args.responseModel,
     numTurns: args.numTurns,
-  };
-}
-
-function normalizeGeneratedFileMap(
-  fileMap: GeneratedSkillFileMap,
-  targetName = fileMap.name,
-): GeneratedSkillFileMap {
-  const retainedFiles = fileMap.files
-    .filter((file) => !shouldOmitGeneratedArtifact(fileMap, file));
-  const retainedPaths = new Set(retainedFiles.map((file) => file.path));
-  return {
-    ...fileMap,
-    files: retainedFiles
-      .map((file) => ({
-        path: file.path,
-        content: normalizeFileContent(file.path === 'SKILL.md'
-          ? ensureSkillFrontmatter({
-            content: stripUnavailableArtifactReferences(
-              stripOutputContractSections(file.content),
-              retainedPaths,
-            ),
-            fileMap,
-            targetName,
-          })
-          : file.content),
-      }))
-      .sort((a, b) => a.path.localeCompare(b.path)),
   };
 }
 
@@ -757,10 +542,12 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
+    clearGeneratedSkillArtifacts(args.rootDir);
+
     args.onStatus?.('Writing skill artifacts');
     const implementation = await runStructuredSkillBuilderAgent({
       runtime: args.runtime,
-      repoPath: args.repoPath,
+      repoPath: args.rootDir,
       skillName: `${args.outline.skill}:authoring-implementation`,
       systemPrompt: authoringSystemPrompt(),
       userPrompt: buildAuthoringImplementationPrompt({
@@ -771,23 +558,18 @@ export async function buildGeneratedSkill(args: {
         targetRootDir: args.rootDir,
         plan: plan.data,
       }),
-      schema: GeneratedSkillFileMapSchema,
+      schema: GeneratedSkillWriterResultSchema,
       model: args.model,
       maxTurns,
+      writeAccess: true,
       abortController: args.abortController,
       repair,
     });
 
-    if (implementation.data.name !== args.outline.skill) {
-      throw new GeneratedSkillBuildError(
-        `Generated skill identity mismatch: expected ${args.outline.skill}, got ${implementation.data.name}`,
-      );
-    }
-
-    let workingFileMap = prepareGeneratedFileMap(
-      implementation.data,
-      args.outline.skill,
-    );
+    let workingArtifact = readArtifactSnapshot({
+      rootDir: args.rootDir,
+      writer: implementation.data,
+    });
 
     const reviewResults: SkillBuilderReviewResult[] = [];
     const revisionResults: SkillBuilderStepMetrics[] = [];
@@ -795,7 +577,7 @@ export async function buildGeneratedSkill(args: {
     let latestReview: GeneratedSkillReviewResult | undefined;
     for (let reviewRound = 0; reviewRound <= MAX_SKILL_REVISION_ATTEMPTS; reviewRound += 1) {
       const deterministic = deterministicValidation({
-        fileMap: workingFileMap,
+        files: workingArtifact.files,
         targetName: args.outline.skill,
       });
 
@@ -807,7 +589,7 @@ export async function buildGeneratedSkill(args: {
         : 'Reviewing revised skill');
       const review = await runStructuredSkillBuilderAgent({
         runtime: args.runtime,
-        repoPath: args.repoPath,
+        repoPath: args.rootDir,
         skillName: `${args.outline.skill}:authoring-validation`,
         systemPrompt: authoringSystemPrompt(),
         userPrompt: buildAuthoringValidationPrompt({
@@ -817,7 +599,7 @@ export async function buildGeneratedSkill(args: {
           targetName: args.outline.skill,
           targetRootDir: args.rootDir,
           plan: plan.data,
-          fileMap: workingFileMap,
+          artifact: workingArtifact,
           deterministicIssues: formatDeterministicIssues(deterministic),
         }),
         schema: GeneratedSkillReviewResultSchema,
@@ -839,7 +621,7 @@ export async function buildGeneratedSkill(args: {
       args.onStatus?.('Revising generated skill');
       const revision = await runStructuredSkillBuilderAgent({
         runtime: args.runtime,
-        repoPath: args.repoPath,
+        repoPath: args.rootDir,
         skillName: `${args.outline.skill}:authoring-revision`,
         systemPrompt: authoringSystemPrompt(),
         userPrompt: buildAuthoringRevisionPrompt({
@@ -849,45 +631,44 @@ export async function buildGeneratedSkill(args: {
           targetName: args.outline.skill,
           targetRootDir: args.rootDir,
           plan: plan.data,
-          fileMap: workingFileMap,
+          artifact: workingArtifact,
           review: review.data,
           deterministicIssues: formatDeterministicIssues(deterministic),
         }),
-        schema: GeneratedSkillFileMapSchema,
+        schema: GeneratedSkillWriterResultSchema,
         model: args.model,
         maxTurns,
+        writeAccess: true,
         abortController: args.abortController,
         repair,
       });
-      if (revision.data.name !== args.outline.skill) {
-        throw new GeneratedSkillBuildError(
-          `Generated skill identity mismatch: expected ${args.outline.skill}, got ${revision.data.name}`,
-        );
-      }
       revisionResults.push(revision);
-      workingFileMap = prepareGeneratedFileMap(
-        revision.data,
-        args.outline.skill,
-      );
+      workingArtifact = readArtifactSnapshot({
+        rootDir: args.rootDir,
+        writer: revision.data,
+      });
     }
 
-    const fileMap: GeneratedSkillFileMap = {
-      ...workingFileMap,
-      externalSources: mergeExternalSources(
-        args.outline.build.externalSources ?? [],
-        plan.data.externalSources,
-        workingFileMap.externalSources,
-      ),
-      missingInputs: uniqueStrings([
-        ...plan.data.missingInputs,
-        ...workingFileMap.missingInputs,
-      ]),
+    const finalExternalSources = mergeExternalSources(
+      args.outline.build.externalSources ?? [],
+      plan.data.externalSources,
+      workingArtifact.externalSources,
+    );
+    const finalMissingInputs = uniqueStrings([
+      ...plan.data.missingInputs,
+      ...workingArtifact.missingInputs,
+      ...reviewResults.flatMap((result) => result.data.missingInputs),
+    ]);
+    workingArtifact = {
+      ...workingArtifact,
+      externalSources: finalExternalSources,
+      missingInputs: finalMissingInputs,
     };
     const finalDeterministic = deterministicValidation({
-      fileMap,
+      files: workingArtifact.files,
       targetName: args.outline.skill,
     });
-    if (!fileMap.files.some((file) => file.path === 'SKILL.md')) {
+    if (!workingArtifact.files.some((file) => file.path === 'SKILL.md')) {
       throw new GeneratedSkillBuildError(
         `Generated skill build did not produce SKILL.md for ${args.outline.skill}`,
       );
@@ -917,11 +698,13 @@ export async function buildGeneratedSkill(args: {
       ...revisionResults.map((result) => result.numTurns),
     ]);
 
-    const artifact = writeGeneratedArtifact({
+    const artifact = artifactFromDisk({
       rootDir: args.rootDir,
-      fileMap,
+      name: args.outline.skill,
       durationMs: performance.now() - startedAt,
       usage,
+      externalSources: finalExternalSources,
+      missingInputs: finalMissingInputs,
       responseModel,
       numTurns,
     });
@@ -941,11 +724,7 @@ export async function buildGeneratedSkill(args: {
         durationMs: artifact.durationMs,
         usage: artifact.usage,
         externalSources: artifact.externalSources,
-        missingInputs: uniqueStrings([
-          ...plan.data.missingInputs,
-          ...artifact.missingInputs,
-          ...reviewResults.flatMap((result) => result.data.missingInputs),
-        ]),
+        missingInputs: finalMissingInputs,
         responseModel: artifact.responseModel,
         numTurns: artifact.numTurns,
         generatedAt: new Date().toISOString(),
@@ -955,11 +734,7 @@ export async function buildGeneratedSkill(args: {
 
     return {
       ...artifact,
-      missingInputs: uniqueStrings([
-        ...plan.data.missingInputs,
-        ...artifact.missingInputs,
-        ...reviewResults.flatMap((result) => result.data.missingInputs),
-      ]),
+      missingInputs: finalMissingInputs,
     };
   } catch (error) {
     if (error instanceof GeneratedSkillBuildError) {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -41,7 +41,7 @@ import {
 } from './skill-prompts.js';
 
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 5;
-const MAX_SKILL_REVISION_ATTEMPTS = 1;
+const MAX_SKILL_REVIEW_REVISIONS = 3;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 interface SkillBuilderStepMetrics {
@@ -247,52 +247,60 @@ function formatReviewIssue(issue: GeneratedSkillReviewResult['issues'][number]):
   return `${location}${issue.message}${fix}`;
 }
 
-function finalBlockingIssues(args: {
-  deterministic: {
-    errors: string[];
-    warnings: string[];
-  };
-  review?: GeneratedSkillReviewResult;
+function finalMechanicalBlockingIssues(deterministic: {
+  errors: string[];
+  warnings: string[];
 }): string[] {
-  // Final blocking combines mechanical runnability with the reviewer verdict.
-  // Do not add deterministic taste checks here; make the authoring reviewer own
-  // qualitative depth and layout feedback.
+  // Only mechanical runnability blocks the final write. Qualitative reviewer
+  // feedback is handled by the bounded review loop and recorded as warnings if
+  // the reviewer still wants changes after the cap.
   const issues: string[] = [];
-  issues.push(...args.deterministic.errors);
-  if (hasMissingGeneratedFileWarning(args.deterministic)) {
-    issues.push(...args.deterministic.warnings.filter((warning) =>
+  issues.push(...deterministic.errors);
+  if (hasMissingGeneratedFileWarning(deterministic)) {
+    issues.push(...deterministic.warnings.filter((warning) =>
       warning.includes('generated artifacts do not include it')
     ));
-  }
-  if (args.review && reviewNeedsRevision(args.review)) {
-    if (args.review.issues.length === 0) {
-      issues.push('Authoring reviewer marked the generated skill invalid without issue details');
-    } else {
-      issues.push(...args.review.issues.map(formatReviewIssue));
-    }
   }
   return uniqueStrings(issues);
 }
 
-function throwIfFinalReviewFailed(args: {
+function throwIfMechanicalValidationFailed(args: {
   targetName: string;
   deterministic: {
     errors: string[];
     warnings: string[];
   };
-  review?: GeneratedSkillReviewResult;
 }): void {
-  const issues = finalBlockingIssues({
-    deterministic: args.deterministic,
-    review: args.review,
-  });
+  const issues = finalMechanicalBlockingIssues(args.deterministic);
   if (issues.length === 0) {
     return;
   }
   throw new GeneratedSkillBuildError(
-    `Generated skill failed final review for ${args.targetName}:\n` +
+    `Generated skill failed mechanical validation for ${args.targetName}:\n` +
     issues.map((issue) => `- ${issue}`).join('\n'),
   );
+}
+
+function boundedReviewWarnings(args: {
+  review?: GeneratedSkillReviewResult;
+  maxRevisions: number;
+}): string[] {
+  if (!args.review || !reviewNeedsRevision(args.review)) {
+    return [];
+  }
+
+  const plural = args.maxRevisions === 1 ? 'revision pass' : 'revision passes';
+  const warnings = [
+    `Authoring reviewer still requested changes after ${args.maxRevisions} ${plural}; using the latest writer draft.`,
+  ];
+  const issues = args.review.issues.length === 0
+    ? ['Authoring reviewer marked the generated skill invalid without issue details']
+    : args.review.issues.map(formatReviewIssue);
+  warnings.push(...issues.slice(0, 5).map((issue) => `Reviewer: ${issue}`));
+  if (issues.length > 5) {
+    warnings.push(`Reviewer: ${issues.length - 5} more issues omitted from summary`);
+  }
+  return warnings;
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -370,6 +378,7 @@ function loadExistingArtifact(args: {
     usage: zeroUsage(),
     externalSources: [],
     missingInputs: [],
+    warnings: [],
   };
 }
 
@@ -429,6 +438,7 @@ function loadCachedArtifact(args: {
     usage: metadata.usage,
     externalSources: metadata.externalSources,
     missingInputs: metadata.missingInputs,
+    warnings: metadata.authoringWarnings,
     responseModel: metadata.responseModel,
     numTurns: metadata.numTurns,
   };
@@ -454,6 +464,7 @@ function artifactFromDisk(args: {
   usage: UsageStats;
   externalSources: SkillBuildExternalSource[];
   missingInputs: string[];
+  warnings: string[];
   responseModel?: string;
   numTurns?: number;
 }): GeneratedSkillArtifact {
@@ -468,6 +479,7 @@ function artifactFromDisk(args: {
     usage: args.usage,
     externalSources: args.externalSources,
     missingInputs: args.missingInputs,
+    warnings: args.warnings,
     responseModel: args.responseModel,
     numTurns: args.numTurns,
   };
@@ -575,7 +587,8 @@ export async function buildGeneratedSkill(args: {
     const revisionResults: SkillBuilderStepMetrics[] = [];
 
     let latestReview: GeneratedSkillReviewResult | undefined;
-    for (let reviewRound = 0; reviewRound <= MAX_SKILL_REVISION_ATTEMPTS; reviewRound += 1) {
+    let reviewHitRevisionLimit = false;
+    for (let reviewRound = 0; ; reviewRound += 1) {
       const deterministic = deterministicValidation({
         files: workingArtifact.files,
         targetName: args.outline.skill,
@@ -613,12 +626,14 @@ export async function buildGeneratedSkill(args: {
 
       if (
         !reviewNeedsRevision(review.data) ||
-        revisionResults.length >= MAX_SKILL_REVISION_ATTEMPTS
+        revisionResults.length >= MAX_SKILL_REVIEW_REVISIONS
       ) {
+        reviewHitRevisionLimit = reviewNeedsRevision(review.data) &&
+          revisionResults.length >= MAX_SKILL_REVIEW_REVISIONS;
         break;
       }
 
-      args.onStatus?.('Revising generated skill');
+      args.onStatus?.(`Revising generated skill (${revisionResults.length + 1}/${MAX_SKILL_REVIEW_REVISIONS})`);
       const revision = await runStructuredSkillBuilderAgent({
         runtime: args.runtime,
         repoPath: args.rootDir,
@@ -659,6 +674,12 @@ export async function buildGeneratedSkill(args: {
       ...workingArtifact.missingInputs,
       ...reviewResults.flatMap((result) => result.data.missingInputs),
     ]);
+    const finalWarnings = uniqueStrings([
+      ...boundedReviewWarnings({
+        review: reviewHitRevisionLimit ? latestReview : undefined,
+        maxRevisions: MAX_SKILL_REVIEW_REVISIONS,
+      }),
+    ]);
     workingArtifact = {
       ...workingArtifact,
       externalSources: finalExternalSources,
@@ -673,10 +694,9 @@ export async function buildGeneratedSkill(args: {
         `Generated skill build did not produce SKILL.md for ${args.outline.skill}`,
       );
     }
-    throwIfFinalReviewFailed({
+    throwIfMechanicalValidationFailed({
       targetName: args.outline.skill,
       deterministic: finalDeterministic,
-      review: latestReview,
     });
 
     const usage = aggregateUsage([
@@ -705,6 +725,7 @@ export async function buildGeneratedSkill(args: {
       usage,
       externalSources: finalExternalSources,
       missingInputs: finalMissingInputs,
+      warnings: finalWarnings,
       responseModel,
       numTurns,
     });
@@ -725,6 +746,7 @@ export async function buildGeneratedSkill(args: {
         usage: artifact.usage,
         externalSources: artifact.externalSources,
         missingInputs: finalMissingInputs,
+        authoringWarnings: finalWarnings,
         responseModel: artifact.responseModel,
         numTurns: artifact.numTurns,
         generatedAt: new Date().toISOString(),
@@ -735,6 +757,7 @@ export async function buildGeneratedSkill(args: {
     return {
       ...artifact,
       missingInputs: finalMissingInputs,
+      warnings: finalWarnings,
     };
   } catch (error) {
     if (error instanceof GeneratedSkillBuildError) {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -127,12 +127,24 @@ function yamlQuoted(value: string): string {
   return JSON.stringify(value);
 }
 
+function targetSubject(targetName: string): string {
+  return targetName
+    .replace(/^wrdn-/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim() || targetName;
+}
+
+function isAuthoringMetadataDescription(value: string): boolean {
+  return /\b(generated|architecture|router|focused references|authoring|SKILL\.md|SPEC\.md|SOURCES\.md)\b/i
+    .test(value);
+}
+
 function fallbackDescription(fileMap: GeneratedSkillFileMap, targetName: string): string {
   const summary = oneLine(fileMap.summary);
-  if (summary) {
+  if (summary && !isAuthoringMetadataDescription(summary)) {
     return summary;
   }
-  return `Use when running the generated ${targetName} Warden skill.`;
+  return `Use when reviewing code changes for ${targetSubject(targetName)} concerns.`;
 }
 
 function ensureSkillFrontmatter(args: {
@@ -140,15 +152,23 @@ function ensureSkillFrontmatter(args: {
   fileMap: GeneratedSkillFileMap;
   targetName: string;
 }): string {
-  if (SKILL_FRONTMATTER_PATTERN.test(args.content)) {
+  const frontmatter = skillFrontmatter(args.content);
+  const description = frontmatter?.['description'];
+  if (
+    frontmatter?.['name'] === args.targetName &&
+    typeof description === 'string' &&
+    description.trim() &&
+    !isAuthoringMetadataDescription(description)
+  ) {
     return args.content;
   }
+  const body = args.content.replace(SKILL_FRONTMATTER_PATTERN, '').trimStart();
   return `---
 name: ${yamlQuoted(args.targetName)}
 description: ${yamlQuoted(fallbackDescription(args.fileMap, args.targetName))}
 ---
 
-${args.content.trimStart()}`;
+${body}`;
 }
 
 function referencedSkillPaths(content: string): string[] {
@@ -497,6 +517,22 @@ function normalizeProviderIssue(
   return issue;
 }
 
+function advisoryProviderIssues(
+  validation: GeneratedSkillValidationResult,
+): GeneratedSkillValidationIssue[] {
+  const issues = validation.issues.map((issue) => ({
+    ...normalizeProviderIssue(issue),
+    severity: 'warning' as const,
+  }));
+  if (!validation.valid && issues.length === 0) {
+    issues.push({
+      severity: 'warning',
+      message: 'Authoring provider marked the generated skill invalid without issue details.',
+    });
+  }
+  return issues;
+}
+
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
   const distinct = [...new Set(models.filter((model): model is string => Boolean(model)))];
   if (distinct.length === 0) {
@@ -825,22 +861,7 @@ export async function buildGeneratedSkill(args: {
         finalDeterministic.errors.map((error) => `- ${error}`).join('\n'),
       );
     }
-    const providerIssues = validation.data.issues.map(normalizeProviderIssue);
-    const providerErrors = providerIssues.filter((issue) => issue.severity === 'error');
-    if (
-      providerErrors.length > 0 ||
-      (!validation.data.valid && providerIssues.length === 0)
-    ) {
-      const issueLines = providerIssues.length > 0
-        ? providerIssues.map((issue) => {
-          const path = issue.path ? `${issue.path}: ` : '';
-          return `- ${issue.severity}: ${path}${issue.message}`;
-        }).join('\n')
-        : '- error: Authoring provider marked the generated skill invalid';
-      throw new GeneratedSkillBuildError(
-        `Generated skill failed provider validation for ${args.outline.skill}:\n${issueLines}`,
-      );
-    }
+    const providerIssues = advisoryProviderIssues(validation.data);
 
     const usage = aggregateUsage([
       plan.usage,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -42,7 +42,7 @@ import {
   defaultValidationMaxTurns,
 } from './skill-prompts.js';
 
-const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
+const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 5;
 const MAX_SKILL_REVISION_ATTEMPTS = 1;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
@@ -114,74 +114,6 @@ function fileManifest(files: { path: string; content: string }[]): {
 function normalizeFileContent(content: string): string {
   const normalized = content.replace(/\r\n/g, '\n');
   return normalized.endsWith('\n') ? normalized : `${normalized}\n`;
-}
-
-function canonicalGeneratedArtifactPath(path: string): string {
-  if (path.startsWith('references/tracks/')) {
-    return `references/${path.slice('references/tracks/'.length)}`;
-  }
-  return path;
-}
-
-function rewriteGeneratedArtifactPathReferences(content: string, pathMap: Map<string, string>): string {
-  let rewritten = content;
-  const entries = [...pathMap.entries()]
-    .filter(([from, to]) => from !== to)
-    .sort((a, b) => b[0].length - a[0].length);
-  for (const [from, to] of entries) {
-    rewritten = rewritten.split(from).join(to);
-  }
-  return rewritten;
-}
-
-function canonicalizeGeneratedFileMapPaths(fileMap: GeneratedSkillFileMap): GeneratedSkillFileMap {
-  const pathMap = new Map<string, string>();
-  const changedPaths: [string, string][] = [];
-  for (const file of fileMap.files) {
-    const canonicalPath = canonicalGeneratedArtifactPath(file.path);
-    pathMap.set(file.path, canonicalPath);
-    if (file.path !== canonicalPath) {
-      changedPaths.push([file.path, canonicalPath]);
-    }
-    if (canonicalPath.startsWith('references/')) {
-      pathMap.set(`references/tracks/${canonicalPath.slice('references/'.length)}`, canonicalPath);
-    }
-  }
-
-  const files = new Map<string, {
-    path: string;
-    content: string;
-  }>();
-  let contentChanged = false;
-  for (const file of fileMap.files) {
-    const path = pathMap.get(file.path) ?? file.path;
-    const content = rewriteGeneratedArtifactPathReferences(file.content, pathMap);
-    contentChanged ||= content !== file.content;
-    const existing = files.get(path);
-    if (!existing || content.length > existing.content.length) {
-      files.set(path, { path, content });
-    }
-  }
-
-  if (changedPaths.length === 0 && !contentChanged) {
-    return fileMap;
-  }
-
-  const validationNotes = [...fileMap.validationNotes];
-  if (changedPaths.length > 0) {
-    validationNotes.push(
-      `Flattened generated reference path(s): ${changedPaths
-        .map(([from, to]) => `${from} -> ${to}`)
-        .sort()
-        .join(', ')}`,
-    );
-  }
-
-  return {
-    ...fileMap,
-    files: [...files.values()].sort((a, b) => a.path.localeCompare(b.path)),
-    validationNotes,
-  };
 }
 
 function skillFrontmatter(content: string): Record<string, unknown> | undefined {
@@ -356,10 +288,7 @@ function prepareGeneratedFileMap(
   fileMap: GeneratedSkillFileMap,
   targetName: string,
 ): GeneratedSkillFileMap {
-  return normalizeGeneratedFileMap(
-    canonicalizeGeneratedFileMapPaths(fileMap),
-    targetName,
-  );
+  return normalizeGeneratedFileMap(fileMap, targetName);
 }
 
 function deterministicValidation(args: {
@@ -417,16 +346,6 @@ function deterministicValidation(args: {
     }
   }
 
-  const hasRuntimeReferences = referenceFiles.length > 0;
-  const sources = files.get('SOURCES.md');
-  if (
-    hasRuntimeReferences &&
-    sources &&
-    /\b(deferred|future passes|next pass|not covered in this pass)\b/i.test(sources)
-  ) {
-    warnings.push('SOURCES.md appears to contain stale deferred-work language while references exist');
-  }
-
   return { errors, warnings };
 }
 
@@ -446,10 +365,6 @@ function hasMissingGeneratedFileWarning(validation: {
   return validation.warnings.some((warning) =>
     warning.includes('generated file map does not include it'),
   );
-}
-
-function hasCanonicalPathChanges(files: { path: string }[]): boolean {
-  return files.some((file) => canonicalGeneratedArtifactPath(file.path) !== file.path);
 }
 
 function reviewNeedsRevision(review: GeneratedSkillReviewResult): boolean {
@@ -543,9 +458,7 @@ function applyContributionResult(args: {
     ...args.original,
     files: [
       ...args.original.files.filter(
-        (file) => !changedFiles.some((changed) =>
-          canonicalGeneratedArtifactPath(changed.path) === canonicalGeneratedArtifactPath(file.path)
-        ),
+        (file) => !changedFiles.some((changed) => changed.path === file.path),
       ),
       ...changedFiles,
     ],
@@ -612,8 +525,7 @@ function loadExistingArtifact(args: {
   });
   if (
     validation.errors.length > 0 ||
-    hasMissingGeneratedFileWarning(validation) ||
-    hasCanonicalPathChanges(args.files)
+    hasMissingGeneratedFileWarning(validation)
   ) {
     return undefined;
   }
@@ -680,8 +592,7 @@ function loadCachedArtifact(args: {
   });
   if (
     validation.errors.length > 0 ||
-    hasMissingGeneratedFileWarning(validation) ||
-    hasCanonicalPathChanges(files)
+    hasMissingGeneratedFileWarning(validation)
   ) {
     const normalizedFileMap = prepareGeneratedFileMap(
       {
@@ -789,12 +700,11 @@ function normalizeGeneratedFileMap(
   fileMap: GeneratedSkillFileMap,
   targetName = fileMap.name,
 ): GeneratedSkillFileMap {
-  const canonicalFileMap = canonicalizeGeneratedFileMapPaths(fileMap);
-  const retainedFiles = canonicalFileMap.files
-    .filter((file) => !shouldOmitGeneratedArtifact(canonicalFileMap, file));
+  const retainedFiles = fileMap.files
+    .filter((file) => !shouldOmitGeneratedArtifact(fileMap, file));
   const retainedPaths = new Set(retainedFiles.map((file) => file.path));
   return {
-    ...canonicalFileMap,
+    ...fileMap,
     files: retainedFiles
       .map((file) => ({
         path: file.path,
@@ -804,7 +714,7 @@ function normalizeGeneratedFileMap(
               stripOutputContractSections(file.content),
               retainedPaths,
             ),
-            fileMap: canonicalFileMap,
+            fileMap,
             targetName,
           })
           : file.content),
@@ -1101,7 +1011,6 @@ export async function buildGeneratedSkill(args: {
         name: artifact.name,
         fileManifest: fileManifest(writtenFiles),
         deterministicWarnings: formatDeterministicIssues(finalDeterministic),
-        validationIssues: [],
         bytes: artifact.bytes,
         durationMs: artifact.durationMs,
         usage: artifact.usage,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -515,7 +515,7 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    const maxTurns = args.maxTurns ?? defaultBuildMaxTurns(args.outline);
+    const maxTurns = args.maxTurns ?? defaultBuildMaxTurns();
     const repair = {
       apiKey: args.apiKey,
       model: args.repairModel,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -21,11 +21,9 @@ import {
 import {
   GeneratedSkillAuthoringPlanSchema,
   GeneratedSkillBuildError,
-  GeneratedSkillContributionSchema,
   GeneratedSkillFileMapSchema,
   GeneratedSkillReviewResultSchema,
   type GeneratedSkillArtifact,
-  type GeneratedSkillContribution,
   type GeneratedSkillFileMap,
   type GeneratedSkillReviewResult,
   type SkillBuildAuthoringProvider,
@@ -36,7 +34,6 @@ import {
   buildAuthoringImplementationPrompt,
   buildAuthoringPlanPrompt,
   buildAuthoringRevisionPrompt,
-  buildAuthoringTrackContributionPrompt,
   buildAuthoringValidationPrompt,
   defaultBuildMaxTurns,
   defaultValidationMaxTurns,
@@ -448,38 +445,6 @@ function mergeExternalSources(
   return [...sources.values()];
 }
 
-function applyContributionResult(args: {
-  original: GeneratedSkillFileMap;
-  contribution: GeneratedSkillContribution;
-  targetName: string;
-}): GeneratedSkillFileMap {
-  const changedFiles = args.contribution.files.filter((file) => file.content.trim().length > 0);
-  const candidate: GeneratedSkillFileMap = {
-    ...args.original,
-    files: [
-      ...args.original.files.filter(
-        (file) => !changedFiles.some((changed) => changed.path === file.path),
-      ),
-      ...changedFiles,
-    ],
-    validationNotes: uniqueStrings([
-      ...args.original.validationNotes,
-      args.contribution.summary,
-      ...args.contribution.validationNotes,
-    ]),
-    missingInputs: uniqueStrings([
-      ...args.original.missingInputs,
-      ...args.contribution.missingInputs,
-    ]),
-    externalSources: mergeExternalSources(
-      args.original.externalSources,
-      args.contribution.externalSources,
-    ),
-  };
-
-  return prepareGeneratedFileMap(candidate, args.targetName);
-}
-
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
   const distinct = [...new Set(models.filter((model): model is string => Boolean(model)))];
   if (distinct.length === 0) {
@@ -823,42 +788,6 @@ export async function buildGeneratedSkill(args: {
       implementation.data,
       args.outline.skill,
     );
-    const contributionResults: SkillBuilderStepMetrics[] = [];
-
-    if (args.outline.tracks.length > 1) {
-      // Tracks are sequential coverage work lanes. They help the writer deepen
-      // topics without overlap, but they must not imply one file per track.
-      for (const track of args.outline.tracks) {
-        args.onStatus?.(`Adding ${track.title}`);
-        const contribution = await runStructuredSkillBuilderAgent({
-          runtime: args.runtime,
-          repoPath: args.repoPath,
-          skillName: `${args.outline.skill}:authoring-track-${track.id}`,
-          systemPrompt: authoringSystemPrompt(),
-          userPrompt: buildAuthoringTrackContributionPrompt({
-            outline: args.outline,
-            source: args.source,
-            authoringSkillRoot: authoringProvider.rootDir,
-            targetName: args.outline.skill,
-            targetRootDir: args.rootDir,
-            plan: plan.data,
-            fileMap: workingFileMap,
-            track,
-          }),
-          schema: GeneratedSkillContributionSchema,
-          model: args.model,
-          maxTurns,
-          abortController: args.abortController,
-          repair,
-        });
-        contributionResults.push(contribution);
-        workingFileMap = applyContributionResult({
-          original: workingFileMap,
-          contribution: contribution.data,
-          targetName: args.outline.skill,
-        });
-      }
-    }
 
     const reviewResults: SkillBuilderReviewResult[] = [];
     const revisionResults: SkillBuilderStepMetrics[] = [];
@@ -972,21 +901,18 @@ export async function buildGeneratedSkill(args: {
     const usage = aggregateUsage([
       plan.usage,
       implementation.usage,
-      ...contributionResults.map((result) => result.usage),
       ...reviewResults.map((result) => result.usage),
       ...revisionResults.map((result) => result.usage),
     ]);
     const responseModel = summarizeResponseModel([
       plan.responseModel,
       implementation.responseModel,
-      ...contributionResults.map((result) => result.responseModel),
       ...reviewResults.map((result) => result.responseModel),
       ...revisionResults.map((result) => result.responseModel),
     ]);
     const numTurns = summarizeTurns([
       plan.numTurns,
       implementation.numTurns,
-      ...contributionResults.map((result) => result.numTurns),
       ...reviewResults.map((result) => result.numTurns),
       ...revisionResults.map((result) => result.numTurns),
     ]);

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -243,11 +243,18 @@ function formatDeterministicIssues(validation: {
 function applyValidationResult(args: {
   original: GeneratedSkillFileMap;
   validation: GeneratedSkillValidationResult;
+  targetName: string;
 }): GeneratedSkillFileMap {
   if (!args.validation.files || args.validation.files.length === 0) {
     return args.original;
   }
-  return {
+  if (
+    !args.validation.files.some((file) => file.path === 'SKILL.md') ||
+    args.validation.files.some((file) => file.content.trim().length === 0)
+  ) {
+    return args.original;
+  }
+  const candidate = {
     ...args.original,
     files: args.validation.files,
     validationNotes: [
@@ -260,6 +267,15 @@ function applyValidationResult(args: {
       ...args.validation.missingInputs,
     ],
   };
+  const validation = deterministicValidation({
+    fileMap: normalizeGeneratedFileMap(candidate, args.targetName),
+    targetName: args.targetName,
+  });
+  if (validation.errors.length > 0) {
+    return args.original;
+  }
+
+  return candidate;
 }
 
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
@@ -572,6 +588,7 @@ export async function buildGeneratedSkill(args: {
     const fileMap = normalizeGeneratedFileMap(applyValidationResult({
       original: initialFileMap,
       validation: validation.data,
+      targetName: args.outline.skill,
     }), args.outline.skill);
     const finalDeterministic = deterministicValidation({
       fileMap,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -35,6 +35,7 @@ import {
   authoringSystemPrompt,
   buildAuthoringImplementationPrompt,
   buildAuthoringPlanPrompt,
+  buildAuthoringRevisionPrompt,
   buildAuthoringTrackContributionPrompt,
   buildAuthoringValidationPrompt,
   defaultBuildMaxTurns,
@@ -43,6 +44,7 @@ import {
 
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
 const LONG_REFERENCE_LINE_LIMIT = 100;
+const MAX_SKILL_REVISION_ATTEMPTS = 1;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 type GeneratedSkillValidationIssue = GeneratedSkillValidationResult['issues'][number];
 
@@ -662,49 +664,6 @@ function hasCanonicalPathChanges(files: { path: string }[]): boolean {
   return files.some((file) => canonicalGeneratedArtifactPath(file.path) !== file.path);
 }
 
-function applyValidationResult(args: {
-  original: GeneratedSkillFileMap;
-  validation: GeneratedSkillValidationResult;
-  targetName: string;
-  outline: SkillBuildOutline;
-}): GeneratedSkillFileMap {
-  if (!args.validation.files || args.validation.files.length === 0) {
-    return args.original;
-  }
-  const replacementFiles = args.validation.files.filter((file) => file.content.trim().length > 0);
-  if (!replacementFiles.some((file) => file.path === 'SKILL.md')) {
-    return args.original;
-  }
-  const candidate = {
-    ...args.original,
-    files: [
-      ...args.original.files.filter(
-        (file) => !replacementFiles.some((replacement) => replacement.path === file.path),
-      ),
-      ...replacementFiles,
-    ],
-    validationNotes: [
-      ...args.original.validationNotes,
-      args.validation.summary,
-      ...args.validation.issues.map((issue) => `${issue.severity}: ${issue.message}`),
-    ],
-    missingInputs: [
-      ...args.original.missingInputs,
-      ...args.validation.missingInputs,
-    ],
-  };
-  const fileMap = prepareGeneratedFileMap(candidate, args.targetName, args.outline);
-  const validation = deterministicValidation({
-    fileMap,
-    targetName: args.targetName,
-  });
-  if (validation.errors.length > 0) {
-    return args.original;
-  }
-
-  return fileMap;
-}
-
 function advisoryProviderIssues(
   validation: GeneratedSkillValidationResult,
 ): GeneratedSkillValidationIssue[] {
@@ -719,6 +678,10 @@ function advisoryProviderIssues(
     });
   }
   return issues;
+}
+
+function reviewNeedsRevision(validation: GeneratedSkillValidationResult): boolean {
+  return !validation.valid || validation.issues.length > 0;
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -1160,45 +1123,96 @@ export async function buildGeneratedSkill(args: {
       }
     }
 
-    const initialFileMap = workingFileMap;
-    const initialDeterministic = deterministicValidation({
-      fileMap: initialFileMap,
-      targetName: args.outline.skill,
-    });
+    const reviewResults: {
+      data: GeneratedSkillValidationResult;
+      usage: UsageStats;
+      responseModel?: string;
+      numTurns?: number;
+    }[] = [];
+    const revisionResults: {
+      usage: UsageStats;
+      responseModel?: string;
+      numTurns?: number;
+    }[] = [];
 
-    args.onStatus?.('Validating generated skill');
-    const validation = await runStructuredSkillBuilderAgent({
-      runtime: args.runtime,
-      repoPath: args.repoPath,
-      skillName: `${args.outline.skill}:authoring-validation`,
-      systemPrompt: authoringSystemPrompt(),
-      userPrompt: buildAuthoringValidationPrompt({
-        outline: args.outline,
-        source: args.source,
-        authoringSkillRoot: authoringProvider.rootDir,
+    let latestReview: GeneratedSkillValidationResult | undefined;
+    for (let reviewRound = 0; reviewRound <= MAX_SKILL_REVISION_ATTEMPTS; reviewRound += 1) {
+      const deterministic = deterministicValidation({
+        fileMap: workingFileMap,
         targetName: args.outline.skill,
-        targetRootDir: args.rootDir,
-        plan: plan.data,
-        fileMap: initialFileMap,
-        deterministicIssues: formatDeterministicIssues(initialDeterministic),
-      }),
-      schema: GeneratedSkillValidationResultSchema,
-      model: args.model,
-      maxTurns: Math.min(maxTurns, defaultValidationMaxTurns()),
-      abortController: args.abortController,
-      repair,
-    });
+      });
 
-    const fileMap = prepareGeneratedFileMap(
-      applyValidationResult({
-        original: initialFileMap,
-        validation: validation.data,
-        targetName: args.outline.skill,
-        outline: args.outline,
-      }),
-      args.outline.skill,
-      args.outline,
-    );
+      args.onStatus?.(reviewRound === 0
+        ? 'Reviewing generated skill'
+        : 'Reviewing revised skill');
+      const review = await runStructuredSkillBuilderAgent({
+        runtime: args.runtime,
+        repoPath: args.repoPath,
+        skillName: `${args.outline.skill}:authoring-validation`,
+        systemPrompt: authoringSystemPrompt(),
+        userPrompt: buildAuthoringValidationPrompt({
+          outline: args.outline,
+          source: args.source,
+          authoringSkillRoot: authoringProvider.rootDir,
+          targetName: args.outline.skill,
+          targetRootDir: args.rootDir,
+          plan: plan.data,
+          fileMap: workingFileMap,
+          deterministicIssues: formatDeterministicIssues(deterministic),
+        }),
+        schema: GeneratedSkillValidationResultSchema,
+        model: args.model,
+        maxTurns: Math.min(maxTurns, defaultValidationMaxTurns()),
+        abortController: args.abortController,
+        repair,
+      });
+      reviewResults.push(review);
+      latestReview = review.data;
+
+      if (
+        !reviewNeedsRevision(review.data) ||
+        revisionResults.length >= MAX_SKILL_REVISION_ATTEMPTS
+      ) {
+        break;
+      }
+
+      args.onStatus?.('Revising generated skill');
+      const revision = await runStructuredSkillBuilderAgent({
+        runtime: args.runtime,
+        repoPath: args.repoPath,
+        skillName: `${args.outline.skill}:authoring-revision`,
+        systemPrompt: authoringSystemPrompt(),
+        userPrompt: buildAuthoringRevisionPrompt({
+          outline: args.outline,
+          source: args.source,
+          authoringSkillRoot: authoringProvider.rootDir,
+          targetName: args.outline.skill,
+          targetRootDir: args.rootDir,
+          plan: plan.data,
+          fileMap: workingFileMap,
+          review: review.data,
+          deterministicIssues: formatDeterministicIssues(deterministic),
+        }),
+        schema: GeneratedSkillFileMapSchema,
+        model: args.model,
+        maxTurns,
+        abortController: args.abortController,
+        repair,
+      });
+      if (revision.data.name !== args.outline.skill) {
+        throw new GeneratedSkillBuildError(
+          `Generated skill identity mismatch: expected ${args.outline.skill}, got ${revision.data.name}`,
+        );
+      }
+      revisionResults.push(revision);
+      workingFileMap = prepareGeneratedFileMap(
+        revision.data,
+        args.outline.skill,
+        args.outline,
+      );
+    }
+
+    const fileMap = workingFileMap;
     const finalDeterministic = deterministicValidation({
       fileMap,
       targetName: args.outline.skill,
@@ -1208,25 +1222,28 @@ export async function buildGeneratedSkill(args: {
         `Generated skill build did not produce SKILL.md for ${args.outline.skill}`,
       );
     }
-    const providerIssues = advisoryProviderIssues(validation.data);
+    const providerIssues = latestReview ? advisoryProviderIssues(latestReview) : [];
 
     const usage = aggregateUsage([
       plan.usage,
       implementation.usage,
       ...contributionResults.map((result) => result.usage),
-      validation.usage,
+      ...reviewResults.map((result) => result.usage),
+      ...revisionResults.map((result) => result.usage),
     ]);
     const responseModel = summarizeResponseModel([
       plan.responseModel,
       implementation.responseModel,
       ...contributionResults.map((result) => result.responseModel),
-      validation.responseModel,
+      ...reviewResults.map((result) => result.responseModel),
+      ...revisionResults.map((result) => result.responseModel),
     ]);
     const numTurns = summarizeTurns([
       plan.numTurns,
       implementation.numTurns,
       ...contributionResults.map((result) => result.numTurns),
-      validation.numTurns,
+      ...reviewResults.map((result) => result.numTurns),
+      ...revisionResults.map((result) => result.numTurns),
     ]);
 
     const artifact = writeGeneratedArtifact({
@@ -1257,7 +1274,7 @@ export async function buildGeneratedSkill(args: {
         missingInputs: [
           ...plan.data.missingInputs,
           ...artifact.missingInputs,
-          ...validation.data.missingInputs,
+          ...reviewResults.flatMap((result) => result.data.missingInputs),
         ],
         responseModel: artifact.responseModel,
         numTurns: artifact.numTurns,
@@ -1271,7 +1288,7 @@ export async function buildGeneratedSkill(args: {
       missingInputs: [
         ...plan.data.missingInputs,
         ...artifact.missingInputs,
-        ...validation.data.missingInputs,
+        ...reviewResults.flatMap((result) => result.data.missingInputs),
       ],
     };
   } catch (error) {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -43,7 +43,6 @@ import {
 } from './skill-prompts.js';
 
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
-const LONG_REFERENCE_LINE_LIMIT = 100;
 const MAX_SKILL_REVISION_ATTEMPTS = 1;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 type GeneratedSkillReviewIssue = GeneratedSkillReviewResult['issues'][number];
@@ -354,232 +353,13 @@ function referencedArtifactPaths(content: string): string[] {
   return [...paths].sort();
 }
 
-function words(value: string): string[] {
-  return value
-    .toLowerCase()
-    .replace(/\.md$/, '')
-    .split(/[^a-z0-9]+/g)
-    .filter(Boolean);
-}
-
-function expandedReferenceWords(path: string): string[] {
-  const aliases: Record<string, string[]> = {
-    authn: ['authentication', 'identity', 'session', 'credential', 'secret'],
-    authz: ['authorization', 'access', 'control', 'permission'],
-    authentication: ['authn', 'login', 'identity', 'session', 'credential', 'password', 'jwt'],
-    authorization: ['authz', 'access', 'control', 'permission', 'role'],
-    android: ['intent', 'webview', 'keystore', 'manifest', 'mobile'],
-    concurrency: ['race', 'condition', 'thread', 'lock', 'atomic'],
-    csrf: ['cross', 'site', 'request', 'forgery', 'client', 'web'],
-    crypto: ['cryptographic', 'encryption', 'secret', 'token', 'key'],
-    deserialization: ['deserialize', 'serialized', 'unserialize', 'pickle', 'marshal'],
-    ios: ['swift', 'objective', 'keychain', 'uikit', 'wkwebview', 'mobile'],
-    rce: ['remote', 'code', 'execution', 'command'],
-    rust: ['unsafe', 'ffi', 'transmute', 'soundness'],
-    secrets: ['secret', 'credential', 'password', 'token', 'key'],
-    session: ['cookie', 'csrf', 'fixation'],
-    ssrf: ['server', 'side', 'request', 'forgery'],
-    tls: ['cryptographic', 'certificate', 'transport', 'encryption'],
-    upload: ['file', 'content', 'type'],
-    xss: ['cross', 'site', 'scripting', 'client', 'web', 'injection'],
-    xxe: ['xml', 'external', 'entity'],
-  };
-  const base = path.split('/').at(-1) ?? path;
-  const set = new Set(words(base));
-  for (const word of [...set]) {
-    for (const alias of aliases[word] ?? []) {
-      set.add(alias);
-    }
-  }
-  if (set.has('path') || set.has('traversal')) {
-    set.add('filesystem');
-    set.add('file');
-  }
-  if (set.has('memory')) {
-    set.add('corruption');
-    set.add('safety');
-  }
-  return [...set];
-}
-
-function trackText(track: SkillBuildOutline['tracks'][number]): string {
-  return [
-    track.id,
-    track.title,
-    track.goal,
-    track.rationale,
-    ...track.sourceSignals,
-    ...track.owns,
-    ...track.excludes,
-    ...track.relevanceSignals,
-    ...track.evidenceFocus,
-    ...track.checks,
-    ...track.safeCounterpatterns,
-    ...track.falsePositiveTraps,
-    ...track.researchHints,
-  ].join(' ').toLowerCase();
-}
-
-function closestTrackForReference(
-  outline: SkillBuildOutline,
-  path: string,
-): SkillBuildOutline['tracks'][number] | undefined {
-  const refWords = expandedReferenceWords(path);
-  let best: {
-    track: SkillBuildOutline['tracks'][number];
-    score: number;
-  } | undefined;
-
-  for (const track of outline.tracks) {
-    const text = trackText(track);
-    const score = refWords.reduce(
-      (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(text) ? 1 : 0),
-      0,
-    );
-    if (!best || score > best.score) {
-      best = { track, score };
-    }
-  }
-
-  return best && best.score > 0 ? best.track : undefined;
-}
-
-function markdownList(items: string[], fallback: string): string {
-  const values = items.length > 0 ? items : [fallback];
-  return values.map((item) => `- ${item}`).join('\n');
-}
-
-function titleFromReferencePath(path: string): string {
-  const base = path.split('/').at(-1)?.replace(/\.md$/, '') || 'reference';
-  return words(base)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
-
-function fallbackReferenceContent(args: {
-  outline: SkillBuildOutline;
-  path: string;
-}): string {
-  const track = closestTrackForReference(args.outline, args.path);
-  if (!track) {
-    return `# ${titleFromReferencePath(args.path)}
-
-Use this reference when the route in SKILL.md matches the changed hunk.
-
-## Use When
-
-- The SKILL.md route points to this reference for the changed hunk.
-
-## Checks
-
-- Trace attacker-controlled input, trust boundaries, sensitive operations, and observable impact before reporting.
-
-## Evidence Required
-
-- Report only findings with changed-line evidence and a plausible exploit path.
-
-## Safe Counterpatterns
-
-- Do not report when the changed code validates inputs, enforces access control, or preserves an existing safe invariant.
-
-## False Positive Traps
-
-- Do not report pattern-only findings without data flow, reachability, and impact.
-`;
-  }
-
-  return `# ${track.title}
-
-${track.goal}
-
-## Use When
-
-${markdownList(track.relevanceSignals, track.rationale)}
-
-## Checks
-
-${markdownList(track.checks, 'Trace exploitability through the changed code before reporting.')}
-
-## Evidence Required
-
-${markdownList(track.evidenceFocus, 'Anchor each finding to changed lines and concrete runtime behavior.')}
-
-## Safe Counterpatterns
-
-${markdownList(track.safeCounterpatterns, 'Do not report when the changed code preserves an existing safe invariant.')}
-
-## False Positive Traps
-
-${markdownList(track.falsePositiveTraps, 'Do not report pattern-only findings without reachability and impact.')}
-`;
-}
-
-function backfillMissingRoutedReferences(
-  fileMap: GeneratedSkillFileMap,
-  outline: SkillBuildOutline,
-): GeneratedSkillFileMap {
-  const files = new Map(fileMap.files.map((file) => [file.path, file.content]));
-  const added = new Set<string>();
-  const visited = new Set<string>();
-  const queue = ['SKILL.md'];
-
-  while (queue.length > 0) {
-    const path = queue.shift();
-    if (!path) {
-      continue;
-    }
-    if (visited.has(path)) {
-      continue;
-    }
-    visited.add(path);
-
-    const content = files.get(path);
-    if (!content) {
-      continue;
-    }
-
-    for (const referencePath of referencedSkillPaths(content)) {
-      if (!files.has(referencePath)) {
-        files.set(referencePath, fallbackReferenceContent({
-          outline,
-          path: referencePath,
-        }));
-        added.add(referencePath);
-      }
-      if (referencePath.startsWith('references/') && !visited.has(referencePath)) {
-        queue.push(referencePath);
-      }
-    }
-  }
-
-  if (added.size === 0) {
-    return fileMap;
-  }
-
-  return {
-    ...fileMap,
-    files: [...files.entries()]
-      .map(([path, content]) => ({ path, content }))
-      .sort((a, b) => a.path.localeCompare(b.path)),
-    validationNotes: [
-      ...fileMap.validationNotes,
-      `Backfilled missing routed reference file(s): ${[...added].sort().join(', ')}`,
-    ],
-  };
-}
-
 function prepareGeneratedFileMap(
   fileMap: GeneratedSkillFileMap,
   targetName: string,
-  outline: SkillBuildOutline,
 ): GeneratedSkillFileMap {
-  const prefilled = backfillMissingRoutedReferences(
+  return normalizeGeneratedFileMap(
     canonicalizeGeneratedFileMapPaths(fileMap),
-    outline,
-  );
-  return backfillMissingRoutedReferences(
-    normalizeGeneratedFileMap(prefilled, targetName),
-    outline,
+    targetName,
   );
 }
 
@@ -612,22 +392,6 @@ function deterministicValidation(args: {
     }
   }
 
-  if (/Generated Warden skill for outline/i.test(skillMd)) {
-    warnings.push('SKILL.md contains generated-template boilerplate');
-  }
-
-  for (const file of args.fileMap.files) {
-    if (!file.path.endsWith('.md')) {
-      continue;
-    }
-    if (containsOutputContract(file.content)) {
-      warnings.push(`${file.path} defines output or report format; Warden injects report schema separately`);
-    }
-    if (containsAuthoringMetadata(file.content)) {
-      warnings.push(`${file.path} contains generated-skill authoring metadata instead of runtime guidance`);
-    }
-  }
-
   const referenceFiles = args.fileMap.files.filter((file) => file.path.startsWith('references/'));
   const routedReferenceFiles = referenceFiles.filter((file) => skillMd.includes(file.path));
   const routeDocuments = [
@@ -647,12 +411,6 @@ function deterministicValidation(args: {
   for (const reference of referenceFiles) {
     if (!routeDocuments.some((content) => content.includes(reference.path))) {
       warnings.push(`SKILL.md does not route runtime reference ${reference.path}`);
-    }
-    const lineCount = reference.content.split('\n').length;
-    if (lineCount > LONG_REFERENCE_LINE_LIMIT && !/^## Contents$/m.test(reference.content)) {
-      warnings.push(
-        `${reference.path} is ${lineCount} lines; add ## Contents or split by lookup need`,
-      );
     }
   }
 
@@ -731,7 +489,6 @@ function applyContributionResult(args: {
   original: GeneratedSkillFileMap;
   contribution: GeneratedSkillContribution;
   targetName: string;
-  outline: SkillBuildOutline;
 }): GeneratedSkillFileMap {
   const changedFiles = args.contribution.files.filter((file) => file.content.trim().length > 0);
   const candidate: GeneratedSkillFileMap = {
@@ -759,7 +516,7 @@ function applyContributionResult(args: {
     ),
   };
 
-  return prepareGeneratedFileMap(candidate, args.targetName, args.outline);
+  return prepareGeneratedFileMap(candidate, args.targetName);
 }
 
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
@@ -889,7 +646,6 @@ function loadCachedArtifact(args: {
         externalSources: metadata.externalSources,
       },
       metadata.name,
-      args.outline,
     );
     const normalizedValidation = deterministicValidation({
       fileMap: normalizedFileMap,
@@ -1108,7 +864,6 @@ export async function buildGeneratedSkill(args: {
     let workingFileMap = prepareGeneratedFileMap(
       implementation.data,
       args.outline.skill,
-      args.outline,
     );
     const contributionResults: SkillBuilderStepMetrics[] = [];
 
@@ -1141,7 +896,6 @@ export async function buildGeneratedSkill(args: {
           original: workingFileMap,
           contribution: contribution.data,
           targetName: args.outline.skill,
-          outline: args.outline,
         });
       }
     }
@@ -1222,11 +976,20 @@ export async function buildGeneratedSkill(args: {
       workingFileMap = prepareGeneratedFileMap(
         revision.data,
         args.outline.skill,
-        args.outline,
       );
     }
 
-    const fileMap = workingFileMap;
+    const fileMap: GeneratedSkillFileMap = {
+      ...workingFileMap,
+      externalSources: mergeExternalSources(
+        plan.data.externalSources,
+        workingFileMap.externalSources,
+      ),
+      missingInputs: uniqueStrings([
+        ...plan.data.missingInputs,
+        ...workingFileMap.missingInputs,
+      ]),
+    };
     const finalDeterministic = deterministicValidation({
       fileMap,
       targetName: args.outline.skill,
@@ -1285,11 +1048,11 @@ export async function buildGeneratedSkill(args: {
         durationMs: artifact.durationMs,
         usage: artifact.usage,
         externalSources: artifact.externalSources,
-        missingInputs: [
+        missingInputs: uniqueStrings([
           ...plan.data.missingInputs,
           ...artifact.missingInputs,
           ...reviewResults.flatMap((result) => result.data.missingInputs),
-        ],
+        ]),
         responseModel: artifact.responseModel,
         numTurns: artifact.numTurns,
         generatedAt: new Date().toISOString(),
@@ -1299,11 +1062,11 @@ export async function buildGeneratedSkill(args: {
 
     return {
       ...artifact,
-      missingInputs: [
+      missingInputs: uniqueStrings([
         ...plan.data.missingInputs,
         ...artifact.missingInputs,
         ...reviewResults.flatMap((result) => result.data.missingInputs),
-      ],
+      ]),
     };
   } catch (error) {
     if (error instanceof GeneratedSkillBuildError) {

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -41,6 +41,7 @@ import {
 const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
 const LONG_REFERENCE_LINE_LIMIT = 100;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+type GeneratedSkillValidationIssue = GeneratedSkillValidationResult['issues'][number];
 
 function artifactFiles(rootDir: string): {
   path: string;
@@ -161,6 +162,210 @@ function referencedSkillPaths(content: string): string[] {
   return [...paths].sort();
 }
 
+function words(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/\.md$/, '')
+    .split(/[^a-z0-9]+/g)
+    .filter(Boolean);
+}
+
+function expandedReferenceWords(path: string): string[] {
+  const aliases: Record<string, string[]> = {
+    authn: ['authentication', 'identity', 'session', 'credential', 'secret'],
+    authz: ['authorization', 'access', 'control', 'permission'],
+    csrf: ['cross', 'site', 'request', 'forgery', 'client', 'web'],
+    crypto: ['cryptographic', 'encryption', 'secret', 'token', 'key'],
+    rce: ['remote', 'code', 'execution', 'command'],
+    ssrf: ['server', 'side', 'request', 'forgery'],
+    tls: ['cryptographic', 'certificate', 'transport', 'encryption'],
+    xss: ['cross', 'site', 'scripting', 'client', 'web', 'injection'],
+    xxe: ['xml', 'external', 'entity'],
+  };
+  const base = path.split('/').at(-1) ?? path;
+  const set = new Set(words(base));
+  for (const word of [...set]) {
+    for (const alias of aliases[word] ?? []) {
+      set.add(alias);
+    }
+  }
+  if (set.has('path') || set.has('traversal')) {
+    set.add('filesystem');
+    set.add('file');
+  }
+  if (set.has('memory')) {
+    set.add('corruption');
+    set.add('safety');
+  }
+  return [...set];
+}
+
+function trackText(track: SkillBuildOutline['tracks'][number]): string {
+  return [
+    track.id,
+    track.title,
+    track.goal,
+    track.rationale,
+    ...track.sourceSignals,
+    ...track.owns,
+    ...track.excludes,
+    ...track.relevanceSignals,
+    ...track.evidenceFocus,
+    ...track.checks,
+    ...track.safeCounterpatterns,
+    ...track.falsePositiveTraps,
+    ...track.researchHints,
+  ].join(' ').toLowerCase();
+}
+
+function closestTrackForReference(
+  outline: SkillBuildOutline,
+  path: string,
+): SkillBuildOutline['tracks'][number] | undefined {
+  const refWords = expandedReferenceWords(path);
+  let best: {
+    track: SkillBuildOutline['tracks'][number];
+    score: number;
+  } | undefined;
+
+  for (const track of outline.tracks) {
+    const text = trackText(track);
+    const score = refWords.reduce(
+      (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(text) ? 1 : 0),
+      0,
+    );
+    if (!best || score > best.score) {
+      best = { track, score };
+    }
+  }
+
+  return best && best.score > 0 ? best.track : undefined;
+}
+
+function markdownList(items: string[], fallback: string): string {
+  const values = items.length > 0 ? items : [fallback];
+  return values.map((item) => `- ${item}`).join('\n');
+}
+
+function titleFromReferencePath(path: string): string {
+  const base = path.split('/').at(-1)?.replace(/\.md$/, '') || 'reference';
+  return words(base)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function fallbackReferenceContent(args: {
+  outline: SkillBuildOutline;
+  path: string;
+}): string {
+  const track = closestTrackForReference(args.outline, args.path);
+  if (!track) {
+    return `# ${titleFromReferencePath(args.path)}
+
+Use this reference when the route in SKILL.md matches the changed hunk.
+
+## Use When
+
+- The SKILL.md route points to this reference for the changed hunk.
+
+## Checks
+
+- Trace attacker-controlled input, trust boundaries, sensitive operations, and observable impact before reporting.
+
+## Evidence Required
+
+- Report only findings with changed-line evidence and a plausible exploit path.
+
+## Safe Counterpatterns
+
+- Do not report when the changed code validates inputs, enforces access control, or preserves an existing safe invariant.
+
+## False Positive Traps
+
+- Do not report pattern-only findings without data flow, reachability, and impact.
+`;
+  }
+
+  return `# ${track.title}
+
+${track.goal}
+
+## Use When
+
+${markdownList(track.relevanceSignals, track.rationale)}
+
+## Checks
+
+${markdownList(track.checks, 'Trace exploitability through the changed code before reporting.')}
+
+## Evidence Required
+
+${markdownList(track.evidenceFocus, 'Anchor each finding to changed lines and concrete runtime behavior.')}
+
+## Safe Counterpatterns
+
+${markdownList(track.safeCounterpatterns, 'Do not report when the changed code preserves an existing safe invariant.')}
+
+## False Positive Traps
+
+${markdownList(track.falsePositiveTraps, 'Do not report pattern-only findings without reachability and impact.')}
+`;
+}
+
+function backfillMissingRoutedReferences(
+  fileMap: GeneratedSkillFileMap,
+  outline: SkillBuildOutline,
+): GeneratedSkillFileMap {
+  const files = new Map(fileMap.files.map((file) => [file.path, file.content]));
+  const added = new Set<string>();
+  const visited = new Set<string>();
+  const queue = ['SKILL.md'];
+
+  while (queue.length > 0) {
+    const path = queue.shift();
+    if (!path) {
+      continue;
+    }
+    if (visited.has(path)) {
+      continue;
+    }
+    visited.add(path);
+
+    const content = files.get(path);
+    if (!content) {
+      continue;
+    }
+
+    for (const referencePath of referencedSkillPaths(content)) {
+      if (!files.has(referencePath)) {
+        files.set(referencePath, fallbackReferenceContent({
+          outline,
+          path: referencePath,
+        }));
+        added.add(referencePath);
+      }
+      if (referencePath.startsWith('references/') && !visited.has(referencePath)) {
+        queue.push(referencePath);
+      }
+    }
+  }
+
+  if (added.size === 0) {
+    return fileMap;
+  }
+
+  return {
+    ...fileMap,
+    files: [...files.entries()]
+      .map(([path, content]) => ({ path, content }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+    validationNotes: [
+      ...fileMap.validationNotes,
+      `Backfilled missing routed reference file(s): ${[...added].sort().join(', ')}`,
+    ],
+  };
+}
+
 function deterministicValidation(args: {
   fileMap: GeneratedSkillFileMap;
   targetName: string;
@@ -276,6 +481,20 @@ function applyValidationResult(args: {
   }
 
   return candidate;
+}
+
+function normalizeProviderIssue(
+  issue: GeneratedSkillValidationIssue,
+): GeneratedSkillValidationIssue {
+  if (
+    issue.severity === 'error' &&
+    issue.path?.startsWith('references/') &&
+    /\breference is \d+ lines\b/i.test(issue.message) &&
+    /\bcontents\b/i.test(issue.message)
+  ) {
+    return { ...issue, severity: 'warning' };
+  }
+  return issue;
 }
 
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
@@ -556,7 +775,10 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    const initialFileMap = normalizeGeneratedFileMap(implementation.data, args.outline.skill);
+    const initialFileMap = backfillMissingRoutedReferences(
+      normalizeGeneratedFileMap(implementation.data, args.outline.skill),
+      args.outline,
+    );
     const initialDeterministic = deterministicValidation({
       fileMap: initialFileMap,
       targetName: args.outline.skill,
@@ -585,11 +807,14 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
-    const fileMap = normalizeGeneratedFileMap(applyValidationResult({
-      original: initialFileMap,
-      validation: validation.data,
-      targetName: args.outline.skill,
-    }), args.outline.skill);
+    const fileMap = backfillMissingRoutedReferences(
+      normalizeGeneratedFileMap(applyValidationResult({
+        original: initialFileMap,
+        validation: validation.data,
+        targetName: args.outline.skill,
+      }), args.outline.skill),
+      args.outline,
+    );
     const finalDeterministic = deterministicValidation({
       fileMap,
       targetName: args.outline.skill,
@@ -600,10 +825,14 @@ export async function buildGeneratedSkill(args: {
         finalDeterministic.errors.map((error) => `- ${error}`).join('\n'),
       );
     }
-    const providerErrors = validation.data.issues.filter((issue) => issue.severity === 'error');
-    if (!validation.data.valid || providerErrors.length > 0) {
-      const issueLines = validation.data.issues.length > 0
-        ? validation.data.issues.map((issue) => {
+    const providerIssues = validation.data.issues.map(normalizeProviderIssue);
+    const providerErrors = providerIssues.filter((issue) => issue.severity === 'error');
+    if (
+      providerErrors.length > 0 ||
+      (!validation.data.valid && providerIssues.length === 0)
+    ) {
+      const issueLines = providerIssues.length > 0
+        ? providerIssues.map((issue) => {
           const path = issue.path ? `${issue.path}: ` : '';
           return `- ${issue.severity}: ${path}${issue.message}`;
         }).join('\n')
@@ -649,7 +878,7 @@ export async function buildGeneratedSkill(args: {
         name: artifact.name,
         fileManifest: fileManifest(writtenFiles),
         deterministicWarnings: finalDeterministic.warnings,
-        validationIssues: validation.data.issues,
+        validationIssues: providerIssues,
         bytes: artifact.bytes,
         durationMs: artifact.durationMs,
         usage: artifact.usage,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -1,12 +1,12 @@
 import { join } from 'node:path';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { parse as parseYaml } from 'yaml';
 import { aggregateUsage } from '../sdk/usage.js';
 import type { Runtime } from '../sdk/runtimes/index.js';
 import { runStructuredSkillBuilderAgent, StructuredSkillBuilderAgentError } from './agentic.js';
 import type { UsageStats } from '../types/index.js';
-import { clearGeneratedSkillArtifacts } from './definition.js';
+import { clearGeneratedSkillArtifacts, readGeneratedSkillArtifactFiles } from './definition.js';
 import { resolveAuthoringProvider } from './authoring-provider.js';
 import {
   type SkillBuildOutline,
@@ -20,6 +20,7 @@ import {
 } from './outline-state.js';
 import {
   GeneratedSkillAuthoringPlanSchema,
+  type GeneratedSkillAuthoringMode,
   GeneratedSkillBuildError,
   GeneratedSkillWriterResultSchema,
   GeneratedSkillReviewResultSchema,
@@ -66,47 +67,6 @@ interface GeneratedSkillArtifactSnapshot {
   validationNotes: string[];
   missingInputs: string[];
   externalSources: SkillBuildExternalSource[];
-}
-
-function artifactFiles(rootDir: string): {
-  path: string;
-  content: string;
-  bytes: number;
-}[] {
-  if (!existsSync(rootDir)) {
-    return [];
-  }
-
-  const files: {
-    path: string;
-    content: string;
-    bytes: number;
-  }[] = [];
-
-  function visit(relativeDir: string): void {
-    for (const entry of readdirSync(join(rootDir, relativeDir), { withFileTypes: true })) {
-      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
-      if (entry.name === 'warden.yaml' || entry.name === 'build-state.json') {
-        continue;
-      }
-      if (entry.isDirectory()) {
-        visit(relativePath);
-        continue;
-      }
-      if (!entry.isFile()) {
-        continue;
-      }
-      const content = readFileSync(join(rootDir, relativePath), 'utf-8');
-      files.push({
-        path: relativePath,
-        content,
-        bytes: Buffer.byteLength(content, 'utf-8'),
-      });
-    }
-  }
-
-  visit('');
-  return files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
 function filesByteLength(files: { content: string }[]): number {
@@ -392,7 +352,7 @@ function loadCachedArtifact(args: {
     return undefined;
   }
 
-  const files = artifactFiles(args.rootDir);
+  const files = readGeneratedSkillArtifactFiles(args.rootDir);
   const state = readSkillBuildState(getBuildStatePath(args.rootDir));
   const metadata = state?.artifact;
   if (!metadata) {
@@ -450,7 +410,7 @@ function readArtifactSnapshot(args: {
 }): GeneratedSkillArtifactSnapshot {
   return {
     summary: args.writer.summary,
-    files: artifactFiles(args.rootDir),
+    files: readGeneratedSkillArtifactFiles(args.rootDir),
     validationNotes: args.writer.validationNotes,
     missingInputs: args.writer.missingInputs,
     externalSources: args.writer.externalSources,
@@ -468,7 +428,7 @@ function artifactFromDisk(args: {
   responseModel?: string;
   numTurns?: number;
 }): GeneratedSkillArtifact {
-  const files = artifactFiles(args.rootDir);
+  const files = readGeneratedSkillArtifactFiles(args.rootDir);
   return {
     kind: 'generated-skill',
     source: 'generated',
@@ -491,6 +451,8 @@ export async function buildGeneratedSkill(args: {
   rootDir: string;
   runtime: Runtime;
   repoPath: string;
+  mode?: GeneratedSkillAuthoringMode;
+  improvementPrompt?: string;
   model?: string;
   maxTurns?: number;
   abortController?: AbortController;
@@ -503,12 +465,13 @@ export async function buildGeneratedSkill(args: {
 }): Promise<GeneratedSkillArtifact> {
   const startedAt = performance.now();
   const statePath = getBuildStatePath(args.rootDir);
+  const mode = args.mode ?? 'build';
   const authoringProvider = resolveAuthoringProvider({
     authoringSkillRoot: args.authoringSkillRoot,
   });
 
   try {
-    if (!args.regenerate) {
+    if (mode === 'build' && !args.regenerate) {
       const cached = loadCachedArtifact({
         rootDir: args.rootDir,
         outline: args.outline,
@@ -524,6 +487,11 @@ export async function buildGeneratedSkill(args: {
     if (!previousState) {
       throw new GeneratedSkillBuildError(
         `Missing generated skill outline state for ${args.outline.skill}`,
+      );
+    }
+    if (mode === 'improve' && !args.improvementPrompt?.trim()) {
+      throw new GeneratedSkillBuildError(
+        `Missing improvement brief for ${args.outline.skill}`,
       );
     }
 
@@ -546,6 +514,8 @@ export async function buildGeneratedSkill(args: {
         authoringSkillRoot: authoringProvider.rootDir,
         targetName: args.outline.skill,
         targetRootDir: args.rootDir,
+        mode,
+        improvementPrompt: args.improvementPrompt,
       }),
       schema: GeneratedSkillAuthoringPlanSchema,
       model: args.model,
@@ -554,9 +524,11 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
-    clearGeneratedSkillArtifacts(args.rootDir);
+    if (mode === 'build') {
+      clearGeneratedSkillArtifacts(args.rootDir);
+    }
 
-    args.onStatus?.('Writing skill artifacts');
+    args.onStatus?.(mode === 'improve' ? 'Improving skill artifacts' : 'Writing skill artifacts');
     const implementation = await runStructuredSkillBuilderAgent({
       runtime: args.runtime,
       repoPath: args.rootDir,
@@ -569,6 +541,8 @@ export async function buildGeneratedSkill(args: {
         targetName: args.outline.skill,
         targetRootDir: args.rootDir,
         plan: plan.data,
+        mode,
+        improvementPrompt: args.improvementPrompt,
       }),
       schema: GeneratedSkillWriterResultSchema,
       model: args.model,
@@ -614,6 +588,8 @@ export async function buildGeneratedSkill(args: {
           plan: plan.data,
           artifact: workingArtifact,
           deterministicIssues: formatDeterministicIssues(deterministic),
+          mode,
+          improvementPrompt: args.improvementPrompt,
         }),
         schema: GeneratedSkillReviewResultSchema,
         model: args.model,
@@ -649,6 +625,8 @@ export async function buildGeneratedSkill(args: {
           artifact: workingArtifact,
           review: review.data,
           deterministicIssues: formatDeterministicIssues(deterministic),
+          mode,
+          improvementPrompt: args.improvementPrompt,
         }),
         schema: GeneratedSkillWriterResultSchema,
         model: args.model,
@@ -664,12 +642,20 @@ export async function buildGeneratedSkill(args: {
       });
     }
 
+    const previousArtifactExternalSources = mode === 'improve'
+      ? previousState.artifact?.externalSources ?? []
+      : [];
+    const previousArtifactMissingInputs = mode === 'improve'
+      ? previousState.artifact?.missingInputs ?? []
+      : [];
     const finalExternalSources = mergeExternalSources(
+      previousArtifactExternalSources,
       args.outline.build.externalSources ?? [],
       plan.data.externalSources,
       workingArtifact.externalSources,
     );
     const finalMissingInputs = uniqueStrings([
+      ...previousArtifactMissingInputs,
       ...plan.data.missingInputs,
       ...workingArtifact.missingInputs,
       ...reviewResults.flatMap((result) => result.data.missingInputs),
@@ -729,7 +715,7 @@ export async function buildGeneratedSkill(args: {
       responseModel,
       numTurns,
     });
-    const writtenFiles = artifactFiles(args.rootDir);
+    const writtenFiles = readGeneratedSkillArtifactFiles(args.rootDir);
     writeSkillBuildState(statePath, {
       ...previousState,
       artifact: {
@@ -763,15 +749,16 @@ export async function buildGeneratedSkill(args: {
     if (error instanceof GeneratedSkillBuildError) {
       throw error;
     }
+    const operation = mode === 'improve' ? 'improvement' : 'build';
     if (error instanceof StructuredSkillBuilderAgentError) {
       throw new GeneratedSkillBuildError(
-        `Generated skill build failed for ${args.outline.skill}: ${error.message}`,
+        `Generated skill ${operation} failed for ${args.outline.skill}: ${error.message}`,
         { cause: error },
       );
     }
     if (error instanceof Error) {
       throw new GeneratedSkillBuildError(
-        `Generated skill build failed for ${args.outline.skill}: ${error.message}`,
+        `Generated skill ${operation} failed for ${args.outline.skill}: ${error.message}`,
         { cause: error },
       );
     }

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -21,9 +21,11 @@ import {
 import {
   GeneratedSkillAuthoringPlanSchema,
   GeneratedSkillBuildError,
+  GeneratedSkillContributionSchema,
   GeneratedSkillFileMapSchema,
   GeneratedSkillValidationResultSchema,
   type GeneratedSkillArtifact,
+  type GeneratedSkillContribution,
   type GeneratedSkillFileMap,
   type GeneratedSkillValidationResult,
   type SkillBuildAuthoringProvider,
@@ -33,6 +35,7 @@ import {
   authoringSystemPrompt,
   buildAuthoringImplementationPrompt,
   buildAuthoringPlanPrompt,
+  buildAuthoringTrackContributionPrompt,
   buildAuthoringValidationPrompt,
   defaultBuildMaxTurns,
   defaultValidationMaxTurns,
@@ -101,6 +104,64 @@ function fileManifest(files: { path: string; content: string }[]): {
 function normalizeFileContent(content: string): string {
   const normalized = content.replace(/\r\n/g, '\n');
   return normalized.endsWith('\n') ? normalized : `${normalized}\n`;
+}
+
+function canonicalGeneratedArtifactPath(path: string): string {
+  if (path.startsWith('references/tracks/')) {
+    return `references/${path.slice('references/tracks/'.length)}`;
+  }
+  return path;
+}
+
+function rewriteGeneratedArtifactPathReferences(content: string, pathMap: Map<string, string>): string {
+  let rewritten = content;
+  const entries = [...pathMap.entries()]
+    .filter(([from, to]) => from !== to)
+    .sort((a, b) => b[0].length - a[0].length);
+  for (const [from, to] of entries) {
+    rewritten = rewritten.split(from).join(to);
+  }
+  return rewritten;
+}
+
+function canonicalizeGeneratedFileMapPaths(fileMap: GeneratedSkillFileMap): GeneratedSkillFileMap {
+  const pathMap = new Map<string, string>();
+  for (const file of fileMap.files) {
+    const canonicalPath = canonicalGeneratedArtifactPath(file.path);
+    pathMap.set(file.path, canonicalPath);
+    if (canonicalPath.startsWith('references/')) {
+      pathMap.set(`references/tracks/${canonicalPath.slice('references/'.length)}`, canonicalPath);
+    }
+  }
+  const changedPaths = [...pathMap.entries()].filter(([from, to]) => from !== to);
+  if (changedPaths.length === 0) {
+    return fileMap;
+  }
+
+  const files = new Map<string, {
+    path: string;
+    content: string;
+  }>();
+  for (const file of fileMap.files) {
+    const path = pathMap.get(file.path) ?? file.path;
+    const content = rewriteGeneratedArtifactPathReferences(file.content, pathMap);
+    const existing = files.get(path);
+    if (!existing || content.length > existing.content.length) {
+      files.set(path, { path, content });
+    }
+  }
+
+  return {
+    ...fileMap,
+    files: [...files.values()].sort((a, b) => a.path.localeCompare(b.path)),
+    validationNotes: [
+      ...fileMap.validationNotes,
+      `Flattened generated reference path(s): ${changedPaths
+        .map(([from, to]) => `${from} -> ${to}`)
+        .sort()
+        .join(', ')}`,
+    ],
+  };
 }
 
 function skillFrontmatter(content: string): Record<string, unknown> | undefined {
@@ -312,54 +373,6 @@ function expandedReferenceWords(path: string): string[] {
   return [...set];
 }
 
-function distinctiveReferenceWords(path: string): string[] {
-  const generic = new Set([
-    'bug',
-    'bugs',
-    'check',
-    'checks',
-    'code',
-    'guide',
-    'review',
-    'safety',
-    'security',
-    'vulnerabilities',
-    'vulnerability',
-  ]);
-  return expandedReferenceWords(path)
-    .filter((word) => word.length > 2 && !generic.has(word));
-}
-
-function referenceContentMatchesPath(path: string, content: string): boolean {
-  const base = path.split('/').at(-1) ?? path;
-  const baseWords = words(base)
-    .filter((word) => distinctiveReferenceWords(word).includes(word));
-  const expandedWords = distinctiveReferenceWords(path);
-  if (expandedWords.length === 0) {
-    return true;
-  }
-  const normalized = content.toLowerCase();
-  const baseMatches = baseWords.reduce(
-    (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(normalized) ? 1 : 0),
-    0,
-  );
-  if (baseWords.length === 1 && baseMatches === 1) {
-    return true;
-  }
-  if (baseWords.length > 1 && baseMatches === baseWords.length) {
-    return true;
-  }
-  const aliasWords = expandedWords.filter((word) => !baseWords.includes(word));
-  const aliasMatches = aliasWords.reduce(
-    (sum, word) => sum + (new RegExp(`\\b${word}\\b`).test(normalized) ? 1 : 0),
-    0,
-  );
-  if (baseMatches > 0) {
-    return aliasMatches >= 1;
-  }
-  return aliasMatches >= 2;
-}
-
 function trackText(track: SkillBuildOutline['tracks'][number]): string {
   return [
     track.id,
@@ -526,42 +539,6 @@ function backfillMissingRoutedReferences(
   };
 }
 
-function repairMismatchedRoutedReferences(
-  fileMap: GeneratedSkillFileMap,
-  outline: SkillBuildOutline,
-): GeneratedSkillFileMap {
-  const replaced: string[] = [];
-  const files = fileMap.files.map((file) => {
-    if (
-      !file.path.startsWith('references/') ||
-      referenceContentMatchesPath(file.path, file.content)
-    ) {
-      return file;
-    }
-    replaced.push(file.path);
-    return {
-      path: file.path,
-      content: fallbackReferenceContent({
-        outline,
-        path: file.path,
-      }),
-    };
-  });
-
-  if (replaced.length === 0) {
-    return fileMap;
-  }
-
-  return {
-    ...fileMap,
-    files,
-    validationNotes: [
-      ...fileMap.validationNotes,
-      `Repaired mismatched routed reference file(s): ${replaced.sort().join(', ')}`,
-    ],
-  };
-}
-
 function deterministicValidation(args: {
   fileMap: GeneratedSkillFileMap;
   targetName: string;
@@ -615,20 +592,17 @@ function deterministicValidation(args: {
   ];
   for (const path of [...new Set(routeDocuments.flatMap(referencedSkillPaths))].sort()) {
     if (!files.has(path)) {
-      errors.push(`SKILL.md routes ${path} but the generated file map does not include it`);
+      warnings.push(`SKILL.md routes ${path} but the generated file map does not include it`);
     }
   }
   for (const path of referencedArtifactPaths(skillMd)) {
     if (!files.has(path)) {
-      errors.push(`SKILL.md references ${path} but the generated file map does not include it`);
+      warnings.push(`SKILL.md references ${path} but the generated file map does not include it`);
     }
   }
   for (const reference of referenceFiles) {
     if (!routeDocuments.some((content) => content.includes(reference.path))) {
       warnings.push(`SKILL.md does not route runtime reference ${reference.path}`);
-    }
-    if (!referenceContentMatchesPath(reference.path, reference.content)) {
-      warnings.push(`${reference.path} content does not match its routed reference path`);
     }
     const lineCount = reference.content.split('\n').length;
     if (lineCount > LONG_REFERENCE_LINE_LIMIT && !/^## Contents$/m.test(reference.content)) {
@@ -651,14 +625,6 @@ function deterministicValidation(args: {
   return { errors, warnings };
 }
 
-function hasReferenceMismatchWarning(validation: {
-  warnings: string[];
-}): boolean {
-  return validation.warnings.some((warning) =>
-    warning.includes('content does not match its routed reference path'),
-  );
-}
-
 function formatDeterministicIssues(validation: {
   errors: string[];
   warnings: string[];
@@ -667,6 +633,18 @@ function formatDeterministicIssues(validation: {
     ...validation.errors.map((message) => `error: ${message}`),
     ...validation.warnings.map((message) => `warning: ${message}`),
   ];
+}
+
+function hasMissingGeneratedFileWarning(validation: {
+  warnings: string[];
+}): boolean {
+  return validation.warnings.some((warning) =>
+    warning.includes('generated file map does not include it'),
+  );
+}
+
+function hasCanonicalPathChanges(files: { path: string }[]): boolean {
+  return files.some((file) => canonicalGeneratedArtifactPath(file.path) !== file.path);
 }
 
 function applyValidationResult(args: {
@@ -701,10 +679,7 @@ function applyValidationResult(args: {
     ],
   };
   const fileMap = backfillMissingRoutedReferences(
-    repairMismatchedRoutedReferences(
-      normalizeGeneratedFileMap(candidate, args.targetName),
-      args.outline,
-    ),
+    normalizeGeneratedFileMap(candidate, args.targetName),
     args.outline,
   );
   const validation = deterministicValidation({
@@ -732,6 +707,60 @@ function advisoryProviderIssues(
     });
   }
   return issues;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)].filter((value) => value.trim().length > 0);
+}
+
+function mergeExternalSources(
+  ...sourceSets: GeneratedSkillFileMap['externalSources'][]
+): GeneratedSkillFileMap['externalSources'] {
+  const sources = new Map<string, GeneratedSkillFileMap['externalSources'][number]>();
+  for (const sourceSet of sourceSets) {
+    for (const source of sourceSet) {
+      sources.set(`${source.title}\n${source.url}`, source);
+    }
+  }
+  return [...sources.values()];
+}
+
+function applyContributionResult(args: {
+  original: GeneratedSkillFileMap;
+  contribution: GeneratedSkillContribution;
+  targetName: string;
+  outline: SkillBuildOutline;
+}): GeneratedSkillFileMap {
+  const changedFiles = args.contribution.files.filter((file) => file.content.trim().length > 0);
+  const candidate: GeneratedSkillFileMap = {
+    ...args.original,
+    files: [
+      ...args.original.files.filter(
+        (file) => !changedFiles.some((changed) =>
+          canonicalGeneratedArtifactPath(changed.path) === canonicalGeneratedArtifactPath(file.path)
+        ),
+      ),
+      ...changedFiles,
+    ],
+    validationNotes: uniqueStrings([
+      ...args.original.validationNotes,
+      args.contribution.summary,
+      ...args.contribution.validationNotes,
+    ]),
+    missingInputs: uniqueStrings([
+      ...args.original.missingInputs,
+      ...args.contribution.missingInputs,
+    ]),
+    externalSources: mergeExternalSources(
+      args.original.externalSources,
+      args.contribution.externalSources,
+    ),
+  };
+
+  return backfillMissingRoutedReferences(
+    normalizeGeneratedFileMap(candidate, args.targetName),
+    args.outline,
+  );
 }
 
 function summarizeResponseModel(models: (string | undefined)[]): string | undefined {
@@ -777,7 +806,11 @@ function loadExistingArtifact(args: {
     },
     targetName: args.name,
   });
-  if (validation.errors.length > 0 || hasReferenceMismatchWarning(validation)) {
+  if (
+    validation.errors.length > 0 ||
+    hasMissingGeneratedFileWarning(validation) ||
+    hasCanonicalPathChanges(args.files)
+  ) {
     return undefined;
   }
 
@@ -841,23 +874,30 @@ function loadCachedArtifact(args: {
     },
     targetName: metadata.name,
   });
-  if (validation.errors.length > 0 || hasReferenceMismatchWarning(validation)) {
-    const normalizedFileMap = normalizeGeneratedFileMap({
-      version: 1,
-      name: metadata.name,
-      files: files.map((file) => ({ path: file.path, content: file.content })),
-      summary: 'Cached generated artifact',
-      validationNotes: [],
-      missingInputs: metadata.missingInputs,
-      externalSources: metadata.externalSources,
-    }, metadata.name);
+  if (
+    validation.errors.length > 0 ||
+    hasMissingGeneratedFileWarning(validation) ||
+    hasCanonicalPathChanges(files)
+  ) {
+    const normalizedFileMap = backfillMissingRoutedReferences(
+      normalizeGeneratedFileMap({
+        version: 1,
+        name: metadata.name,
+        files: files.map((file) => ({ path: file.path, content: file.content })),
+        summary: 'Cached generated artifact',
+        validationNotes: [],
+        missingInputs: metadata.missingInputs,
+        externalSources: metadata.externalSources,
+      }, metadata.name),
+      args.outline,
+    );
     const normalizedValidation = deterministicValidation({
       fileMap: normalizedFileMap,
       targetName: metadata.name,
     });
     if (
       normalizedValidation.errors.length > 0 ||
-      hasReferenceMismatchWarning(normalizedValidation)
+      hasMissingGeneratedFileWarning(normalizedValidation)
     ) {
       return undefined;
     }
@@ -876,7 +916,7 @@ function loadCachedArtifact(args: {
       artifact: {
         ...metadata,
         fileManifest: fileManifest(writtenFiles),
-        deterministicWarnings: normalizedValidation.warnings,
+        deterministicWarnings: formatDeterministicIssues(normalizedValidation),
         bytes: artifact.bytes,
         generatedAt: new Date().toISOString(),
       },
@@ -945,11 +985,12 @@ function normalizeGeneratedFileMap(
   fileMap: GeneratedSkillFileMap,
   targetName = fileMap.name,
 ): GeneratedSkillFileMap {
-  const retainedFiles = fileMap.files
-    .filter((file) => !shouldOmitGeneratedArtifact(fileMap, file));
+  const canonicalFileMap = canonicalizeGeneratedFileMapPaths(fileMap);
+  const retainedFiles = canonicalFileMap.files
+    .filter((file) => !shouldOmitGeneratedArtifact(canonicalFileMap, file));
   const retainedPaths = new Set(retainedFiles.map((file) => file.path));
   return {
-    ...fileMap,
+    ...canonicalFileMap,
     files: retainedFiles
       .map((file) => ({
         path: file.path,
@@ -959,7 +1000,7 @@ function normalizeGeneratedFileMap(
               stripOutputContractSections(file.content),
               retainedPaths,
             ),
-            fileMap,
+            fileMap: canonicalFileMap,
             targetName,
           })
           : file.content),
@@ -1064,13 +1105,51 @@ export async function buildGeneratedSkill(args: {
       );
     }
 
-    const initialFileMap = repairMismatchedRoutedReferences(
-      backfillMissingRoutedReferences(
-        normalizeGeneratedFileMap(implementation.data, args.outline.skill),
-        args.outline,
-      ),
+    let workingFileMap = backfillMissingRoutedReferences(
+      normalizeGeneratedFileMap(implementation.data, args.outline.skill),
       args.outline,
     );
+    const contributionResults: {
+      usage: UsageStats;
+      responseModel?: string;
+      numTurns?: number;
+    }[] = [];
+
+    if (args.outline.tracks.length > 1) {
+      for (const track of args.outline.tracks) {
+        args.onStatus?.(`Adding ${track.title}`);
+        const contribution = await runStructuredSkillBuilderAgent({
+          runtime: args.runtime,
+          repoPath: args.repoPath,
+          skillName: `${args.outline.skill}:authoring-track-${track.id}`,
+          systemPrompt: authoringSystemPrompt(),
+          userPrompt: buildAuthoringTrackContributionPrompt({
+            outline: args.outline,
+            source: args.source,
+            authoringSkillRoot: authoringProvider.rootDir,
+            targetName: args.outline.skill,
+            targetRootDir: args.rootDir,
+            plan: plan.data,
+            fileMap: workingFileMap,
+            track,
+          }),
+          schema: GeneratedSkillContributionSchema,
+          model: args.model,
+          maxTurns,
+          abortController: args.abortController,
+          repair,
+        });
+        contributionResults.push(contribution);
+        workingFileMap = applyContributionResult({
+          original: workingFileMap,
+          contribution: contribution.data,
+          targetName: args.outline.skill,
+          outline: args.outline,
+        });
+      }
+    }
+
+    const initialFileMap = workingFileMap;
     const initialDeterministic = deterministicValidation({
       fileMap: initialFileMap,
       targetName: args.outline.skill,
@@ -1099,26 +1178,22 @@ export async function buildGeneratedSkill(args: {
       repair,
     });
 
-    const fileMap = repairMismatchedRoutedReferences(
-      backfillMissingRoutedReferences(
-        normalizeGeneratedFileMap(applyValidationResult({
-          original: initialFileMap,
-          validation: validation.data,
-          targetName: args.outline.skill,
-          outline: args.outline,
-        }), args.outline.skill),
-        args.outline,
-      ),
+    const fileMap = backfillMissingRoutedReferences(
+      normalizeGeneratedFileMap(applyValidationResult({
+        original: initialFileMap,
+        validation: validation.data,
+        targetName: args.outline.skill,
+        outline: args.outline,
+      }), args.outline.skill),
       args.outline,
     );
     const finalDeterministic = deterministicValidation({
       fileMap,
       targetName: args.outline.skill,
     });
-    if (finalDeterministic.errors.length > 0) {
+    if (!fileMap.files.some((file) => file.path === 'SKILL.md')) {
       throw new GeneratedSkillBuildError(
-        `Generated skill failed validation for ${args.outline.skill}:\n` +
-        finalDeterministic.errors.map((error) => `- ${error}`).join('\n'),
+        `Generated skill build did not produce SKILL.md for ${args.outline.skill}`,
       );
     }
     const providerIssues = advisoryProviderIssues(validation.data);
@@ -1126,16 +1201,19 @@ export async function buildGeneratedSkill(args: {
     const usage = aggregateUsage([
       plan.usage,
       implementation.usage,
+      ...contributionResults.map((result) => result.usage),
       validation.usage,
     ]);
     const responseModel = summarizeResponseModel([
       plan.responseModel,
       implementation.responseModel,
+      ...contributionResults.map((result) => result.responseModel),
       validation.responseModel,
     ]);
     const numTurns = summarizeTurns([
       plan.numTurns,
       implementation.numTurns,
+      ...contributionResults.map((result) => result.numTurns),
       validation.numTurns,
     ]);
 
@@ -1158,7 +1236,7 @@ export async function buildGeneratedSkill(args: {
         authoringProvider,
         name: artifact.name,
         fileManifest: fileManifest(writtenFiles),
-        deterministicWarnings: finalDeterministic.warnings,
+        deterministicWarnings: formatDeterministicIssues(finalDeterministic),
         validationIssues: providerIssues,
         bytes: artifact.bytes,
         durationMs: artifact.durationMs,

--- a/src/skill-builder/skill.ts
+++ b/src/skill-builder/skill.ts
@@ -23,11 +23,11 @@ import {
   GeneratedSkillBuildError,
   GeneratedSkillContributionSchema,
   GeneratedSkillFileMapSchema,
-  GeneratedSkillValidationResultSchema,
+  GeneratedSkillReviewResultSchema,
   type GeneratedSkillArtifact,
   type GeneratedSkillContribution,
   type GeneratedSkillFileMap,
-  type GeneratedSkillValidationResult,
+  type GeneratedSkillReviewResult,
   type SkillBuildAuthoringProvider,
 } from './skill-contract.js';
 export { GeneratedSkillBuildError } from './skill-contract.js';
@@ -46,7 +46,17 @@ const GENERATED_SKILL_ARTIFACT_SCHEMA_VERSION = 4;
 const LONG_REFERENCE_LINE_LIMIT = 100;
 const MAX_SKILL_REVISION_ATTEMPTS = 1;
 const SKILL_FRONTMATTER_PATTERN = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
-type GeneratedSkillValidationIssue = GeneratedSkillValidationResult['issues'][number];
+type GeneratedSkillReviewIssue = GeneratedSkillReviewResult['issues'][number];
+
+interface SkillBuilderStepMetrics {
+  usage: UsageStats;
+  responseModel?: string;
+  numTurns?: number;
+}
+
+interface SkillBuilderReviewResult extends SkillBuilderStepMetrics {
+  data: GeneratedSkillReviewResult;
+}
 
 function artifactFiles(rootDir: string): {
   path: string;
@@ -665,13 +675,13 @@ function hasCanonicalPathChanges(files: { path: string }[]): boolean {
 }
 
 function advisoryProviderIssues(
-  validation: GeneratedSkillValidationResult,
-): GeneratedSkillValidationIssue[] {
-  const issues = validation.issues.map((issue) => ({
+  review: GeneratedSkillReviewResult,
+): GeneratedSkillReviewIssue[] {
+  const issues = review.issues.map((issue) => ({
     ...issue,
     severity: 'warning' as const,
   }));
-  if (!validation.valid && issues.length === 0) {
+  if (!review.valid && issues.length === 0) {
     issues.push({
       severity: 'warning',
       message: 'Authoring provider marked the generated skill invalid without issue details.',
@@ -680,8 +690,8 @@ function advisoryProviderIssues(
   return issues;
 }
 
-function reviewNeedsRevision(validation: GeneratedSkillValidationResult): boolean {
-  return !validation.valid || validation.issues.length > 0;
+function reviewNeedsRevision(review: GeneratedSkillReviewResult): boolean {
+  return !review.valid || review.issues.length > 0;
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -1083,11 +1093,7 @@ export async function buildGeneratedSkill(args: {
       args.outline.skill,
       args.outline,
     );
-    const contributionResults: {
-      usage: UsageStats;
-      responseModel?: string;
-      numTurns?: number;
-    }[] = [];
+    const contributionResults: SkillBuilderStepMetrics[] = [];
 
     if (args.outline.tracks.length > 1) {
       for (const track of args.outline.tracks) {
@@ -1123,19 +1129,10 @@ export async function buildGeneratedSkill(args: {
       }
     }
 
-    const reviewResults: {
-      data: GeneratedSkillValidationResult;
-      usage: UsageStats;
-      responseModel?: string;
-      numTurns?: number;
-    }[] = [];
-    const revisionResults: {
-      usage: UsageStats;
-      responseModel?: string;
-      numTurns?: number;
-    }[] = [];
+    const reviewResults: SkillBuilderReviewResult[] = [];
+    const revisionResults: SkillBuilderStepMetrics[] = [];
 
-    let latestReview: GeneratedSkillValidationResult | undefined;
+    let latestReview: GeneratedSkillReviewResult | undefined;
     for (let reviewRound = 0; reviewRound <= MAX_SKILL_REVISION_ATTEMPTS; reviewRound += 1) {
       const deterministic = deterministicValidation({
         fileMap: workingFileMap,
@@ -1160,7 +1157,7 @@ export async function buildGeneratedSkill(args: {
           fileMap: workingFileMap,
           deterministicIssues: formatDeterministicIssues(deterministic),
         }),
-        schema: GeneratedSkillValidationResultSchema,
+        schema: GeneratedSkillReviewResultSchema,
         model: args.model,
         maxTurns: Math.min(maxTurns, defaultValidationMaxTurns()),
         abortController: args.abortController,

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,10 +1,9 @@
 import { readFile, readdir } from 'node:fs/promises';
-import { dirname, extname, isAbsolute, join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { loadSkillMd, SkillLoadError } from '@sentry/dotagents-lib';
 import type { SkillDefinition } from '../config/schema.js';
-import { isPathLike } from '../utils/path.js';
+import { isPathLike, resolvePathTarget } from '../utils/path.js';
 
 export class SkillLoaderError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
@@ -68,21 +67,7 @@ export const AGENT_MARKER_FILE = 'AGENT.md';
  * Resolve a skill path, handling absolute paths, tilde expansion, and relative paths.
  */
 export function resolveSkillPath(nameOrPath: string, repoRoot?: string): string {
-  // Expand ~ to home directory
-  if (nameOrPath.startsWith('~/')) {
-    return join(homedir(), nameOrPath.slice(2));
-  }
-  if (nameOrPath === '~') {
-    return homedir();
-  }
-
-  // Absolute path - use as-is
-  if (isAbsolute(nameOrPath)) {
-    return nameOrPath;
-  }
-
-  // Relative path - join with repoRoot if available
-  return repoRoot ? join(repoRoot, nameOrPath) : nameOrPath;
+  return resolvePathTarget(nameOrPath, repoRoot);
 }
 
 /**

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,11 +1,22 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { isPathLike } from './path.js';
+import { isPathLike, resolvePathTarget } from './path.js';
 
 describe('isPathLike', () => {
   it('identifies filesystem path targets', () => {
     expect(isPathLike('./skills/security')).toBe(true);
     expect(isPathLike('/Users/test/skills/security')).toBe(true);
     expect(isPathLike('skills\\security')).toBe(true);
+    expect(isPathLike('~')).toBe(true);
     expect(isPathLike('security')).toBe(false);
+  });
+});
+
+describe('resolvePathTarget', () => {
+  it('resolves CLI path targets consistently', () => {
+    expect(resolvePathTarget('./skills/security', '/repo/root')).toBe(join('/repo/root', 'skills', 'security'));
+    expect(resolvePathTarget('/tmp/skills/security', '/repo/root')).toBe('/tmp/skills/security');
+    expect(resolvePathTarget('~/skills/security', '/repo/root')).toBe(join(homedir(), 'skills/security'));
   });
 });

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,6 +1,25 @@
+import { homedir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+
 /**
  * Check whether a target string should be treated as a filesystem path.
  */
 export function isPathLike(value: string): boolean {
-  return value.startsWith('.') || value.includes('/') || value.includes('\\');
+  return value === '~' || value.startsWith('.') || value.includes('/') || value.includes('\\');
+}
+
+/**
+ * Resolve a CLI path target against a base directory.
+ */
+export function resolvePathTarget(path: string, baseDir?: string): string {
+  if (path.startsWith('~/')) {
+    return join(homedir(), path.slice(2));
+  }
+  if (path === '~') {
+    return homedir();
+  }
+  if (isAbsolute(path)) {
+    return path;
+  }
+  return baseDir ? join(baseDir, path) : path;
 }


### PR DESCRIPTION
Generated skill authoring now uses a writer-owned build/improve pipeline for repo-local review skills. Warden supplies the goal, task coverage, improvement brief when present, source expectations, and runtime constraints, then reads the writers disk output from the target skill root.

**Writer-Owned Build And Improve**

Build and improve share the same implementation path. The writer runs in the generated skill root with trusted write access, Warden preserves `warden.yaml` and `build-state.json`, and explicit relative or absolute skill paths work alongside discovered `.warden`, `.agents`, and `.claude` roots.

**Review Quality Guidance**

Generated Warden skills are treated as review skills by default. The wrapper guidance asks for changed-line evidence, boundary or invariant, cause, affected operation, missing guard, impact, and fix before reporting findings, while keeping reference segmentation qualitative rather than one-file-per-topic deterministic.

**Validation Boundary**

The reviewer drives bounded qualitative revision rounds. Deterministic checks stay mechanical: generated artifacts must be readable, and `quick_validate.py` now only checks `SKILL.md` frontmatter/YAML identity instead of markdown structure, source depth, reference shape, or maintenance-doc headings.