### PR TITLE
fix(action): Use relative findings output path

### DIFF
--- a/src/action/workflow/base.test.ts
+++ b/src/action/workflow/base.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { EventContext, SkillReport } from '../../types/index.js';
+import { getFindingsOutputPath, writeFindingsOutput } from './base.js';
+
+describe('findings output', () => {
+  let tempDir: string;
+  let previousGithubOutput: string | undefined;
+  let previousGithubWorkspace: string | undefined;
+  let previousRunnerTemp: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'warden-findings-output-'));
+    previousGithubOutput = process.env['GITHUB_OUTPUT'];
+    previousGithubWorkspace = process.env['GITHUB_WORKSPACE'];
+    previousRunnerTemp = process.env['RUNNER_TEMP'];
+    process.env['GITHUB_OUTPUT'] = join(tempDir, 'github-output');
+    delete process.env['RUNNER_TEMP'];
+  });
+
+  afterEach(() => {
+    if (previousGithubOutput === undefined) {
+      delete process.env['GITHUB_OUTPUT'];
+    } else {
+      process.env['GITHUB_OUTPUT'] = previousGithubOutput;
+    }
+
+    if (previousGithubWorkspace === undefined) {
+      delete process.env['GITHUB_WORKSPACE'];
+    } else {
+      process.env['GITHUB_WORKSPACE'] = previousGithubWorkspace;
+    }
+
+    if (previousRunnerTemp === undefined) {
+      delete process.env['RUNNER_TEMP'];
+    } else {
+      process.env['RUNNER_TEMP'] = previousRunnerTemp;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes findings to the workspace and exposes a repo-relative output path', () => {
+    process.env['GITHUB_WORKSPACE'] = tempDir;
+
+    const filePath = writeFindingsOutput([createReport()], createContext(tempDir));
+
+    expect(filePath).toBe(join(tempDir, 'warden-findings.json'));
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(process.env['GITHUB_OUTPUT']!, 'utf-8')).toBe(
+      'findings-file=warden-findings.json\n'
+    );
+
+    const payload = JSON.parse(readFileSync(filePath, 'utf-8')) as {
+      summary: { totalFindings: number };
+    };
+    expect(payload.summary.totalFindings).toBe(1);
+  });
+
+  it('falls back to RUNNER_TEMP when no repo path is provided', () => {
+    const runnerTemp = join(tempDir, 'runner-temp');
+    mkdirSync(runnerTemp);
+    process.env['RUNNER_TEMP'] = runnerTemp;
+
+    expect(getFindingsOutputPath()).toBe(join(runnerTemp, 'warden-findings.json'));
+  });
+});
+
+function createContext(repoPath: string): EventContext {
+  return {
+    eventType: 'schedule',
+    action: 'scheduled',
+    repository: {
+      owner: 'getsentry',
+      name: 'example',
+      fullName: 'getsentry/example',
+      defaultBranch: 'main',
+    },
+    pullRequest: {
+      number: 1,
+      title: 'Scheduled Analysis',
+      body: null,
+      author: 'warden',
+      baseBranch: 'main',
+      headBranch: 'main',
+      headSha: 'abc123',
+      baseSha: 'abc123',
+      files: [],
+    },
+    repoPath,
+  };
+}
+
+function createReport(): SkillReport {
+  return {
+    skill: 'test-skill',
+    summary: 'Found one issue',
+    findings: [
+      {
+        id: 'finding-1',
+        severity: 'high',
+        title: 'Example finding',
+        description: 'A test finding',
+        location: { path: 'src/index.ts', startLine: 1 },
+      },
+    ],
+  };
+}

--- a/src/action/workflow/base.ts
+++ b/src/action/workflow/base.ts
@@ -6,10 +6,11 @@
 
 import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, isAbsolute, join, relative } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { Octokit } from '@octokit/rest';
 import { execFileNonInteractive } from '../../utils/exec.js';
+import { isRepoRelativePath, normalizePath } from '../../utils/path.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import { countSeverity } from '../../triggers/matcher.js';
 import type { TriggerResult } from '../triggers/executor.js';
