### PR TITLE
Clarify that supported PR actions are any valid Github PR actions

### DIFF
--- a/skills/warden/references/config-schema.md
+++ b/skills/warden/references/config-schema.md
@@ -99,7 +99,7 @@ fixBranchPrefix = "security-fix"       # Branch name prefix
 All skills run locally regardless of trigger type. Skills with no triggers run everywhere (wildcard). Use `type = "local"` for skills that should *only* run locally.
 
 **Actions (for pull_request):**
-- `opened`, `synchronize`, `reopened`, `closed`
+- `opened`, `synchronize`, `ready_for_review`, `reopened`, `closed` or any valid GitHub `pull_request` webhook action
 
 ## Severity Values
 


### PR DESCRIPTION
Hello, thanks for this tool!

While setting it up I had a Codex review incorrectly flag `ready_for_review` as unsupported. I checked the source and tested it and it works fine, so my proposal is to soften the skill wording a bit to make it clear that any Github PR action from [this list](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) is valid.

<img width="782" height="639" alt="image" src="https://github.com/user-attachments/assets/6d32da23-3551-4108-bc93-273d53fe8a85" />