@@ -257,14 +258,6 @@ export async function getDefaultBranchFromAPI(
 // -----------------------------------------------------------------------------
 // Findings Output File
 // -----------------------------------------------------------------------------
-
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, '/');
-}
-
-function isRepoRelativePath(path: string): boolean {
-  return path !== '' && path !== '..' && !path.startsWith('../') && !isAbsolute(path);
-}
 
 function getFindingsOutputValue(filePath: string, repoPath: string): string {
   const relativePath = normalizePath(relative(repoPath, filePath));

--- a/src/action/workflow/base.ts
+++ b/src/action/workflow/base.ts
@@ -6,7 +6,7 @@
 
 import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { Octokit } from '@octokit/rest';
 import { execFileNonInteractive } from '../../utils/exec.js';
@@ -258,11 +258,31 @@ export async function getDefaultBranchFromAPI(
 // Findings Output File
 // -----------------------------------------------------------------------------
 
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+function isRepoRelativePath(path: string): boolean {
+  return path !== '' && path !== '..' && !path.startsWith('../') && !isAbsolute(path);
+}
+
+function getFindingsOutputValue(filePath: string, repoPath: string): string {
+  const relativePath = normalizePath(relative(repoPath, filePath));
+  return isRepoRelativePath(relativePath) ? relativePath : filePath;
+}
+
 /**
  * Get the path for the findings output file.
- * Uses RUNNER_TEMP (GitHub Actions) with fallback to OS temp dir.
+ *
+ * Uses the GitHub Actions workspace when available so action consumers can pass
+ * the output to upload actions that expect repo-relative paths. Falls back to
+ * RUNNER_TEMP for local callers and tests.
  */
-export function getFindingsOutputPath(): string {
+export function getFindingsOutputPath(repoPath?: string): string {
+  if (repoPath && process.env['GITHUB_WORKSPACE']) {
+    return join(repoPath, 'warden-findings.json');
+  }
+
   const tmpDir = process.env['RUNNER_TEMP'] ?? tmpdir();
   return join(tmpDir, 'warden-findings.json');
 }
@@ -270,14 +290,15 @@ export function getFindingsOutputPath(): string {
 /**
  * Write structured findings data to a JSON file for external export (GCS, S3, etc.).
  *
- * Always writes to a known location under RUNNER_TEMP and sets the `findings-file`
- * output so downstream steps can reference the path.
+ * Sets `findings-file` to a repo-relative path when possible so downstream
+ * steps can reference the path without tripping ignore processors on absolute
+ * runner temp paths.
  */
 export function writeFindingsOutput(
   reports: SkillReport[],
   context: EventContext
 ): string {
-  const filePath = getFindingsOutputPath();
+  const filePath = getFindingsOutputPath(context.repoPath);
   const allFindings = reports.flatMap((r) => r.findings);
 
   const output = {
@@ -330,6 +351,6 @@ export function writeFindingsOutput(
 
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(output, null, 2));
-  setOutput('findings-file', filePath);
+  setOutput('findings-file', getFindingsOutputValue(filePath, context.repoPath));
   return filePath;
 }

--- a/src/cli/files.test.ts
+++ b/src/cli/files.test.ts
@@ -135,6 +135,22 @@ describe('expandFileGlobs', () => {
     expect(files[0]).toContain('specific.ts');
   });
 
+  it('does not pass outside-repo absolute paths to gitignore matching', async () => {
+    const outsideDir = join(tmpdir(), `warden-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(outsideDir, { recursive: true });
+
+    try {
+      const outsideFile = join(outsideDir, 'outside.ts');
+      writeFileSync(outsideFile, 'content');
+
+      const files = await expandFileGlobs([outsideFile], tempDir);
+
+      expect(files).toEqual([outsideFile]);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it('returns empty for no matches', async () => {
     const files = await expandFileGlobs(['*.nonexistent'], tempDir);
     expect(files).toHaveLength(0);

--- a/src/cli/files.ts
+++ b/src/cli/files.ts
@@ -1,29 +1,17 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { resolve, relative, dirname, join, isAbsolute } from 'node:path';
+import { resolve, relative, dirname, join } from 'node:path';
 import fg from 'fast-glob';
 import ignore, { type Ignore } from 'ignore';
 import { countPatchChunks } from '../types/index.js';
 import type { FileChange } from '../types/index.js';
 import { execGitNonInteractive } from '../utils/exec.js';
+import { isRepoRelativePath, normalizePath } from '../utils/path.js';
 
 export interface ExpandGlobOptions {
   /** Working directory for glob expansion (default: process.cwd()) */
   cwd?: string;
   /** Respect .gitignore files (default: true) */
   gitignore?: boolean;
-}
-
-/**
- * Normalize path separators to forward slashes for cross-platform consistency.
- * fast-glob always returns forward slashes, but Node.js path functions use
- * backslashes on Windows.
- */
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, '/');
-}
-
-function isValidIgnorePath(path: string): boolean {
-  return path !== '' && path !== '..' && !path.startsWith('../') && !isAbsolute(path);
 }
 
 function hasGlobCharacters(pattern: string): boolean {
@@ -212,7 +200,7 @@ export async function expandFileGlobs(
   // Normalize paths to forward slashes for consistent matching
   const filteredFiles = files.filter((file) => {
     const relativePath = normalizePath(relative(gitRoot, file));
-    if (!isValidIgnorePath(relativePath)) {
+    if (!isRepoRelativePath(relativePath)) {
       return true;
     }
     return !ig.ignores(relativePath);

--- a/src/cli/files.ts
+++ b/src/cli/files.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { resolve, relative, dirname, join } from 'node:path';
+import { resolve, relative, dirname, join, isAbsolute } from 'node:path';
 import fg from 'fast-glob';
 import ignore, { type Ignore } from 'ignore';
 import { countPatchChunks } from '../types/index.js';
@@ -20,6 +20,10 @@ export interface ExpandGlobOptions {
  */
 function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+function isValidIgnorePath(path: string): boolean {
+  return path !== '' && path !== '..' && !path.startsWith('../') && !isAbsolute(path);
 }
 
 function hasGlobCharacters(pattern: string): boolean {
@@ -208,6 +212,9 @@ export async function expandFileGlobs(
   // Normalize paths to forward slashes for consistent matching
   const filteredFiles = files.filter((file) => {
     const relativePath = normalizePath(relative(gitRoot, file));
+    if (!isValidIgnorePath(relativePath)) {
+      return true;
+    }
     return !ig.ignores(relativePath);
   });
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -2,6 +2,20 @@ import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
 /**
+ * Normalize path separators to forward slashes for cross-platform consistency.
+ */
+export function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+/**
+ * Check whether a normalized path stays within a repository-relative boundary.
+ */
+export function isRepoRelativePath(path: string): boolean {
+  return path !== '' && path !== '..' && !path.startsWith('../') && !isAbsolute(path);
+}
+
+/**
  * Check whether a target string should be treated as a filesystem path.
  */
 export function isPathLike(value: string): boolean {


### PR DESCRIPTION
Write Warden's findings JSON to the GitHub Actions workspace and expose the action output as a repo-relative path.

The previous output pointed at an absolute RUNNER_TEMP path. Downstream upload actions that apply ignore rules can reject those absolute paths because their ignore processors expect repo-relative pathnames.

This also guards Warden's own gitignore filtering so absolute glob matches outside the repo are not passed into ignore().ignores().

Fixes #288