### PR TITLE
feat(sdk): Add finding verification pass

### DIFF
--- a/src/action/checks/manager.ts
+++ b/src/action/checks/manager.ts
@@ -87,6 +87,7 @@ export function buildCoreSummaryData(
     conclusion: 'success' | 'failure' | 'neutral' | 'cancelled';
     durationMs?: number;
     usage?: UsageStats;
+    auxiliaryUsage?: AuxiliaryUsageMap;
   }[];
 } {
   // Aggregate auxiliary usage across all reports
@@ -115,6 +116,7 @@ export function buildCoreSummaryData(
         : ('failure' as const),
       durationMs: r.report?.durationMs,
       usage: r.report?.usage,
+      auxiliaryUsage: r.report?.auxiliaryUsage,
     })),
   };
 }

--- a/src/action/fix-evaluation/judge.runtime-options.test.ts
+++ b/src/action/fix-evaluation/judge.runtime-options.test.ts
@@ -62,6 +62,12 @@ describe('evaluateFix runtime options', () => {
       expect.objectContaining({
         model: undefined,
         maxRetries: undefined,
+        prompt: expect.stringContaining('<reported_issue>'),
+      })
+    );
+    expect(runAuxiliary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('<output_format>'),
       })
     );
   });

--- a/src/action/fix-evaluation/judge.ts
+++ b/src/action/fix-evaluation/judge.ts
@@ -1,6 +1,12 @@
 import type { Octokit } from '@octokit/rest';
 import { z } from 'zod';
 import type { ExistingComment } from '../../output/dedup.js';
+import {
+  buildFileListSection,
+  buildJsonOutputSection,
+  buildTaggedSection,
+  joinPromptSections,
+} from '../../sdk/prompt-sections.js';
 import { getRuntime, type AuxiliaryTool, type RuntimeName } from '../../sdk/runtimes/index.js';
 import { emptyUsage } from '../../sdk/usage.js';
 import { FixJudgeVerdictSchema } from './types.js';
@@ -63,35 +69,25 @@ function buildPrompt(input: FixJudgeInput): string {
   const { comment, changedFiles, codeBeforeFix, codeAfterFix, commitMessages } = input;
 
   const afterCodeSection = codeAfterFix
-    ? `
-
-## Code at Issue Location (AFTER this commit)
-\`\`\`
-${codeAfterFix}
-\`\`\``
-    : '';
+    ? buildTaggedSection('after_code', codeAfterFix)
+    : undefined;
 
   const commitMessagesSection =
     commitMessages && commitMessages.length > 0
-      ? `
-
-## Commit Messages (Developer Intent)
-${commitMessages.map((msg, i) => `${i + 1}. ${msg.split('\n')[0]}`).join('\n')}
-
-Use these to help understand what the developer was trying to do. A commit mentioning "fix" or the issue topic suggests intent to address it.`
-      : '';
+      ? buildTaggedSection('developer_intent', [
+          ...commitMessages.map((msg, i) => `${i + 1}. ${msg.split('\n')[0]}`),
+          '',
+          'Use these to help understand what the developer was trying to do. A commit mentioning "fix" or the issue topic suggests intent to address it.',
+        ])
+      : undefined;
 
   const investigationStrategy = codeAfterFix
-    ? `## Investigation Strategy
-
-Compare the BEFORE and AFTER code above to determine if the issue was fixed.
+    ? `Compare the BEFORE and AFTER code above to determine if the issue was fixed.
 Use tools only if you need additional context:
 
 - \`get_file_diff(path)\` - See unified diff of changes to a file
 - \`get_file_at_commit(path, "before"|"after", startLine?, endLine?)\` - Read more file content if needed`
-    : `## Investigation Strategy
-
-Use tools to determine if the issue was fixed:
+    : `Use tools to determine if the issue was fixed:
 
 1. **Start with get_file_diff** on the issue's file (if changed) to see what was modified
 2. **Use get_file_at_commit with "after"** to see the current state at the issue location
@@ -101,20 +97,22 @@ Tools:
 - \`get_file_diff(path)\` - See unified diff of changes to a file
 - \`get_file_at_commit(path, "before"|"after", startLine?, endLine?)\` - Read file content at either commit`;
 
-  return `# Task: Judge whether a code change fixed a reported issue
-
-**Key Question: Does the reported issue still exist in the code after this commit?**
-
-## Verdict Definitions
-
+  return joinPromptSections([
+    `<task>
+Judge whether a code change fixed a reported issue.
+</task>`,
+    `<key_question>
+Does the reported issue still exist in the code after this commit?
+</key_question>`,
+    `<verdict_definitions>
 Choose ONE verdict based on these criteria:
 
-**resolved** - The issue NO LONGER EXISTS. Evidence:
+resolved - The issue NO LONGER EXISTS. Evidence:
 - The problematic code was corrected (directly or via equivalent fix)
 - The code was refactored in a way that eliminates the issue by design
 - The problematic code was intentionally removed (file deleted, function removed, dead code cleaned up)
 
-**attempted_failed** - A fix was CLEARLY ATTEMPTED but the issue PERSISTS. Evidence:
+attempted_failed - A fix was CLEARLY ATTEMPTED but the issue PERSISTS. Evidence:
 - Changes DIRECTLY modify the reported file at or near the issue location
 - AND the changes appear specifically intended to address THIS issue
 - BUT the core issue remains (wrong fix, incomplete fix, edge cases missed)
@@ -122,38 +120,28 @@ Choose ONE verdict based on these criteria:
 - Do NOT use for general refactoring, unrelated bug fixes, or changes to other files
 - When in doubt between attempted_failed and not_attempted, prefer not_attempted
 
-**not_attempted** - The issue was NOT ADDRESSED. Evidence:
+not_attempted - The issue was NOT ADDRESSED. Evidence:
 - No changes to the problematic code or its logic
 - Changes are unrelated (different feature, different bug, unrelated refactor)
 - The reported code is identical or functionally unchanged
 - Changes are in other files with no clear connection to the reported issue
-
-## The Reported Issue
-
-**Title:** ${comment.title}
-**File:** ${comment.path}
-**Line:** ${comment.line}
-
-**Description:**
-${comment.description}
-
-## Code at Issue Location (BEFORE this commit)
-\`\`\`
-${codeBeforeFix}
-\`\`\`
-${afterCodeSection}
-
-## Changed Files in This Commit
-${changedFiles.map((f) => `- ${f}`).join('\n')}
-${commitMessagesSection}
-
-${investigationStrategy}
-
-## Response Format
-
-IMPORTANT: Your response must be ONLY a JSON object with no other text. Do not explain your reasoning in prose - put your one-sentence explanation in the "reasoning" field.
-
-{"status": "resolved|attempted_failed|not_attempted", "reasoning": "One sentence explaining your verdict"}`;
+</verdict_definitions>`,
+    buildTaggedSection('reported_issue', [
+      `<title>${comment.title}</title>`,
+      `<file>${comment.path}</file>`,
+      `<line>${comment.line}</line>`,
+      '<description>',
+      comment.description,
+      '</description>',
+    ]),
+    buildTaggedSection('before_code', codeBeforeFix),
+    afterCodeSection,
+    buildFileListSection('changed_files', changedFiles),
+    commitMessagesSection,
+    buildTaggedSection('investigation_strategy', investigationStrategy),
+    buildJsonOutputSection(`{"status": "resolved|attempted_failed|not_attempted", "reasoning": "One sentence explaining your verdict"}
+Put your one-sentence explanation in the "reasoning" field.`),
+  ]);
 }
 
 const GetFileDiffInput = z.object({

--- a/src/action/triggers/executor.ts
+++ b/src/action/triggers/executor.ts
@@ -143,6 +143,7 @@ export async function executeTrigger(
             maxContextFiles: trigger.maxContextFiles,
             pathToClaudeCodeExecutable: claudePath,
             auxiliaryMaxRetries: trigger.auxiliaryMaxRetries,
+            verifyFindings: trigger.verifyFindings,
           },
         };
 

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -182,6 +182,7 @@ export async function runScheduleWorkflow(
         batchDelayMs: resolved.batchDelayMs,
         maxContextFiles: resolved.maxContextFiles,
         auxiliaryMaxRetries: resolved.auxiliaryMaxRetries,
+        verifyFindings: resolved.verifyFindings,
         pathToClaudeCodeExecutable: claudePath,
       });
       console.log(`Found ${report.findings.length} findings`);

--- a/src/cli/commands/runs.test.ts
+++ b/src/cli/commands/runs.test.ts
@@ -152,6 +152,35 @@ describe('runRunsList', () => {
 
     stdoutSpy.mockRestore();
   });
+
+  it('lists total cost including auxiliary usage', async () => {
+    const logDir = join(testDir, '.warden', 'logs');
+    writeFixture(logDir, 'ddd44444-2026-02-18T10-00-00-000Z.jsonl', [
+      {
+        skill: 'review',
+        summary: 'Done',
+        findings: [],
+        usage: { inputTokens: 3000, outputTokens: 680, costUSD: 20 },
+        auxiliaryUsage: {
+          verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+        },
+      },
+    ], 1000, 'ddd44444-0000-0000-0000-000000000000', new Date('2026-02-18T10:00:00.000Z'));
+
+    vi.spyOn(await import('../git.js'), 'getRepoRoot').mockReturnValue(testDir);
+
+    const reporter = createTestReporter();
+    const options = createDefaultOptions();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const exitCode = await runRunsList(options, reporter);
+    expect(exitCode).toBe(0);
+
+    const output = errorSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+    expect(output).toContain('$26.19');
+
+    errorSpy.mockRestore();
+  });
 });
 
 describe('runRunsShow', () => {

--- a/src/cli/commands/runs.ts
+++ b/src/cli/commands/runs.ts
@@ -12,6 +12,7 @@ import {
   pluralize,
   formatDuration,
   formatCost,
+  totalUsageCost,
   shortRunId,
   parseJsonlReports,
   parseLogMetadata,
@@ -143,6 +144,13 @@ function formatSeverityBreakdown(bySeverity: Partial<Record<Severity, number>>):
 }
 
 /**
+ * Get the total rendered cost for a saved run summary.
+ */
+function getSummaryCostUSD(summary: { usage?: SkillReport['usage']; auxiliaryUsage?: SkillReport['auxiliaryUsage'] }): number | undefined {
+  return totalUsageCost(summary.usage, summary.auxiliaryUsage);
+}
+
+/**
  * List sessions in `.warden/logs/`. Empty (no-file, no-skill) runs
  * are hidden unless `all` is set.
  */
@@ -211,7 +219,7 @@ export async function runRunsList(
       findings: meta?.summary?.totalFindings,
       bySeverity: meta?.summary?.bySeverity,
       durationMs: meta?.summary?.run.durationMs,
-      costUSD: meta?.summary?.usage?.costUSD,
+      costUSD: meta?.summary ? getSummaryCostUSD(meta.summary) : undefined,
       skills: meta?.skills,
       inProgress: meta?.inProgress ?? false,
     }));
@@ -283,9 +291,10 @@ export async function runRunsList(
     }
 
     if (summary) {
+      const costUSD = getSummaryCostUSD(summary);
       totals.findings += summary.totalFindings;
       totals.durationMs += summary.run.durationMs;
-      if (summary.usage) totals.costUSD += summary.usage.costUSD;
+      totals.costUSD += costUSD ?? 0;
       for (const [sev, count] of Object.entries(summary.bySeverity)) {
         totals.bySeverity[sev as Severity] += count;
       }
@@ -297,7 +306,7 @@ export async function runRunsList(
         files: meta.totalFiles > 0 ? String(meta.totalFiles) : '',
         findings: formatSeverityBreakdown(summary.bySeverity),
         time: formatDuration(summary.run.durationMs),
-        cost: summary.usage ? formatCost(summary.usage.costUSD) : '',
+        cost: costUSD !== undefined ? formatCost(costUSD) : '',
         sha: meta.headSha ? meta.headSha.slice(0, 7) : '',
         model: meta.model ?? '-',
         skills: skills.join(', '),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,23 +4,9 @@ initSentry('cli');
 
 import { main, abortController, interrupted } from './main.js';
 import { UserAbortError } from './input.js';
+import { createSigintHandler } from './signals.js';
 
-let interruptCount = 0;
-
-process.on('SIGINT', () => {
-  interruptCount++;
-  abortController.abort();
-  interrupted.value = true;
-
-  if (interruptCount > 1) {
-    // Second Ctrl+C: force exit immediately
-    process.exit(130);
-  }
-
-  // First Ctrl+C: let the main flow collect partial results.
-  // The interrupt message is rendered by Ink (TTY) or logPlain (non-TTY)
-  // via the abort signal listener -- no direct stderr writes needed here.
-});
+process.on('SIGINT', createSigintHandler({ abortController, interrupted }));
 
 main().catch(async (error) => {
   if (error instanceof UserAbortError) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -485,6 +485,7 @@ interface SkillToRun {
   auxiliaryModel?: string;
   synthesisModel?: string;
   auxiliaryMaxRetries?: number;
+  verifyFindings?: boolean;
 }
 
 export interface RunSkillSpec {
@@ -507,7 +508,7 @@ interface ProcessedResults {
 
 type SkillRunnerOptionOverrides = Pick<
   SkillRunnerOptions,
-  'model' | 'maxTurns' | 'runtime' | 'auxiliaryModel' | 'synthesisModel' | 'auxiliaryMaxRetries'
+  'model' | 'maxTurns' | 'runtime' | 'auxiliaryModel' | 'synthesisModel' | 'auxiliaryMaxRetries' | 'verifyFindings'
 >;
 
 /** Apply per-skill runner overrides on top of the shared execution defaults. */
@@ -525,6 +526,7 @@ export function mergeSkillRunnerOptions(
   if (overrides.auxiliaryMaxRetries !== undefined) {
     merged.auxiliaryMaxRetries = overrides.auxiliaryMaxRetries;
   }
+  if (overrides.verifyFindings !== undefined) merged.verifyFindings = overrides.verifyFindings;
 
   return merged;
 }
@@ -874,6 +876,7 @@ export async function runSkills(
         match?.auxiliaryMaxRetries ??
         config?.defaults?.auxiliary?.maxRetries ??
         config?.defaults?.auxiliaryMaxRetries,
+      verifyFindings: match?.verifyFindings ?? (config?.defaults?.verification?.enabled !== false),
     }];
   } else if (config) {
     // Get skills from matched triggers, preserving remote property and filters
@@ -897,6 +900,7 @@ export async function runSkills(
         auxiliaryModel: t.auxiliaryModel,
         synthesisModel: t.synthesisModel,
         auxiliaryMaxRetries: t.auxiliaryMaxRetries,
+        verifyFindings: t.verifyFindings,
       }));
   } else {
     skillsToRun = [];
@@ -935,6 +939,7 @@ export async function runSkills(
     auxiliaryMaxRetries:
       config?.defaults?.auxiliary?.maxRetries ??
       config?.defaults?.auxiliaryMaxRetries,
+    verifyFindings: config?.defaults?.verification?.enabled !== false,
   };
   const specs: RunSkillSpec[] = skillsToRun.map(({ skill, remote, filters, ...skillOptions }) => ({
     name: skill,
@@ -1263,6 +1268,7 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
       maxTurns: trigger.maxTurns,
       maxContextFiles: config.defaults?.chunking?.maxContextFiles,
       auxiliaryMaxRetries: trigger.auxiliaryMaxRetries,
+      verifyFindings: trigger.verifyFindings,
     },
   }));
   let tasks: SkillTaskOptions[];

--- a/src/cli/output/formatters.test.ts
+++ b/src/cli/output/formatters.test.ts
@@ -7,6 +7,9 @@ import {
   formatProgress,
   truncate,
   padRight,
+  formatUsage,
+  formatUsagePlain,
+  totalUsageCost,
   formatStatsCompact,
   formatSeverityBadge,
   formatConfidenceBadge,
@@ -171,6 +174,37 @@ describe('formatCost', () => {
     expect(formatCost(1.5)).toBe('$1.50');
     expect(formatCost(0.0892)).toBe('$0.09');
     expect(formatCost(0)).toBe('$0.00');
+  });
+});
+
+describe('totalUsageCost', () => {
+  it('adds auxiliary cost to primary usage cost', () => {
+    const usage: UsageStats = {
+      inputTokens: 3000,
+      outputTokens: 680,
+      costUSD: 20,
+    };
+    const auxiliaryUsage: AuxiliaryUsageMap = {
+      verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+    };
+
+    expect(totalUsageCost(usage, auxiliaryUsage)).toBeCloseTo(26.19);
+  });
+});
+
+describe('formatUsage', () => {
+  it('renders total cost when auxiliary usage is present', () => {
+    const usage: UsageStats = {
+      inputTokens: 3000,
+      outputTokens: 680,
+      costUSD: 20,
+    };
+    const auxiliaryUsage: AuxiliaryUsageMap = {
+      verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+    };
+
+    expect(formatUsage(usage, auxiliaryUsage)).toBe('3.0k in / 680 out · $26.19 (+verification: $6.19)');
+    expect(formatUsagePlain(usage, auxiliaryUsage)).toBe('3.0k input, 680 output, $26.19 (+verification: $6.19)');
   });
 });
 

--- a/src/cli/output/formatters.ts
+++ b/src/cli/output/formatters.ts
@@ -257,6 +257,15 @@ export function formatCost(costUSD: number): string {
 }
 
 /**
+ * Calculate total cost across primary and auxiliary usage.
+ */
+export function totalUsageCost(usage?: UsageStats, auxiliaryUsage?: AuxiliaryUsageMap): number | undefined {
+  const hasAuxiliaryUsage = auxiliaryUsage !== undefined && Object.keys(auxiliaryUsage).length > 0;
+  if (!usage && !hasAuxiliaryUsage) return undefined;
+  return (usage?.costUSD ?? 0) + (auxiliaryUsage ? totalAuxiliaryCost(auxiliaryUsage) : 0);
+}
+
+/**
  * Format token counts for display.
  */
 export function formatTokens(tokens: number): string {
@@ -272,21 +281,23 @@ export function formatTokens(tokens: number): string {
 /**
  * Format usage stats for terminal display.
  */
-export function formatUsage(usage: UsageStats): string {
+export function formatUsage(usage: UsageStats, auxiliaryUsage?: AuxiliaryUsageMap): string {
   const inputStr = formatTokens(usage.inputTokens);
   const outputStr = formatTokens(usage.outputTokens);
-  const costStr = formatCost(usage.costUSD);
-  return `${inputStr} in / ${outputStr} out · ${costStr}`;
+  const costStr = formatCost(totalUsageCost(usage, auxiliaryUsage) ?? 0);
+  const auxSuffix = auxiliaryUsage ? formatAuxiliarySuffix(auxiliaryUsage) : '';
+  return `${inputStr} in / ${outputStr} out · ${costStr}${auxSuffix}`;
 }
 
 /**
  * Format usage stats for plain text display.
  */
-export function formatUsagePlain(usage: UsageStats): string {
+export function formatUsagePlain(usage: UsageStats, auxiliaryUsage?: AuxiliaryUsageMap): string {
   const inputStr = formatTokens(usage.inputTokens);
   const outputStr = formatTokens(usage.outputTokens);
-  const costStr = formatCost(usage.costUSD);
-  return `${inputStr} input, ${outputStr} output, ${costStr}`;
+  const costStr = formatCost(totalUsageCost(usage, auxiliaryUsage) ?? 0);
+  const auxSuffix = auxiliaryUsage ? formatAuxiliarySuffix(auxiliaryUsage) : '';
+  return `${inputStr} input, ${outputStr} output, ${costStr}${auxSuffix}`;
 }
 
 /**
@@ -330,9 +341,7 @@ export function formatStatsCompact(durationMs?: number, usage?: UsageStats, auxi
   if (usage) {
     parts.push(`${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out`);
 
-    const auxCost = auxiliaryUsage ? totalAuxiliaryCost(auxiliaryUsage) : 0;
-    const totalCost = usage.costUSD + auxCost;
-    const costStr = formatCost(totalCost);
+    const costStr = formatCost(totalUsageCost(usage, auxiliaryUsage) ?? 0);
     const auxSuffix = auxiliaryUsage ? formatAuxiliarySuffix(auxiliaryUsage) : '';
     parts.push(`${costStr}${auxSuffix}`);
   }

--- a/src/cli/output/index.ts
+++ b/src/cli/output/index.ts
@@ -21,6 +21,7 @@ export {
   countBySeverity,
   formatCost,
   formatTokens,
+  totalUsageCost,
   formatUsage,
   formatUsagePlain,
 } from './formatters.js';

--- a/src/cli/output/ink-runner.test.tsx
+++ b/src/cli/output/ink-runner.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Verbosity } from './verbosity.js';
-import { runSkillTasksWithInk } from './ink-runner.js';
+import { getSkillCostUSD, runSkillTasksWithInk } from './ink-runner.js';
 
 const { mockRender, mockRunComposedSkillTasks } = vi.hoisted(() => ({
   mockRender: vi.fn(() => ({
@@ -64,5 +64,75 @@ describe('runSkillTasksWithInk', () => {
     expect(output).toContain('SKILLS');
     expect(output.match(/SKILLS/g)).toHaveLength(1);
     expect(output.indexOf('SKILLS')).toBeLessThan(output.indexOf('security/authz'));
+  });
+
+  it('adds auxiliary usage to rendered skill cost', () => {
+    expect(getSkillCostUSD({
+      name: 'find-warden-bugs',
+      displayName: 'find-warden-bugs',
+      status: 'running',
+      findings: [],
+      files: [{
+        filename: 'src/app.ts',
+        status: 'done',
+        currentHunk: 1,
+        totalHunks: 1,
+        findings: [],
+        usage: { inputTokens: 10, outputTokens: 1, costUSD: 20 },
+      }],
+      auxiliaryUsage: {
+        verification: { inputTokens: 5, outputTokens: 1, costUSD: 6.19 },
+      },
+    })).toBeCloseTo(26.19);
+  });
+
+  it('prints completed skill cost with auxiliary usage included', async () => {
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const usage = { inputTokens: 10, outputTokens: 1, costUSD: 20 };
+    const auxiliaryUsage = {
+      verification: { inputTokens: 5, outputTokens: 1, costUSD: 6.19 },
+    };
+
+    mockRunComposedSkillTasks.mockImplementationOnce(async (_tasks, callbacks) => {
+      callbacks.onSkillStart({
+        name: 'find-warden-bugs',
+        displayName: 'find-warden-bugs',
+        status: 'running',
+        files: [],
+        findings: [],
+      });
+      callbacks.onSkillUpdate('find-warden-bugs', {
+        status: 'done',
+        durationMs: 1_200,
+        findings: [],
+        usage,
+        auxiliaryUsage,
+      });
+      callbacks.onSkillComplete('find-warden-bugs', {
+        skill: 'find-warden-bugs',
+        summary: 'find-warden-bugs: No issues found',
+        findings: [],
+        usage,
+        auxiliaryUsage,
+        durationMs: 1_200,
+      });
+      return [];
+    });
+
+    await runSkillTasksWithInk(
+      [{
+        name: 'find-warden-bugs',
+        displayName: 'find-warden-bugs',
+      } as never],
+      {
+        mode: { isTTY: true, supportsColor: false, columns: 80 },
+        verbosity: Verbosity.Normal,
+        concurrency: 2,
+      },
+    );
+
+    const output = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('find-warden-bugs');
+    expect(output).toContain('$26.19');
   });
 });

--- a/src/cli/output/ink-runner.test.tsx
+++ b/src/cli/output/ink-runner.test.tsx
@@ -216,4 +216,41 @@ describe('runSkillTasksWithInk', () => {
 
     expect(controller.signal.aborted).toBe(false);
   });
+
+  it('does not trigger fail-fast from file findings in quiet mode', async () => {
+    const controller = new AbortController();
+
+    mockRunComposedSkillTasks.mockImplementationOnce(async (_tasks, callbacks) => {
+      callbacks.onFileUpdate('find-warden-bugs', 'src/app.ts', {
+        status: 'done',
+        findings: [{
+          id: 'candidate',
+          severity: 'high',
+          title: 'Rejected candidate',
+          description: 'Rejected during verification',
+        }],
+      });
+      callbacks.onSkillComplete('find-warden-bugs', {
+        skill: 'find-warden-bugs',
+        summary: 'find-warden-bugs: No issues found',
+        findings: [],
+      });
+      return [];
+    });
+
+    await runSkillTasksWithInk(
+      [{
+        name: 'find-warden-bugs',
+        displayName: 'find-warden-bugs',
+      } as never],
+      {
+        mode: { isTTY: true, supportsColor: false, columns: 80 },
+        verbosity: Verbosity.Quiet,
+        concurrency: 2,
+        failFastController: controller,
+      },
+    );
+
+    expect(controller.signal.aborted).toBe(false);
+  });
 });

--- a/src/cli/output/ink-runner.test.tsx
+++ b/src/cli/output/ink-runner.test.tsx
@@ -135,4 +135,85 @@ describe('runSkillTasksWithInk', () => {
     expect(output).toContain('find-warden-bugs');
     expect(output).toContain('$26.19');
   });
+
+  it('preserves skipped status when skipped skills emit completion', async () => {
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    mockRunComposedSkillTasks.mockImplementationOnce(async (_tasks, callbacks) => {
+      callbacks.onSkillSkipped('empty-skill');
+      callbacks.onSkillComplete('empty-skill', {
+        skill: 'empty-skill',
+        summary: 'No code changes to analyze',
+        findings: [],
+        durationMs: 100,
+      });
+      return [];
+    });
+
+    await runSkillTasksWithInk(
+      [{
+        name: 'empty-skill',
+        displayName: 'empty-skill',
+      } as never],
+      {
+        mode: { isTTY: true, supportsColor: false, columns: 80 },
+        verbosity: Verbosity.Normal,
+        concurrency: 2,
+      },
+    );
+
+    const output = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('empty-skill');
+    expect(output).toContain('[skipped]');
+  });
+
+  it('does not trigger fail-fast from file findings before completion', async () => {
+    const controller = new AbortController();
+
+    mockRunComposedSkillTasks.mockImplementationOnce(async (_tasks, callbacks) => {
+      callbacks.onSkillStart({
+        name: 'find-warden-bugs',
+        displayName: 'find-warden-bugs',
+        status: 'running',
+        files: [{
+          filename: 'src/app.ts',
+          status: 'running',
+          currentHunk: 1,
+          totalHunks: 1,
+          findings: [],
+        }],
+        findings: [],
+      });
+      callbacks.onFileUpdate('find-warden-bugs', 'src/app.ts', {
+        status: 'done',
+        findings: [{
+          id: 'candidate',
+          severity: 'high',
+          title: 'Rejected candidate',
+          description: 'Rejected during verification',
+        }],
+      });
+      callbacks.onSkillComplete('find-warden-bugs', {
+        skill: 'find-warden-bugs',
+        summary: 'find-warden-bugs: No issues found',
+        findings: [],
+      });
+      return [];
+    });
+
+    await runSkillTasksWithInk(
+      [{
+        name: 'find-warden-bugs',
+        displayName: 'find-warden-bugs',
+      } as never],
+      {
+        mode: { isTTY: true, supportsColor: false, columns: 80 },
+        verbosity: Verbosity.Normal,
+        concurrency: 2,
+        failFastController: controller,
+      },
+    );
+
+    expect(controller.signal.aborted).toBe(false);
+  });
 });

--- a/src/cli/output/ink-runner.tsx
+++ b/src/cli/output/ink-runner.tsx
@@ -25,7 +25,7 @@ import {
   type SkillState,
   type FileState,
 } from './tasks.js';
-import { formatDuration, formatCost, truncate, countBySeverity, formatSeverityDot, pluralize } from './formatters.js';
+import { formatDuration, formatCost, truncate, countBySeverity, formatSeverityDot, pluralize, totalAuxiliaryCost } from './formatters.js';
 import { Semaphore } from '../../utils/index.js';
 import { Verbosity } from './verbosity.js';
 import { ICON_CHECK, ICON_SKIPPED, ICON_PENDING, ICON_ERROR, SPINNER_FRAMES } from './icons.js';
@@ -62,12 +62,25 @@ function FileProgress({ file }: { file: FileState }): React.ReactElement {
   );
 }
 
+export function getSkillCostUSD(skill: SkillState): number | undefined {
+  const hasFileUsage = skill.files.some((file) => file.usage !== undefined);
+  const primaryCost = skill.usage?.costUSD
+    ?? (hasFileUsage ? skill.files.reduce((sum, file) => sum + (file.usage?.costUSD ?? 0), 0) : undefined);
+  const auxiliaryCost = skill.auxiliaryUsage ? totalAuxiliaryCost(skill.auxiliaryUsage) : 0;
+
+  if (primaryCost === undefined && auxiliaryCost === 0) {
+    return undefined;
+  }
+
+  return (primaryCost ?? 0) + auxiliaryCost;
+}
+
 function RunningSkill({ skill }: { skill: SkillState }): React.ReactElement {
   const activeFiles = skill.files.filter((f) => f.status === 'running');
   const doneCount = skill.files.filter((f) => f.status === 'done' || f.status === 'skipped').length;
   const totalCount = skill.files.length;
   const findingCount = skill.files.reduce((sum, f) => sum + f.findings.length, 0);
-  const cost = skill.files.reduce((sum, f) => sum + (f.usage?.costUSD ?? 0), 0);
+  const cost = getSkillCostUSD(skill);
 
   return (
     <Box flexDirection="column">
@@ -76,7 +89,7 @@ function RunningSkill({ skill }: { skill: SkillState }): React.ReactElement {
         <Text> {skill.displayName}</Text>
         {totalCount > 0 && <Text dimColor>  [{doneCount}/{totalCount} files]</Text>}
         {findingCount > 0 && <Text>  {findingCount} {findingCount === 1 ? 'finding' : 'findings'}</Text>}
-        {cost > 0 && <Text dimColor>  {formatCost(cost)}</Text>}
+        {cost !== undefined && cost > 0 && <Text dimColor>  {formatCost(cost)}</Text>}
       </Box>
       {activeFiles.map((file) => (
         <Box key={file.filename} marginLeft={2}>
@@ -97,7 +110,7 @@ function CompletedSkill({ skill }: { skill: SkillState }): React.ReactElement {
   }
 
   const findingCount = skill.findings.length;
-  const cost = skill.usage?.costUSD;
+  const cost = getSkillCostUSD(skill);
   const duration = skill.durationMs ? formatDuration(skill.durationMs) : undefined;
 
   if (skill.status === 'error') {
@@ -212,9 +225,11 @@ function printFileSummary(file: FileState): void {
 function printSkillSummary(skillStates: SkillState[]): void {
   for (const skill of skillStates) {
     const duration = skill.durationMs ? chalk.dim(` [${formatDuration(skill.durationMs)}]`) : '';
+    const cost = getSkillCostUSD(skill);
+    const costText = cost !== undefined && cost > 0 ? chalk.dim(`  ${formatCost(cost)}`) : '';
 
     if (skill.status === 'done') {
-      process.stderr.write(`${chalk.green(ICON_CHECK)} ${skill.displayName}${duration}\n`);
+      process.stderr.write(`${chalk.green(ICON_CHECK)} ${skill.displayName}${duration}${costText}\n`);
     } else if (skill.status === 'skipped') {
       process.stderr.write(`${chalk.yellow(ICON_SKIPPED)} ${skill.displayName} ${chalk.dim('[skipped]')}\n`);
     } else if (skill.status === 'error') {
@@ -369,8 +384,20 @@ export async function runSkillTasksWithInk(
         }
       }
     },
-    onSkillComplete: (_name, report) => {
+    onSkillComplete: (name, report) => {
       fireStreamHook?.(report);
+      const idx = skillStates.findIndex((s) => s.name === name);
+      const existing = skillStates[idx];
+      if (idx >= 0 && existing) {
+        skillStates[idx] = {
+          ...existing,
+          status: existing.status === 'error' ? 'error' : 'done',
+          durationMs: report.durationMs,
+          findings: report.findings,
+          usage: report.usage,
+          auxiliaryUsage: report.auxiliaryUsage,
+        };
+      }
       updateUI();
     },
     onChunkComplete: (name, chunk) => {

--- a/src/cli/output/ink-runner.tsx
+++ b/src/cli/output/ink-runner.tsx
@@ -272,20 +272,14 @@ export async function runSkillTasksWithInk(
     const composedTasks = composeTasksWithFailFast(tasks, failFastController);
     const callbacks: SkillProgressCallbacks = {
       ...noopCallbacks,
-      ...(failFastController
-        ? {
-            onFileUpdate: (_skillName: string, _filename: string, updates: Partial<FileState>) => {
-              if (updates.status === 'done' && updates.findings && updates.findings.length > 0) {
-                failFastController.abort();
-              }
-            },
-          }
-        : {}),
-      ...(fireStreamHook
+      ...(fireStreamHook || failFastController
         ? {
             onSkillComplete: (name: string, report) => {
               noopCallbacks.onSkillComplete(name, report);
-              fireStreamHook(report);
+              fireStreamHook?.(report);
+              if (failFastController && report.findings.length > 0) {
+                failFastController.abort();
+              }
             },
           }
         : {}),

--- a/src/cli/output/ink-runner.tsx
+++ b/src/cli/output/ink-runner.tsx
@@ -377,10 +377,6 @@ export async function runSkillTasksWithInk(
         if (file) {
           Object.assign(file, updates);
           updateUI();
-          // Fail-fast: abort when a file completes with findings
-          if (failFastController && updates.status === 'done' && updates.findings && updates.findings.length > 0) {
-            failFastController.abort();
-          }
         }
       }
     },
@@ -391,12 +387,15 @@ export async function runSkillTasksWithInk(
       if (idx >= 0 && existing) {
         skillStates[idx] = {
           ...existing,
-          status: existing.status === 'error' ? 'error' : 'done',
+          status: existing.status === 'error' || existing.status === 'skipped' ? existing.status : 'done',
           durationMs: report.durationMs,
           findings: report.findings,
           usage: report.usage,
           auxiliaryUsage: report.auxiliaryUsage,
         };
+      }
+      if (failFastController && report.findings.length > 0) {
+        failFastController.abort();
       }
       updateUI();
     },

--- a/src/cli/output/reporter.test.ts
+++ b/src/cli/output/reporter.test.ts
@@ -155,6 +155,22 @@ describe('Reporter', () => {
       expect(output).toContain('Total time: 5.0s');
     });
 
+    it('shows total usage cost in log mode', () => {
+      const reporter = new Reporter(logMode(), Verbosity.Normal);
+      reporter.renderSummary([
+        makeReport({
+          usage: { inputTokens: 3000, outputTokens: 680, costUSD: 20 },
+          auxiliaryUsage: {
+            verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+          },
+        }),
+      ], 5000);
+
+      const output = errorSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+      expect(output).toContain('$26.19');
+      expect(output).toContain('+verification: $6.19');
+    });
+
     it('outputs only finding counts in Quiet mode', () => {
       const reporter = new Reporter(logMode(), Verbosity.Quiet);
       reporter.renderSummary([makeReport({ findings: [makeFinding()] })], 1000);

--- a/src/cli/output/reporter.ts
+++ b/src/cli/output/reporter.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import figures from 'figures';
-import type { SkillReport, Finding, FileChange, UsageStats } from '../../types/index.js';
+import type { SkillReport, Finding, FileChange, UsageStats, AuxiliaryUsageMap } from '../../types/index.js';
 import { Verbosity } from './verbosity.js';
 import { type OutputMode, timestamp } from './tty.js';
 import {
@@ -15,6 +15,7 @@ import {
 import { BoxRenderer } from './box.js';
 import { ICON_CHECK } from './icons.js';
 import { getVersion } from '../../utils/index.js';
+import { mergeAuxiliaryUsage } from '../../sdk/usage.js';
 
 /**
  * Map a file change status to its single-character symbol.
@@ -186,6 +187,19 @@ export class Reporter {
   }
 
   /**
+   * Aggregate auxiliary usage stats from multiple reports.
+   */
+  private aggregateAuxiliaryUsage(reports: SkillReport[]): AuxiliaryUsageMap | undefined {
+    let totalAuxiliaryUsage: AuxiliaryUsageMap | undefined;
+    for (const report of reports) {
+      if (report.auxiliaryUsage) {
+        totalAuxiliaryUsage = mergeAuxiliaryUsage(totalAuxiliaryUsage, report.auxiliaryUsage);
+      }
+    }
+    return totalAuxiliaryUsage;
+  }
+
+  /**
    * Render the summary section.
    */
   renderSummary(reports: SkillReport[], totalDuration: number, options?: { traceId?: string }): void {
@@ -201,6 +215,7 @@ export class Reporter {
     }
     const counts = countBySeverity(allFindings);
     const totalUsage = this.aggregateUsage(reports);
+    const totalAuxiliaryUsage = this.aggregateAuxiliaryUsage(reports);
 
     if (this.verbosity === Verbosity.Quiet) {
       // Quiet mode: just output the summary line
@@ -226,7 +241,7 @@ export class Reporter {
       }
       const durationLine = `Analysis completed in ${formatDuration(totalDuration)}`;
       if (totalUsage) {
-        this.log(chalk.dim(`${durationLine} · ${formatUsage(totalUsage)}`));
+        this.log(chalk.dim(`${durationLine} · ${formatUsage(totalUsage, totalAuxiliaryUsage)}`));
       } else {
         this.log(chalk.dim(durationLine));
       }
@@ -248,7 +263,7 @@ export class Reporter {
         this.logPlain(`${totalSkippedFiles} ${pluralize(totalSkippedFiles, 'file')} skipped`);
       }
       if (totalUsage) {
-        this.logPlain(`Usage: ${formatUsagePlain(totalUsage)}`);
+        this.logPlain(`Usage: ${formatUsagePlain(totalUsage, totalAuxiliaryUsage)}`);
       }
       this.logPlain(`Total time: ${formatDuration(totalDuration)}`);
       if (options?.traceId && this.verbosity >= Verbosity.Verbose) {

--- a/src/cli/output/tasks.test.ts
+++ b/src/cli/output/tasks.test.ts
@@ -10,7 +10,6 @@ import type { SkillDefinition } from '../../config/schema.js';
 import { Semaphore, runPool } from '../../utils/index.js';
 import { SkillRunnerError, WardenAuthenticationError } from '../../sdk/errors.js';
 import * as sdkRunner from '../../sdk/runner.js';
-import * as fixQuality from '../../sdk/fix-quality.js';
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
@@ -486,6 +485,42 @@ describe('createDefaultCallbacks', () => {
       const cb = createDefaultCallbacks(tasks, logMode(), Verbosity.Normal);
       expect(cb.onExtractionResult).toBeUndefined();
     });
+
+    it('onFindingProcessing is defined at Debug verbosity', () => {
+      const tasks = [makeTask('t', 's')];
+      const cb = createDefaultCallbacks(tasks, logMode(), Verbosity.Debug);
+      expect(cb.onFindingProcessing).toBeDefined();
+    });
+
+    it('onFindingProcessing is undefined below Debug verbosity', () => {
+      const tasks = [makeTask('t', 's')];
+      const cb = createDefaultCallbacks(tasks, logMode(), Verbosity.Normal);
+      expect(cb.onFindingProcessing).toBeUndefined();
+    });
+
+    it('logs finding processing events in debug mode', () => {
+      const tasks = [makeTask('t', 's')];
+      const cb = createDefaultCallbacks(tasks, logMode(), Verbosity.Debug);
+
+      cb.onFindingProcessing!('t', {
+        stage: 'verification',
+        action: 'rejected',
+        finding: {
+          id: 'f1',
+          severity: 'high',
+          title: 'Candidate',
+          description: 'desc',
+          location: { path: 'src/app.ts', startLine: 10 },
+        },
+        reason: 'guarded upstream',
+      });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const msg = errorSpy.mock.calls[0]![0] as string;
+      expect(msg).toContain('DEBUG: verification:rejected');
+      expect(msg).toContain('src/app.ts:10');
+      expect(msg).toContain('guarded upstream');
+    });
   });
 
   describe('onHunkFailed', () => {
@@ -893,7 +928,7 @@ describe('runSkillTask model lanes', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses synthesisModel for consolidation and auxiliaryModel for auxiliary gates', async () => {
+  it('passes model lanes to shared finding post-processing', async () => {
     const fakeHunk = {
       hunk: { newStart: 1, newCount: 10 },
     } as unknown as HunkWithContext;
@@ -911,18 +946,9 @@ describe('runSkillTask model lanes', () => {
       failedExtractions: 0,
       hunkFailures: [],
     } satisfies FileAnalysisResult);
-    const mergeSpy = vi.spyOn(sdkRunner, 'mergeCrossLocationFindings').mockResolvedValue({
+    const postProcessSpy = vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
       findings: [finding],
-      mergedCount: 0,
-    });
-    const sanitizeSpy = vi.spyOn(fixQuality, 'sanitizeFindingsSuggestedFixes').mockResolvedValue({
-      findings: [finding],
-      stats: {
-        checked: 0,
-        strippedDeterministic: 0,
-        strippedSemantic: 0,
-        semanticUnavailable: 0,
-      },
+      auxiliaryUsage: [],
     });
 
     const result = await runSkillTask({
@@ -942,13 +968,12 @@ describe('runSkillTask model lanes', () => {
     }, 1, noopCallbacks());
 
     expect(result.report?.error).toBeUndefined();
-    expect(mergeSpy).toHaveBeenCalledWith(
+    expect(postProcessSpy).toHaveBeenCalledWith(
       expect.any(Array),
-      expect.objectContaining({ model: 'claude-opus-4-5' })
-    );
-    expect(sanitizeSpy).toHaveBeenCalledWith(
-      expect.any(Array),
-      expect.objectContaining({ model: 'claude-haiku-4-5' })
+      expect.objectContaining({
+        auxiliaryModel: 'claude-haiku-4-5',
+        synthesisModel: 'claude-opus-4-5',
+      })
     );
   });
 });

--- a/src/cli/output/tasks.test.ts
+++ b/src/cli/output/tasks.test.ts
@@ -57,7 +57,7 @@ describe('createDefaultCallbacks', () => {
   });
 
   afterEach(() => {
-    errorSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   describe('onSkillStart', () => {
@@ -683,6 +683,104 @@ describe('runSkillTasks', () => {
 
     expect(results).toHaveLength(0);
     expect(resolveSkill).not.toHaveBeenCalled();
+  });
+
+  it('does not fail-fast on findings rejected by post-processing', async () => {
+    const candidate = makeFinding();
+    const controller = new AbortController();
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+
+    const prepareFiles = vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    const analyzeFile = vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [candidate],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+    } satisfies FileAnalysisResult);
+    const postProcessFindings = vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
+      findings: [],
+      auxiliaryUsage: [],
+    });
+
+    const results = await runSkillTasks([{
+      name: 'verify-skill',
+      resolveSkill: async () =>
+        ({ name: 'verify-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+    }], {
+      mode: logMode(),
+      verbosity: Verbosity.Quiet,
+      concurrency: 1,
+      failFastController: controller,
+    });
+
+    expect(results[0]?.report?.findings).toEqual([]);
+    expect(controller.signal.aborted).toBe(false);
+    expect(postProcessFindings).toHaveBeenCalled();
+
+    prepareFiles.mockRestore();
+    analyzeFile.mockRestore();
+    postProcessFindings.mockRestore();
+  });
+
+  it('fail-fast aborts after final findings are post-processed', async () => {
+    const finalFinding = makeFinding();
+    const controller = new AbortController();
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+
+    const prepareFiles = vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    const analyzeFile = vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finalFinding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+    } satisfies FileAnalysisResult);
+    const postProcessFindings = vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
+      findings: [finalFinding],
+      auxiliaryUsage: [],
+    });
+
+    await runSkillTasks([{
+      name: 'verify-skill',
+      resolveSkill: async () =>
+        ({ name: 'verify-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+    }], {
+      mode: logMode(),
+      verbosity: Verbosity.Quiet,
+      concurrency: 1,
+      failFastController: controller,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+
+    prepareFiles.mockRestore();
+    analyzeFile.mockRestore();
+    postProcessFindings.mockRestore();
   });
 });
 

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -5,7 +5,7 @@
  * Reporter spec: specs/reporters.md
  */
 
-import type { SkillReport, SeverityThreshold, ConfidenceThreshold, Finding, UsageStats, EventContext, HunkFailure } from '../../types/index.js';
+import type { SkillReport, SeverityThreshold, ConfidenceThreshold, Finding, UsageStats, EventContext, HunkFailure, AuxiliaryUsageMap } from '../../types/index.js';
 import type { SkillDefinition } from '../../config/schema.js';
 import { Sentry, emitSkillMetrics, logger } from '../../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, classifyError } from '../../sdk/errors.js';
@@ -109,6 +109,7 @@ export interface SkillState {
   files: FileState[];
   findings: Finding[];
   usage?: UsageStats;
+  auxiliaryUsage?: AuxiliaryUsageMap;
   error?: string;
 }
 
@@ -508,6 +509,8 @@ export async function runSkillTask(
             status: 'error',
             durationMs: duration,
             findings: [],
+            usage: errorReport.usage,
+            auxiliaryUsage: errorReport.auxiliaryUsage,
           });
           callbacks.onSkillComplete(name, errorReport);
           // Carry a typed error alongside the report so consumers that re-throw
@@ -583,6 +586,7 @@ export async function runSkillTask(
           durationMs: duration,
           findings: finalFindings,
           usage: report.usage,
+          auxiliaryUsage: report.auxiliaryUsage,
         });
         callbacks.onSkillComplete(name, report);
 

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -7,15 +7,14 @@
 
 import type { SkillReport, SeverityThreshold, ConfidenceThreshold, Finding, UsageStats, EventContext, HunkFailure } from '../../types/index.js';
 import type { SkillDefinition } from '../../config/schema.js';
-import { Sentry, emitSkillMetrics, emitDedupMetrics, emitFixGateMetrics, logger } from '../../sentry.js';
+import { Sentry, emitSkillMetrics, logger } from '../../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, classifyError } from '../../sdk/errors.js';
 import {
   prepareFiles,
   analyzeFile,
   aggregateUsage,
   aggregateAuxiliaryUsage,
-  deduplicateFindings,
-  mergeCrossLocationFindings,
+  postProcessFindings,
   generateSummary,
   type AuxiliaryUsageEntry,
   type SkillRunnerOptions,
@@ -23,8 +22,8 @@ import {
   type PreparedFile,
   type PRPromptContext,
   type ChunkAnalysisResult,
+  type FindingProcessingEvent,
 } from '../../sdk/runner.js';
-import { sanitizeFindingsSuggestedFixes } from '../../sdk/fix-quality.js';
 import chalk from 'chalk';
 import figures from 'figures';
 import { Verbosity } from './verbosity.js';
@@ -73,6 +72,16 @@ function debugLog(mode: OutputMode, message: string): void {
 function findingLocation(finding: Finding): string {
   if (!finding.location) return 'unknown';
   return formatLocation(finding.location.path, finding.location.startLine, finding.location.endLine);
+}
+
+function findingSummary(finding: Finding): string {
+  return `${findingLocation(finding)}: ${finding.title}`;
+}
+
+function formatFindingProcessingEvent(event: FindingProcessingEvent): string {
+  const reason = event.reason ? ` (${event.reason})` : '';
+  const replacement = event.replacement ? ` -> ${findingSummary(event.replacement)}` : '';
+  return `${event.stage}:${event.action} ${findingSummary(event.finding)}${replacement}${reason}`;
 }
 
 /**
@@ -164,6 +173,8 @@ export interface SkillProgressCallbacks {
   onPromptSize?: (skillName: string, filename: string, lineRange: string, systemChars: number, userChars: number, totalChars: number, estimatedTokens: number) => void;
   /** Called with extraction result details (debug mode) */
   onExtractionResult?: (skillName: string, filename: string, lineRange: string, findingsCount: number, method: 'regex' | 'llm' | 'none') => void;
+  /** Called when findings are dropped, revised, merged, or stripped after analysis */
+  onFindingProcessing?: (skillName: string, event: FindingProcessingEvent) => void;
   /** Called when hunk analysis fails (SDK error, API error, abort) */
   onHunkFailed?: (skillName: string, filename: string, lineRange: string, error: string) => void;
   /** Called when findings extraction fails (both regex and LLM fallback failed) */
@@ -505,52 +516,30 @@ export async function runSkillTask(
           return { name, report: errorReport, error: runnerError, failOn, minConfidence };
         }
 
-        const uniqueFindings = deduplicateFindings(allFindings);
-        emitDedupMetrics(skill.name, allFindings.length, uniqueFindings.length);
-
-        // Merge findings that describe the same issue at different locations
-        const mergeResult = await mergeCrossLocationFindings(uniqueFindings, {
-          apiKey: runnerOptions.apiKey,
-          repoPath: context.repoPath,
-          runtime: runnerOptions.runtime,
-          model: runnerOptions.synthesisModel,
-          maxRetries: runnerOptions.auxiliaryMaxRetries,
-        });
-        let mergedFindings = mergeResult.findings;
-        if (mergeResult.usage) {
-          allAuxEntries.push({ agent: 'merge', usage: mergeResult.usage });
-        }
-        const sanitized = await sanitizeFindingsSuggestedFixes(mergedFindings, {
+        const processed = await postProcessFindings(allFindings, {
+          skill,
           repoPath: context.repoPath,
           apiKey: runnerOptions.apiKey,
           runtime: runnerOptions.runtime,
-          model: runnerOptions.auxiliaryModel,
-          maxRetries: runnerOptions.auxiliaryMaxRetries,
+          auxiliaryModel: runnerOptions.auxiliaryModel,
+          synthesisModel: runnerOptions.synthesisModel,
+          auxiliaryMaxRetries: runnerOptions.auxiliaryMaxRetries,
+          verifyFindings: runnerOptions.verifyFindings,
+          maxTurns: runnerOptions.maxTurns,
+          abortController: runnerOptions.abortController,
+          pathToClaudeCodeExecutable: runnerOptions.pathToClaudeCodeExecutable,
+          prContext,
+          onFindingProcessing: (event) => {
+            callbacks.onFindingProcessing?.(name, event);
+          },
         });
-        mergedFindings = sanitized.findings;
-        if (sanitized.usage) {
-          allAuxEntries.push({ agent: 'fix_gate', usage: sanitized.usage });
-        }
-        emitFixGateMetrics(
-          skill.name,
-          sanitized.stats.checked,
-          sanitized.stats.strippedDeterministic,
-          sanitized.stats.strippedSemantic,
-          sanitized.stats.semanticUnavailable
-        );
-        if (sanitized.stats.checked > 0) {
-          logger.info('Suggested fix quality gate', {
-            'fix_gate.checked': sanitized.stats.checked,
-            'fix_gate.stripped_deterministic': sanitized.stats.strippedDeterministic,
-            'fix_gate.stripped_semantic': sanitized.stats.strippedSemantic,
-            'fix_gate.semantic_unavailable': sanitized.stats.semanticUnavailable,
-          });
-        }
+        const finalFindings = processed.findings;
+        allAuxEntries.push(...processed.auxiliaryUsage);
 
         const report: SkillReport = {
           skill: skill.name,
-          summary: generateSummary(skill.name, mergedFindings),
-          findings: mergedFindings,
+          summary: generateSummary(skill.name, finalFindings),
+          findings: finalFindings,
           usage: aggregateUsage(allUsage),
           durationMs: duration,
           model: runnerOptions?.model,
@@ -592,7 +581,7 @@ export async function runSkillTask(
         callbacks.onSkillUpdate(name, {
           status: 'done',
           durationMs: duration,
-          findings: mergedFindings,
+          findings: finalFindings,
           usage: report.usage,
         });
         callbacks.onSkillComplete(name, report);
@@ -778,6 +767,11 @@ export function createDefaultCallbacks(
     onExtractionResult: verbosity >= Verbosity.Debug
       ? (_skillName, filename, lineRange, findingsCount, method) => {
           debugLog(mode, `Extracted ${findingsCount} ${pluralize(findingsCount, 'finding')} from ${filename}:${lineRange} via ${method}`);
+        }
+      : undefined,
+    onFindingProcessing: verbosity >= Verbosity.Debug
+      ? (_skillName, event) => {
+          debugLog(mode, formatFindingProcessingEvent(event));
         }
       : undefined,
     // Verbose mode: show per-hunk analysis failures (spec: event #16 hunk_failed)

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -894,21 +894,14 @@ export async function runSkillTasks(
 
   const wrappedCallbacks: SkillProgressCallbacks = {
     ...effectiveCallbacks,
-    ...(failFastController
-      ? {
-          onFileUpdate: (skillName: string, filename: string, updates: Partial<FileState>) => {
-            effectiveCallbacks.onFileUpdate(skillName, filename, updates);
-            if (updates.status === 'done' && updates.findings && updates.findings.length > 0) {
-              failFastController.abort();
-            }
-          },
-        }
-      : {}),
-    ...(onSkillComplete
+    ...(onSkillComplete || failFastController
       ? {
           onSkillComplete: (name: string, report: SkillReport) => {
             effectiveCallbacks.onSkillComplete(name, report);
-            try { onSkillComplete(report); } catch { /* streaming hook must not break the run */ }
+            try { onSkillComplete?.(report); } catch { /* streaming hook must not break the run */ }
+            if (failFastController && report.findings.length > 0) {
+              failFastController.abort();
+            }
           },
         }
       : {}),

--- a/src/cli/signals.test.ts
+++ b/src/cli/signals.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSigintHandler } from './signals.js';
+
+describe('createSigintHandler', () => {
+  it('aborts gracefully on the first SIGINT', () => {
+    const abortController = new AbortController();
+    const interrupted = { value: false };
+    const exit = vi.fn();
+
+    const handleSigint = createSigintHandler({
+      abortController,
+      interrupted,
+      exit,
+      now: () => 1_000,
+    });
+
+    handleSigint();
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(interrupted.value).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('ignores duplicate SIGINT delivery from the same interrupt', () => {
+    const abortController = new AbortController();
+    const interrupted = { value: false };
+    const exit = vi.fn();
+    let now = 1_000;
+
+    const handleSigint = createSigintHandler({
+      abortController,
+      interrupted,
+      exit,
+      now: () => now,
+      duplicateWindowMs: 750,
+    });
+
+    handleSigint();
+    now += 10;
+    handleSigint();
+
+    expect(interrupted.value).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('forces exit on a later second SIGINT', () => {
+    const abortController = new AbortController();
+    const interrupted = { value: false };
+    const exit = vi.fn();
+    let now = 1_000;
+
+    const handleSigint = createSigintHandler({
+      abortController,
+      interrupted,
+      exit,
+      now: () => now,
+      duplicateWindowMs: 750,
+    });
+
+    handleSigint();
+    now += 1_000;
+    handleSigint();
+
+    expect(exit).toHaveBeenCalledWith(130);
+  });
+});

--- a/src/cli/signals.ts
+++ b/src/cli/signals.ts
@@ -1,0 +1,38 @@
+const DEFAULT_DUPLICATE_SIGINT_WINDOW_MS = 750;
+
+interface SigintHandlerOptions {
+  abortController: AbortController;
+  interrupted: { value: boolean };
+  now?: () => number;
+  exit?: (code: number) => void;
+  duplicateWindowMs?: number;
+}
+
+/**
+ * Create the CLI SIGINT handler.
+ */
+export function createSigintHandler(options: SigintHandlerOptions): () => void {
+  const duplicateWindowMs = options.duplicateWindowMs ?? DEFAULT_DUPLICATE_SIGINT_WINDOW_MS;
+  const now = options.now ?? (() => Date.now());
+  const exit = options.exit ?? ((code) => process.exit(code));
+  let gracefulInterruptSeen = false;
+  let lastSigintAt = 0;
+
+  return () => {
+    const sigintAt = now();
+    if (gracefulInterruptSeen && sigintAt - lastSigintAt < duplicateWindowMs) {
+      return;
+    }
+
+    lastSigintAt = sigintAt;
+
+    if (gracefulInterruptSeen) {
+      exit(130);
+      return;
+    }
+
+    gracefulInterruptSeen = true;
+    options.abortController.abort();
+    options.interrupted.value = true;
+  };
+}

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -432,6 +432,21 @@ describe('resolveSkillConfigs', () => {
       expect(resolved?.auxiliaryMaxRetries).toBe(2);
     });
 
+    it('enables finding verification by default and allows disabling it', () => {
+      const [defaultResolved] = resolveSkillConfigs(baseConfig);
+      expect(defaultResolved?.verifyFindings).toBe(true);
+
+      const config: WardenConfig = {
+        ...baseConfig,
+        defaults: {
+          verification: { enabled: false },
+        },
+      };
+
+      const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.verifyFindings).toBe(false);
+    });
+
     it('falls back to auxiliary model when synthesis model is unset', () => {
       const config: WardenConfig = {
         ...baseConfig,
@@ -851,6 +866,20 @@ describe('maxTurns config', () => {
     expect(result.data?.defaults?.runtime).toBe('claude');
     expect(result.data?.defaults?.auxiliary?.model).toBe('claude-haiku-4-5');
     expect(result.data?.defaults?.synthesis?.model).toBe('claude-opus-4-5');
+  });
+
+  it('accepts verification defaults', () => {
+    const config = {
+      version: 1,
+      defaults: {
+        verification: { enabled: false },
+      },
+      skills: [],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.defaults?.verification?.enabled).toBe(false);
   });
 
   it('rejects unknown runtimes', () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -791,6 +791,37 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved[1]?.runtime).toBe('pi');
   });
 
+  it('lets repo-defined skills inherit base verification defaults when omitted', () => {
+    const baseConfig: WardenConfig = {
+      version: 1,
+      defaults: {
+        verification: { enabled: false },
+      },
+      skills: [{
+        name: 'org-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const repoConfig: WardenConfig = {
+      version: 1,
+      skills: [{
+        name: 'repo-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const resolved = resolveLayeredSkillConfigs({
+      config: { version: 1, skills: [] },
+      baseConfig,
+      repoConfig,
+    });
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]?.verifyFindings).toBe(false);
+    expect(resolved[1]?.verifyFindings).toBe(false);
+  });
+
   it('uses layer-specific skill roots when both layers define the same skill name', () => {
     const baseConfig: WardenConfig = {
       version: 1,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -795,7 +795,12 @@ describe('resolveLayeredSkillConfigs', () => {
     const baseConfig: WardenConfig = {
       version: 1,
       defaults: {
+        failOn: 'high',
+        model: 'base-model',
+        ignorePaths: ['base/**'],
+        runtime: 'claude',
         verification: { enabled: false },
+        chunking: { maxContextFiles: 25 },
       },
       skills: [{
         name: 'org-skill',
@@ -820,6 +825,11 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved).toHaveLength(2);
     expect(resolved[0]?.verifyFindings).toBe(false);
     expect(resolved[1]?.verifyFindings).toBe(false);
+    expect(resolved[1]?.runtime).toBe('claude');
+    expect(resolved[1]?.failOn).toBeUndefined();
+    expect(resolved[1]?.model).toBeUndefined();
+    expect(resolved[1]?.filters.ignorePaths).toBeUndefined();
+    expect(resolved[1]?.maxContextFiles).toBeUndefined();
   });
 
   it('uses layer-specific skill roots when both layers define the same skill name', () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -120,6 +120,7 @@ function mergeDefaults(base?: Defaults, overlay?: Defaults): Defaults | undefine
     agent: mergeNestedConfig(base.agent, overlay.agent),
     auxiliary: mergeNestedConfig(base.auxiliary, overlay.auxiliary),
     synthesis: mergeNestedConfig(base.synthesis, overlay.synthesis),
+    verification: mergeNestedConfig(base.verification, overlay.verification),
     ignorePaths: mergeArray(base.ignorePaths, overlay.ignorePaths),
     chunking: mergeChunkingConfig(base.chunking, overlay.chunking),
   };
@@ -298,6 +299,8 @@ export interface ResolvedTrigger {
   synthesisModel?: string;
   /** Max retries for auxiliary structured model calls. */
   auxiliaryMaxRetries?: number;
+  /** Whether candidate findings should be verified in a second pass. */
+  verifyFindings?: boolean;
   /** Minimum confidence for findings (merged: trigger > skill > defaults) */
   minConfidence?: ConfidenceThreshold;
   /** Batch delay to use for this trigger's skill execution */
@@ -347,6 +350,7 @@ export function resolveSkillConfigs(
   const auxiliaryMaxRetries =
     defaults?.auxiliary?.maxRetries ??
     defaults?.auxiliaryMaxRetries;
+  const verifyFindings = defaults?.verification?.enabled !== false;
 
   for (const skill of config.skills) {
     const baseModel =
@@ -389,6 +393,7 @@ export function resolveSkillConfigs(
         auxiliaryModel,
         synthesisModel,
         auxiliaryMaxRetries,
+        verifyFindings,
         minConfidence: skill.minConfidence ?? defaults?.minConfidence,
         batchDelayMs: defaults?.batchDelayMs,
         maxContextFiles: defaults?.chunking?.maxContextFiles,
@@ -416,6 +421,7 @@ export function resolveSkillConfigs(
           auxiliaryModel,
           synthesisModel,
           auxiliaryMaxRetries,
+          verifyFindings,
           minConfidence: trigger.minConfidence ?? skill.minConfidence ?? defaults?.minConfidence,
           batchDelayMs: defaults?.batchDelayMs,
           maxContextFiles: defaults?.chunking?.maxContextFiles,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -144,6 +144,21 @@ function mergeLogsConfig(
   return { ...base, ...overlay };
 }
 
+function inheritRepoLayerDefaults(base?: Defaults, repo?: Defaults): Defaults | undefined {
+  const inherited: Defaults = { ...(repo ?? {}) };
+
+  if (base?.runtime !== undefined && inherited.runtime === undefined) {
+    inherited.runtime = base.runtime;
+  }
+
+  const verification = mergeNestedConfig(base?.verification, repo?.verification);
+  if (verification) {
+    inherited.verification = verification;
+  }
+
+  return Object.keys(inherited).length > 0 ? inherited : undefined;
+}
+
 export function mergeWardenConfigs(base: WardenConfig, overlay: WardenConfig): WardenConfig {
   const mergedConfig = {
     version: 1 as const,
@@ -442,7 +457,7 @@ export function resolveLayeredSkillConfigs(
   if (layered.baseConfig && layered.repoConfig) {
     const repoConfigWithInheritedDefaults: WardenConfig = {
       ...layered.repoConfig,
-      defaults: mergeDefaults(layered.baseConfig.defaults, layered.repoConfig.defaults),
+      defaults: inheritRepoLayerDefaults(layered.baseConfig.defaults, layered.repoConfig.defaults),
     };
 
     return [

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -440,21 +440,14 @@ export function resolveLayeredSkillConfigs(
   skillRootsByName?: LayeredSkillRootsByName
 ): ResolvedTrigger[] {
   if (layered.baseConfig && layered.repoConfig) {
-    const repoConfigWithInheritedRuntime: WardenConfig =
-      layered.baseConfig.defaults?.runtime !== undefined &&
-      layered.repoConfig.defaults?.runtime === undefined
-        ? {
-            ...layered.repoConfig,
-            defaults: {
-              ...layered.repoConfig.defaults,
-              runtime: layered.baseConfig.defaults.runtime,
-            },
-          }
-        : layered.repoConfig;
+    const repoConfigWithInheritedDefaults: WardenConfig = {
+      ...layered.repoConfig,
+      defaults: mergeDefaults(layered.baseConfig.defaults, layered.repoConfig.defaults),
+    };
 
     return [
       ...resolveSkillConfigs(layered.baseConfig, cliModel, skillRootsByName?.base),
-      ...resolveSkillConfigs(repoConfigWithInheritedRuntime, cliModel, skillRootsByName?.repo),
+      ...resolveSkillConfigs(repoConfigWithInheritedDefaults, cliModel, skillRootsByName?.repo),
     ];
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -73,6 +73,12 @@ export const SynthesisRuntimeConfigSchema = z.object({
 }).strict();
 export type SynthesisRuntimeConfig = z.infer<typeof SynthesisRuntimeConfigSchema>;
 
+export const VerificationConfigSchema = z.object({
+  /** Verify candidate findings in a second read-only pass. Defaults to true. */
+  enabled: z.boolean().optional(),
+}).strict();
+export type VerificationConfig = z.infer<typeof VerificationConfigSchema>;
+
 // Skill trigger definition (nested under [[skills.triggers]])
 export const SkillTriggerSchema = z.object({
   /** Trigger type: pull_request (GitHub), local (CLI), or schedule (cron) */
@@ -201,6 +207,8 @@ export const DefaultsSchema = z.object({
   auxiliary: AuxiliaryRuntimeConfigSchema.optional(),
   /** Model defaults for post-analysis synthesis/consolidation. */
   synthesis: SynthesisRuntimeConfigSchema.optional(),
+  /** Candidate finding verification. Enabled by default; set enabled=false to opt out. */
+  verification: VerificationConfigSchema.optional(),
   /** Minimum confidence level for findings. Findings below this are filtered from output. Default: medium */
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Path patterns to exclude from all skills */

--- a/src/evals/runner.ts
+++ b/src/evals/runner.ts
@@ -8,6 +8,8 @@ import { runSkill } from '../sdk/runner.js';
 import { runJudge } from './judge.js';
 import { evalPassed } from './types.js';
 import type { EvalMeta, EvalResult } from './types.js';
+import type { Finding } from '../types/index.js';
+import type { FindingProcessingEvent } from '../sdk/runner.js';
 
 export interface RunEvalOptions {
   /** Anthropic API key */
@@ -73,6 +75,17 @@ function setupEvalRepo(meta: EvalMeta, log: (msg: string) => void): string {
   }
 }
 
+function formatFinding(finding: Finding): string {
+  const loc = finding.location ? `${finding.location.path}:${finding.location.startLine}` : 'general';
+  return `${loc} "${finding.title}"`;
+}
+
+function formatFindingProcessingEvent(event: FindingProcessingEvent): string {
+  const reason = event.reason ? ` (${event.reason})` : '';
+  const replacement = event.replacement ? ` -> ${formatFinding(event.replacement)}` : '';
+  return `Finding ${event.stage}:${event.action} ${formatFinding(event.finding)}${replacement}${reason}`;
+}
+
 /**
  * Run a single eval scenario end-to-end.
  *
@@ -130,6 +143,13 @@ export async function runEval(
       model,
       verbose: options.verbose,
       parallel: false,
+      callbacks: options.verbose
+        ? {
+            onFindingProcessing: (event) => {
+              log(formatFindingProcessingEvent(event));
+            },
+          }
+        : undefined,
     });
 
     log(`Skill complete: ${report.findings.length} finding(s)`);

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -6,6 +6,11 @@ import { findingLine } from '../types/index.js';
 import { getRuntime } from '../sdk/runtimes/index.js';
 import { applyMergeGroups } from '../sdk/extract.js';
 import type { AuxiliaryCallOptions } from '../sdk/extract.js';
+import {
+  buildJsonOutputSection,
+  formatIndexedFindingsForPrompt,
+  joinPromptSections,
+} from '../sdk/prompt-sections.js';
 
 /**
  * Parsed marker data from a Warden comment.
@@ -446,30 +451,27 @@ async function findSemanticDuplicates(
     .map((c, i) => `${i + 1}. [${c.path}:${c.line}] "${c.title}" - ${c.description}`)
     .join('\n');
 
-  const findingsList = findings
-    .map((f, i) => {
-      const line = f.location?.endLine ?? f.location?.startLine;
-      const loc = f.location ? `${f.location.path}:${line}` : 'general';
-      return `${i + 1}. [${loc}] "${f.title}" - ${f.description}`;
-    })
-    .join('\n');
+  const findingsList = formatIndexedFindingsForPrompt(findings);
 
-  const prompt = `Compare these code review findings and identify duplicates.
-
-Existing comments:
+  const prompt = joinPromptSections([
+    `<task>
+Compare these code review findings and identify duplicates.
+</task>`,
+    `<existing_comments>
 ${existingList}
-
-New findings:
+</existing_comments>`,
+    `<new_findings>
 ${findingsList}
-
+</new_findings>`,
+    `<deduplication_rules>
 Return a JSON array of objects identifying which findings are DUPLICATES of which existing comments.
 Only mark as duplicate if they describe the SAME issue at the SAME location (within a few lines).
 Different issues at the same location are NOT duplicates.
-
-Return ONLY the JSON array in this format:
-[{"findingIndex": 1, "existingIndex": 2}]
+</deduplication_rules>`,
+    buildJsonOutputSection(`[{"findingIndex": 1, "existingIndex": 2}]
 where findingIndex is the 1-based index of the new finding and existingIndex is the 1-based index of the matching existing comment.
-Return [] if none are duplicates.`;
+Return [] if none are duplicates.`),
+  ]);
 
   const result = await getRuntime(options.runtime).runAuxiliary({
     task: 'deduplication',
@@ -746,24 +748,24 @@ export async function consolidateBatchFindings(
   // Phase 3: LLM consolidation for proximity clusters
   // Only send clustered findings to the LLM (deduplicated across clusters)
   const clusteredList = [...new Set(clusters.flat())];
-  const findingsList = clusteredList
-    .map((f, i) => {
-      const line = findingLine(f);
-      const loc = f.location ? `${f.location.path}:${line}` : 'general';
-      return `${i + 1}. [${loc}] (${f.severity}) "${f.title}" - ${f.description}`;
-    })
-    .join('\n');
+  const findingsList = formatIndexedFindingsForPrompt(clusteredList, {
+    includeSeverity: true,
+  });
 
-  const prompt = `You are deduplicating code review findings. Group findings that describe the SAME root cause or bug.
-
-Findings:
+  const prompt = joinPromptSections([
+    `<task>
+Group findings that describe the SAME root cause or bug.
+</task>`,
+    `<findings>
 ${findingsList}
-
+</findings>`,
+    `<deduplication_rules>
 Return a JSON array of arrays, where each inner array contains the 1-based indices of findings that describe the same root cause.
 Only group findings that are truly about the same underlying issue. Findings about different issues should NOT be grouped even if they're nearby.
 Singletons (findings with no duplicates) should not appear in any group.
-
-Return ONLY the JSON array. Return [] if no findings share a root cause.`;
+</deduplication_rules>`,
+    buildJsonOutputSection('Return the JSON array. Return [] if no findings share a root cause.'),
+  ]);
 
   const result = await getRuntime(options.runtime).runAuxiliary({
     task: 'deduplication',

--- a/src/output/github-checks.test.ts
+++ b/src/output/github-checks.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   severityToAnnotationLevel,
   findingsToAnnotations,
   determineConclusion,
   aggregateSeverityCounts,
+  updateCoreCheck,
 } from './github-checks.js';
 import type { Finding, SkillReport } from '../types/index.js';
 
@@ -385,5 +386,46 @@ describe('aggregateSeverityCounts', () => {
       medium: 0,
       low: 0,
     });
+  });
+});
+
+describe('updateCoreCheck', () => {
+  it('renders total skill cost including auxiliary usage', async () => {
+    const update = vi.fn().mockResolvedValue({ data: {} });
+    const octokit = { checks: { update } } as unknown as Parameters<typeof updateCoreCheck>[0];
+
+    await updateCoreCheck(
+      octokit,
+      123,
+      {
+        totalSkills: 1,
+        totalFindings: 0,
+        findingsBySeverity: { high: 0, medium: 0, low: 0 },
+        totalDurationMs: 1000,
+        totalUsage: { inputTokens: 3000, outputTokens: 680, costUSD: 20 },
+        totalAuxiliaryUsage: {
+          verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+        },
+        findings: [],
+        skillResults: [
+          {
+            name: 'find-warden-bugs',
+            findingCount: 0,
+            conclusion: 'success',
+            durationMs: 1000,
+            usage: { inputTokens: 3000, outputTokens: 680, costUSD: 20 },
+            auxiliaryUsage: {
+              verification: { inputTokens: 100, outputTokens: 50, costUSD: 6.19 },
+            },
+          },
+        ],
+      },
+      'success',
+      { owner: 'getsentry', repo: 'warden' },
+    );
+
+    const request = update.mock.calls[0]![0] as { output: { summary: string } };
+    expect(request.output.summary).toContain('| find-warden-bugs | 0 | 1.0s | $26.19 |');
+    expect(request.output.summary).toContain('**Cost:** $26.19 (+verification: $6.19)');
   });
 });

--- a/src/output/github-checks.ts
+++ b/src/output/github-checks.ts
@@ -1,7 +1,7 @@
 import type { Octokit } from '@octokit/rest';
 import { SEVERITY_ORDER, filterFindings } from '../types/index.js';
 import type { Severity, SeverityThreshold, ConfidenceThreshold, Finding, SkillReport, UsageStats, AuxiliaryUsageMap } from '../types/index.js';
-import { formatDuration, formatCost, formatTokens, totalAuxiliaryCost, formatAuxiliarySuffix } from '../cli/output/formatters.js';
+import { formatDuration, formatCost, formatTokens, totalUsageCost, formatAuxiliarySuffix } from '../cli/output/formatters.js';
 import { escapeHtml } from '../utils/index.js';
 
 /**
@@ -62,6 +62,7 @@ export interface CoreCheckSummaryData {
     conclusion: CheckConclusion;
     durationMs?: number;
     usage?: UsageStats;
+    auxiliaryUsage?: AuxiliaryUsageMap;
   }[];
 }
 
@@ -377,7 +378,8 @@ function renderStatsFooter(
   usage: UsageStats | undefined,
   auxiliaryUsage: AuxiliaryUsageMap | undefined
 ): string[] {
-  if (durationMs === undefined && !usage) return [];
+  const cost = totalUsageCost(usage, auxiliaryUsage);
+  if (durationMs === undefined && !usage && cost === undefined) return [];
 
   const parts: string[] = [];
   if (durationMs !== undefined) {
@@ -385,10 +387,10 @@ function renderStatsFooter(
   }
   if (usage) {
     parts.push(`**Tokens:** ${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out`);
-    const auxCost = auxiliaryUsage ? totalAuxiliaryCost(auxiliaryUsage) : 0;
-    const totalCost = usage.costUSD + auxCost;
+  }
+  if (cost !== undefined) {
     const auxSuffix = auxiliaryUsage ? formatAuxiliarySuffix(auxiliaryUsage) : '';
-    parts.push(`**Cost:** ${formatCost(totalCost)}${auxSuffix}`);
+    parts.push(`**Cost:** ${formatCost(cost)}${auxSuffix}`);
   }
 
   return ['---', parts.join(' · ')];
@@ -441,7 +443,7 @@ function buildCoreSummary(data: CoreCheckSummaryData): string {
   }
 
   // Skills table in collapsible section
-  const hasSkillStats = data.skillResults.some((s) => s.durationMs !== undefined || s.usage);
+  const hasSkillStats = data.skillResults.some((s) => s.durationMs !== undefined || s.usage || s.auxiliaryUsage);
   const skillPlural = data.totalSkills === 1 ? '' : 's';
 
   lines.push('<details>');
@@ -454,7 +456,8 @@ function buildCoreSummary(data: CoreCheckSummaryData): string {
     );
     for (const skill of data.skillResults) {
       const duration = skill.durationMs !== undefined ? formatDuration(skill.durationMs) : '-';
-      const cost = skill.usage ? formatCost(skill.usage.costUSD) : '-';
+      const costUSD = totalUsageCost(skill.usage, skill.auxiliaryUsage);
+      const cost = costUSD !== undefined ? formatCost(costUSD) : '-';
       lines.push(`| ${skill.name} | ${skill.findingCount} | ${duration} | ${cost} |`);
     }
   } else {

--- a/src/sdk/analyze-verification.test.ts
+++ b/src/sdk/analyze-verification.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SkillDefinition } from '../config/schema.js';
+import type { EventContext, UsageStats } from '../types/index.js';
+import { runSkill } from './analyze.js';
+import { getRuntime, type Runtime } from './runtimes/index.js';
+import { verifyFindings } from './verify.js';
+
+vi.mock('./runtimes/index.js', () => ({
+  getRuntime: vi.fn(),
+  getRuntimeProviderOptions: vi.fn(() => undefined),
+}));
+
+vi.mock('./verify.js', () => ({
+  verifyFindings: vi.fn(),
+}));
+
+function makeUsage(): UsageStats {
+  return { inputTokens: 10, outputTokens: 5, costUSD: 0.001 };
+}
+
+function makeContext(): EventContext {
+  return {
+    eventType: 'pull_request',
+    action: 'opened',
+    repository: { owner: 'o', name: 'r', fullName: 'o/r', defaultBranch: 'main' },
+    repoPath: '/repo',
+    pullRequest: {
+      number: 1,
+      title: 'Test PR',
+      body: '',
+      author: 'test',
+      baseBranch: 'main',
+      headBranch: 'feature',
+      headSha: 'head',
+      baseSha: 'base',
+      files: [{
+        filename: 'src/app.ts',
+        status: 'modified',
+        additions: 1,
+        deletions: 1,
+        patch: '@@ -10,1 +10,1 @@\n-old\n+new',
+        chunks: 1,
+      }],
+    },
+  };
+}
+
+function makeSkill(): SkillDefinition {
+  return {
+    name: 'test-skill',
+    description: 'test',
+    prompt: 'Only report real bugs.',
+  };
+}
+
+describe('runSkill verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: vi.fn().mockResolvedValue({
+        result: {
+          status: 'success',
+          text: JSON.stringify({
+            findings: [{
+              id: 'raw',
+              severity: 'high',
+              confidence: 'high',
+              title: 'Candidate',
+              description: 'desc',
+              location: { path: 'src/app.ts', startLine: 10 },
+            }],
+          }),
+          errors: [],
+          usage: makeUsage(),
+        },
+      }),
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+  });
+
+  it('drops findings rejected by verification before reporting', async () => {
+    vi.mocked(verifyFindings).mockResolvedValue({
+      findings: [],
+      usage: makeUsage(),
+    });
+
+    const report = await runSkill(makeSkill(), makeContext(), {
+      auxiliaryModel: 'claude-haiku-4-5',
+    });
+
+    expect(report.findings).toEqual([]);
+    expect(report.auxiliaryUsage?.['verification']).toEqual(makeUsage());
+    expect(verifyFindings).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ model: 'claude-haiku-4-5' })
+    );
+  });
+});

--- a/src/sdk/analyze.test.ts
+++ b/src/sdk/analyze.test.ts
@@ -8,6 +8,7 @@ import { getRuntime, type Runtime } from './runtimes/index.js';
 
 vi.mock('./runtimes/index.js', () => ({
   getRuntime: vi.fn(),
+  getRuntimeProviderOptions: vi.fn(() => undefined),
 }));
 
 function makeFinding(startLine: number, id = `f-${startLine}`): Finding {

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -1,14 +1,14 @@
 import type { SkillDefinition } from '../config/schema.js';
 import type { Finding, RetryConfig } from '../types/index.js';
 import { getHunkLineRange, type HunkWithContext } from '../diff/index.js';
-import { Sentry, emitExtractionMetrics, emitRetryMetric, emitDedupMetrics, emitFixGateMetrics, logger } from '../sentry.js';
+import { Sentry, emitExtractionMetrics, emitRetryMetric } from '../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, isRetryableError, isAuthenticationError, isAuthenticationErrorMessage, isSubprocessError, classifyError, mapExtractionErrorCode, sanitizeErrorMessage } from './errors.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
 import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage } from './usage.js';
 import { buildHunkSystemPrompt, buildHunkUserPrompt, type PRPromptContext } from './prompt.js';
-import { extractFindingsJson, extractFindingsWithLLM, validateFindings, deduplicateFindings, mergeCrossLocationFindings } from './extract.js';
-import { sanitizeFindingsSuggestedFixes } from './fix-quality.js';
-import { getRuntime } from './runtimes/index.js';
+import { extractFindingsJson, extractFindingsWithLLM, validateFindings } from './extract.js';
+import { postProcessFindings } from './post-process.js';
+import { getRuntime, getRuntimeProviderOptions } from './runtimes/index.js';
 import type { SkillRunResult } from './runtimes/index.js';
 import {
   LARGE_PROMPT_THRESHOLD_CHARS,
@@ -200,10 +200,6 @@ async function analyzeHunk(
         try {
           const runtimeName = options.runtime ?? 'claude';
           const runtime = getRuntime(runtimeName);
-          const providerOptions =
-            runtimeName === 'claude'
-              ? { pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable }
-              : undefined;
           const { result: resultMessage, authError } = await runtime.runSkill({
             systemPrompt,
             userPrompt,
@@ -215,7 +211,9 @@ async function analyzeHunk(
               model: options.model,
               abortController: options.abortController,
             },
-            providerOptions,
+            providerOptions: getRuntimeProviderOptions(runtimeName, {
+              pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+            }),
           });
 
           // Check for authentication errors from auth_status messages
@@ -792,51 +790,26 @@ export async function runSkill(
     );
   }
 
-  // Deduplicate findings
-  const uniqueFindings = deduplicateFindings(allFindings);
-  emitDedupMetrics(skill.name, allFindings.length, uniqueFindings.length);
-
-  // Merge findings that describe the same issue at different locations
-  const mergeResult = await mergeCrossLocationFindings(uniqueFindings, {
-    apiKey: options.apiKey,
-    repoPath: context.repoPath,
-    runtime: options.runtime,
-    model: options.synthesisModel,
-    maxRetries: options.auxiliaryMaxRetries,
-  });
-  let mergedFindings = mergeResult.findings;
-  if (mergeResult.usage) {
-    allAuxiliaryUsage.push({ agent: 'merge', usage: mergeResult.usage });
-  }
-  const sanitized = await sanitizeFindingsSuggestedFixes(mergedFindings, {
+  const processed = await postProcessFindings(allFindings, {
+    skill,
     repoPath: context.repoPath,
     apiKey: options.apiKey,
     runtime: options.runtime,
-    model: options.auxiliaryModel,
-    maxRetries: options.auxiliaryMaxRetries,
+    auxiliaryModel: options.auxiliaryModel,
+    synthesisModel: options.synthesisModel,
+    auxiliaryMaxRetries: options.auxiliaryMaxRetries,
+    verifyFindings: options.verifyFindings,
+    maxTurns: options.maxTurns,
+    abortController: options.abortController,
+    pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+    prContext,
+    onFindingProcessing: options.callbacks?.onFindingProcessing,
   });
-  mergedFindings = sanitized.findings;
-  if (sanitized.usage) {
-    allAuxiliaryUsage.push({ agent: 'fix_gate', usage: sanitized.usage });
-  }
-  emitFixGateMetrics(
-    skill.name,
-    sanitized.stats.checked,
-    sanitized.stats.strippedDeterministic,
-    sanitized.stats.strippedSemantic,
-    sanitized.stats.semanticUnavailable
-  );
-  if (sanitized.stats.checked > 0) {
-    logger.info('Suggested fix quality gate', {
-      'fix_gate.checked': sanitized.stats.checked,
-      'fix_gate.stripped_deterministic': sanitized.stats.strippedDeterministic,
-      'fix_gate.stripped_semantic': sanitized.stats.strippedSemantic,
-      'fix_gate.semantic_unavailable': sanitized.stats.semanticUnavailable,
-    });
-  }
+  const finalFindings = processed.findings;
+  allAuxiliaryUsage.push(...processed.auxiliaryUsage);
 
   // Generate summary
-  const summary = generateSummary(skill.name, mergedFindings);
+  const summary = generateSummary(skill.name, finalFindings);
 
   // Aggregate usage across all hunks
   const totalUsage = aggregateUsage(allUsage);
@@ -844,7 +817,7 @@ export async function runSkill(
   const report: SkillReport = {
     skill: skill.name,
     summary,
-    findings: mergedFindings,
+    findings: finalFindings,
     usage: totalUsage,
     durationMs: Date.now() - startTime,
     model: options.model,

--- a/src/sdk/extract.test.ts
+++ b/src/sdk/extract.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { extractFindingsWithLLM, mergeCrossLocationFindings, mergeGroupLocations } from './extract.js';
+import {
+  deduplicateFindings,
+  extractFindingsWithLLM,
+  mergeCrossLocationFindings,
+  mergeGroupLocations,
+} from './extract.js';
 import type { Finding } from '../types/index.js';
 
 // Mock callHaiku to avoid real API calls
@@ -46,6 +51,33 @@ describe('extractFindingsWithLLM', () => {
       error: 'llm_extraction_failed: Request timed out',
       preview: '{ "findings": [',
       usage: { inputTokens: 10, outputTokens: 0, costUSD: 0.001 },
+    });
+  });
+});
+
+describe('deduplicateFindings', () => {
+  it('reports dropped duplicate findings', () => {
+    const kept = makeFinding({
+      id: 'f1',
+      title: 'Duplicate issue',
+      location: { path: 'src/a.ts', startLine: 1 },
+    });
+    const duplicate = makeFinding({
+      id: 'f2',
+      title: 'Duplicate issue',
+      location: { path: 'src/a.ts', startLine: 1 },
+    });
+    const onFindingProcessing = vi.fn();
+
+    const result = deduplicateFindings([kept, duplicate], onFindingProcessing);
+
+    expect(result).toEqual([kept]);
+    expect(onFindingProcessing).toHaveBeenCalledWith({
+      stage: 'dedupe',
+      action: 'dropped',
+      finding: duplicate,
+      replacement: kept,
+      reason: 'duplicate title and location',
     });
   });
 });
@@ -135,7 +167,12 @@ describe('mergeCrossLocationFindings', () => {
       usage: { inputTokens: 100, outputTokens: 10, costUSD: 0.001 },
     });
 
-    const result = await mergeCrossLocationFindings(findings, { apiKey: 'test-key', repoPath: tempDir });
+    const onFindingProcessing = vi.fn();
+    const result = await mergeCrossLocationFindings(findings, {
+      apiKey: 'test-key',
+      repoPath: tempDir,
+      onFindingProcessing,
+    });
     expect(result.findings).toHaveLength(1);
     expect(result.mergedCount).toBe(1);
     // Winner is the one with higher severity
@@ -143,6 +180,13 @@ describe('mergeCrossLocationFindings', () => {
     expect(result.findings[0]!.additionalLocations).toEqual([
       { path: 'src/b.ts', startLine: 2 },
     ]);
+    expect(onFindingProcessing).toHaveBeenCalledWith(expect.objectContaining({
+      stage: 'merge',
+      action: 'merged',
+      finding: findings[1],
+      reason: 'same root cause at another location',
+      replacement: expect.objectContaining({ id: 'f1' }),
+    }));
   });
 
   it('merges 3+ locations in one group', async () => {

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -6,6 +6,13 @@ import { FindingSchema, compareFindingPriority } from '../types/index.js';
 import type { Finding, Location, UsageStats } from '../types/index.js';
 import { getRuntime } from './runtimes/index.js';
 import type { RuntimeName } from './runtimes/index.js';
+import type { FindingProcessingEvent } from './types.js';
+import {
+  buildJsonOutputSection,
+  buildTaggedSection,
+  formatIndexedFindingsForPrompt,
+  joinPromptSections,
+} from './prompt-sections.js';
 
 /** Pattern to match the start of findings JSON (allows whitespace after brace) */
 export const FINDINGS_JSON_START = /\{\s*"findings"/;
@@ -201,12 +208,14 @@ export async function extractFindingsWithLLM(
   // Truncate input while preserving JSON boundaries
   const truncatedText = truncateForLLMFallback(rawText, LLM_FALLBACK_MAX_CHARS);
 
-  const userContent = `Extract the findings JSON from this model output.
-Return ONLY valid JSON in format: {"findings": [...]}
-If no findings exist, return: {"findings": []}
-
-Model output:
-${truncatedText}`;
+  const userContent = joinPromptSections([
+    `<task>
+Extract the findings JSON from this model output.
+</task>`,
+    buildJsonOutputSection(`Return this shape: {"findings": [...]}
+If no findings exist, return: {"findings": []}`),
+    buildTaggedSection('model_output', truncatedText),
+  ]);
 
   const result = await getRuntime(runtime).runAuxiliary({
     task: 'extraction',
@@ -279,15 +288,30 @@ export function validateFindings(findings: unknown[], filename: string): Finding
   return validated;
 }
 
+type FindingProcessingCallback = (event: FindingProcessingEvent) => void;
+
 /**
  * Deduplicate findings by title and location.
  */
-export function deduplicateFindings(findings: Finding[]): Finding[] {
-  const seen = new Set<string>();
+export function deduplicateFindings(
+  findings: Finding[],
+  onFindingProcessing?: FindingProcessingCallback
+): Finding[] {
+  const seen = new Map<string, Finding>();
   return findings.filter((f) => {
     const key = `${f.title}:${f.location?.path}:${f.location?.startLine}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
+    const kept = seen.get(key);
+    if (kept) {
+      onFindingProcessing?.({
+        stage: 'dedupe',
+        action: 'dropped',
+        finding: f,
+        replacement: kept,
+        reason: 'duplicate title and location',
+      });
+      return false;
+    }
+    seen.set(key, f);
     return true;
   });
 }
@@ -411,6 +435,23 @@ export function applyMergeGroups(
   return { absorbed, replacements };
 }
 
+function sameLocation(a: Location | undefined, b: Location | undefined): boolean {
+  return Boolean(a && b && locationKey(a) === locationKey(b));
+}
+
+function findReplacementForAbsorbed(
+  finding: Finding,
+  replacements: Map<Finding, Finding>
+): Finding | undefined {
+  for (const replacement of replacements.values()) {
+    if (replacement.additionalLocations?.some((loc) => sameLocation(loc, finding.location))) {
+      return replacement;
+    }
+  }
+
+  return undefined;
+}
+
 /** Schema for LLM merge response: groups of finding indices sharing a root cause. */
 const MergeGroupsSchema = z.array(z.array(z.number().int()));
 
@@ -454,7 +495,10 @@ function readSnippet(repoPath: string, filePath: string, startLine: number, cont
  */
 export async function mergeCrossLocationFindings(
   findings: Finding[],
-  options?: AuxiliaryCallOptions & { repoPath?: string }
+  options?: AuxiliaryCallOptions & {
+    repoPath?: string;
+    onFindingProcessing?: FindingProcessingCallback;
+  }
 ): Promise<MergeResult> {
   const apiKey = options?.apiKey;
   const repoPath = options?.repoPath ?? '.';
@@ -465,23 +509,24 @@ export async function mergeCrossLocationFindings(
     return { findings, mergedCount: 0 };
   }
 
-  // Build context for each finding
-  const findingDescriptions = withLocations.map((f, i) => {
-    const loc = f.location;
-    if (!loc) return '';
-    const range = loc.endLine ? `${loc.startLine}-${loc.endLine}` : `${loc.startLine}`;
-    const snippet = readSnippet(repoPath, loc.path, loc.startLine);
-    const codeBlock = snippet ? `\n   Code: ${snippet.split('\n').join('\n   ')}` : '';
-    return `${i + 1}. [${loc.path}:${range}] "${f.title}" - ${f.description}${codeBlock}`;
+  const findingDescriptions = formatIndexedFindingsForPrompt(withLocations, {
+    locationStyle: 'range',
+    snippet: (finding) => {
+      const loc = finding.location;
+      return loc ? readSnippet(repoPath, loc.path, loc.startLine) : undefined;
+    },
   });
 
-  const prompt = `Identify which of these code review findings describe the SAME underlying issue appearing at different locations. Group them by shared root cause.
-
-Findings:
-${findingDescriptions.join('\n')}
-
-Return a JSON array of arrays, where each inner array contains the 1-based indices of findings about the same issue.
-Singletons should not appear. Return [] if no findings describe the same issue.`;
+  const prompt = joinPromptSections([
+    `<task>
+Identify which of these code review findings describe the SAME underlying issue appearing at different locations. Group them by shared root cause.
+</task>`,
+    `<findings>
+${findingDescriptions}
+</findings>`,
+    buildJsonOutputSection(`Return a JSON array of arrays, where each inner array contains the 1-based indices of findings about the same issue.
+Singletons should not appear. Return [] if no findings describe the same issue.`),
+  ]);
 
   const result = await getRuntime(options?.runtime).runSynthesis({
     task: 'consolidation',
@@ -501,6 +546,16 @@ Singletons should not appear. Return [] if no findings describe the same issue.`
 
   if (absorbed.size === 0) {
     return { findings, mergedCount: 0, usage: result.usage };
+  }
+
+  for (const finding of absorbed) {
+    options?.onFindingProcessing?.({
+      stage: 'merge',
+      action: 'merged',
+      finding,
+      replacement: findReplacementForAbsorbed(finding, replacements),
+      reason: 'same root cause at another location',
+    });
   }
 
   const merged = findings

--- a/src/sdk/fix-quality.test.ts
+++ b/src/sdk/fix-quality.test.ts
@@ -42,10 +42,22 @@ describe('sanitizeFindingsSuggestedFixes', () => {
 
   it('strips suggestion when diff is unparseable', async () => {
     const finding = makeFinding('this is not a diff');
+    const onFindingProcessing = vi.fn();
 
-    const result = await sanitizeFindingsSuggestedFixes([finding], { repoPath, apiKey: 'k' });
+    const result = await sanitizeFindingsSuggestedFixes([finding], {
+      repoPath,
+      apiKey: 'k',
+      onFindingProcessing,
+    });
     expect(result.findings[0]?.suggestedFix).toBeUndefined();
     expect(result.stats.strippedDeterministic).toBe(1);
+    expect(onFindingProcessing).toHaveBeenCalledWith(expect.objectContaining({
+      stage: 'fix_gate',
+      action: 'stripped_fix',
+      finding,
+      reason: 'suggested fix failed deterministic validation',
+      replacement: expect.not.objectContaining({ suggestedFix: expect.anything() }),
+    }));
   });
 
   it('strips suggestion on path mismatch', async () => {

--- a/src/sdk/fix-quality.ts
+++ b/src/sdk/fix-quality.ts
@@ -7,6 +7,8 @@ import type { Finding, UsageStats } from '../types/index.js';
 import { getRuntime } from './runtimes/index.js';
 import type { RuntimeName } from './runtimes/index.js';
 import { aggregateUsage } from './usage.js';
+import { buildJsonOutputSection, buildTaggedSection, joinPromptSections } from './prompt-sections.js';
+import type { FindingProcessingEvent } from './types.js';
 
 export interface FixQualityStats {
   checked: number;
@@ -27,6 +29,7 @@ interface SanitizeSuggestedFixesOptions {
   runtime?: RuntimeName;
   model?: string;
   maxRetries?: number;
+  onFindingProcessing?: (event: FindingProcessingEvent) => void;
 }
 
 const SEMANTIC_PROMPT_MAX_CHARS = 4000;
@@ -139,23 +142,22 @@ async function runSemanticGate(
   const originalForPrompt = fileContent.slice(0, SEMANTIC_PROMPT_MAX_CHARS);
   const patchedForPrompt = patchedContent.slice(0, SEMANTIC_PROMPT_MAX_CHARS);
 
-  const prompt = [
-    'Judge whether this suggested code fix is valid.',
-    'Return JSON only: {"verdict":"pass|fail","reason":"..."}',
-    'Pass only if the diff clearly addresses the stated issue without obvious regressions in the shown code.',
-    '',
-    `Issue title: ${finding.title}`,
-    `Issue description: ${finding.description}`,
-    '',
-    'Original file:',
-    originalForPrompt,
-    '',
-    'Patched file:',
-    patchedForPrompt,
-    '',
-    'Suggested diff:',
-    finding.suggestedFix?.diff ?? '',
-  ].join('\n');
+  const prompt = joinPromptSections([
+    `<task>
+Judge whether this suggested code fix is valid.
+</task>`,
+    `<fix_quality_rule>
+Pass only if the diff clearly addresses the stated issue without obvious regressions in the shown code.
+</fix_quality_rule>`,
+    buildTaggedSection('issue', [
+      `<title>${finding.title}</title>`,
+      `<description>${finding.description}</description>`,
+    ]),
+    buildTaggedSection('original_file', originalForPrompt),
+    buildTaggedSection('patched_file', patchedForPrompt),
+    buildTaggedSection('suggested_diff', finding.suggestedFix?.diff ?? ''),
+    buildJsonOutputSection('{"verdict":"pass|fail","reason":"..."}'),
+  ]);
 
   const result = await getRuntime(runtime).runAuxiliary({
     task: 'fix_quality',
@@ -199,7 +201,15 @@ export async function sanitizeFindingsSuggestedFixes(
     const deterministic = runDeterministicGate(finding, options.repoPath);
     if (!deterministic.pass) {
       stats.strippedDeterministic++;
-      sanitized.push(stripSuggestedFix(finding));
+      const stripped = stripSuggestedFix(finding);
+      options.onFindingProcessing?.({
+        stage: 'fix_gate',
+        action: 'stripped_fix',
+        finding,
+        replacement: stripped,
+        reason: 'suggested fix failed deterministic validation',
+      });
+      sanitized.push(stripped);
       continue;
     }
 
@@ -215,7 +225,15 @@ export async function sanitizeFindingsSuggestedFixes(
 
     if (semantic.verdict === 'fail') {
       stats.strippedSemantic++;
-      sanitized.push(stripSuggestedFix(finding));
+      const stripped = stripSuggestedFix(finding);
+      options.onFindingProcessing?.({
+        stage: 'fix_gate',
+        action: 'stripped_fix',
+        finding,
+        replacement: stripped,
+        reason: 'suggested fix failed semantic validation',
+      });
+      sanitized.push(stripped);
       continue;
     }
 

--- a/src/sdk/json-output.ts
+++ b/src/sdk/json-output.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import type { UsageStats } from '../types/index.js';
 import { extractJson } from './haiku.js';
+import { buildJsonOutputSection, buildTaggedSection, joinPromptSections } from './prompt-sections.js';
 import { getRuntime, type Runtime, type RuntimeName } from './runtimes/index.js';
 
 const JSON_REPAIR_MAX_CHARS = 60_000;
@@ -82,15 +83,17 @@ async function repairJsonOutput<T>(
     maxTokens: repair.maxTokens ?? JSON_REPAIR_MAX_TOKENS,
     timeout: repair.timeout ?? JSON_REPAIR_TIMEOUT_MS,
     schema,
-    prompt: `Extract and repair the JSON value from this model output.
-
-Return only valid JSON accepted by the provided schema. Preserve the model's structured content as much as possible. If the output contains markdown fences, escaped newlines, or prose around JSON, remove only the wrapper/prose and repair JSON escaping. Do not summarize or invent new content.
-
-The local parser failed with:
-${reason}
-
-Model output:
-${truncateForRepair(output)}`,
+    prompt: joinPromptSections([
+      `<task>
+Extract and repair the JSON value from this model output.
+</task>`,
+      buildJsonOutputSection(`Return JSON accepted by the provided schema.
+Preserve the model's structured content as much as possible.
+If the output contains markdown fences, escaped newlines, or prose around JSON, remove only the wrapper/prose and repair JSON escaping.
+Do not summarize or invent new content.`),
+      buildTaggedSection('parse_error', reason),
+      buildTaggedSection('model_output', truncateForRepair(output)),
+    ]),
   });
 
   if (!result.success) {

--- a/src/sdk/post-process.ts
+++ b/src/sdk/post-process.ts
@@ -1,0 +1,106 @@
+import type { SkillDefinition } from '../config/schema.js';
+import { emitDedupMetrics, emitFixGateMetrics, logger } from '../sentry.js';
+import type { Finding } from '../types/index.js';
+import { deduplicateFindings, mergeCrossLocationFindings } from './extract.js';
+import { sanitizeFindingsSuggestedFixes } from './fix-quality.js';
+import type { PromptPRContext } from './prompt-sections.js';
+import type { RuntimeName } from './runtimes/index.js';
+import type { AuxiliaryUsageEntry, FindingProcessingEvent } from './types.js';
+import { verifyFindings } from './verify.js';
+
+export interface PostProcessFindingsOptions {
+  skill: SkillDefinition;
+  repoPath: string;
+  apiKey?: string;
+  runtime?: RuntimeName;
+  auxiliaryModel?: string;
+  synthesisModel?: string;
+  auxiliaryMaxRetries?: number;
+  verifyFindings?: boolean;
+  maxTurns?: number;
+  abortController?: AbortController;
+  pathToClaudeCodeExecutable?: string;
+  prContext?: PromptPRContext;
+  onFindingProcessing?: (event: FindingProcessingEvent) => void;
+}
+
+export interface PostProcessFindingsResult {
+  findings: Finding[];
+  auxiliaryUsage: AuxiliaryUsageEntry[];
+}
+
+/**
+ * Run the shared post-analysis finding pipeline.
+ */
+export async function postProcessFindings(
+  findings: Finding[],
+  options: PostProcessFindingsOptions
+): Promise<PostProcessFindingsResult> {
+  const auxiliaryUsage: AuxiliaryUsageEntry[] = [];
+
+  const uniqueFindings = deduplicateFindings(findings, options.onFindingProcessing);
+  emitDedupMetrics(options.skill.name, findings.length, uniqueFindings.length);
+
+  let currentFindings = uniqueFindings;
+  if (options.verifyFindings !== false) {
+    const verification = await verifyFindings(currentFindings, {
+      repoPath: options.repoPath,
+      skill: options.skill,
+      runtime: options.runtime,
+      model: options.auxiliaryModel,
+      maxTurns: options.maxTurns,
+      abortController: options.abortController,
+      pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+      prContext: options.prContext,
+      onFindingProcessing: options.onFindingProcessing,
+    });
+    currentFindings = verification.findings;
+    if (verification.usage) {
+      auxiliaryUsage.push({ agent: 'verification', usage: verification.usage });
+    }
+  }
+
+  const mergeResult = await mergeCrossLocationFindings(currentFindings, {
+    apiKey: options.apiKey,
+    repoPath: options.repoPath,
+    runtime: options.runtime,
+    model: options.synthesisModel,
+    maxRetries: options.auxiliaryMaxRetries,
+    onFindingProcessing: options.onFindingProcessing,
+  });
+  currentFindings = mergeResult.findings;
+  if (mergeResult.usage) {
+    auxiliaryUsage.push({ agent: 'merge', usage: mergeResult.usage });
+  }
+
+  const sanitized = await sanitizeFindingsSuggestedFixes(currentFindings, {
+    repoPath: options.repoPath,
+    apiKey: options.apiKey,
+    runtime: options.runtime,
+    model: options.auxiliaryModel,
+    maxRetries: options.auxiliaryMaxRetries,
+    onFindingProcessing: options.onFindingProcessing,
+  });
+  currentFindings = sanitized.findings;
+  if (sanitized.usage) {
+    auxiliaryUsage.push({ agent: 'fix_gate', usage: sanitized.usage });
+  }
+
+  emitFixGateMetrics(
+    options.skill.name,
+    sanitized.stats.checked,
+    sanitized.stats.strippedDeterministic,
+    sanitized.stats.strippedSemantic,
+    sanitized.stats.semanticUnavailable
+  );
+  if (sanitized.stats.checked > 0) {
+    logger.info('Suggested fix quality gate', {
+      'fix_gate.checked': sanitized.stats.checked,
+      'fix_gate.stripped_deterministic': sanitized.stats.strippedDeterministic,
+      'fix_gate.stripped_semantic': sanitized.stats.strippedSemantic,
+      'fix_gate.semantic_unavailable': sanitized.stats.semanticUnavailable,
+    });
+  }
+
+  return { findings: currentFindings, auxiliaryUsage };
+}

--- a/src/sdk/prompt-sections.test.ts
+++ b/src/sdk/prompt-sections.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFileListSection,
+  buildJsonOutputSection,
+  buildTaggedSection,
+  formatIndexedFindingsForPrompt,
+  joinPromptSections,
+} from './prompt-sections.js';
+import type { Finding } from '../types/index.js';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: 'ABC-123',
+    severity: 'high',
+    confidence: 'medium',
+    title: 'Unsafe query',
+    description: 'User input reaches SQL without parameters.',
+    location: { path: 'src/db.ts', startLine: 10, endLine: 12 },
+    ...overrides,
+  };
+}
+
+describe('prompt section helpers', () => {
+  it('builds tagged sections and omits empty content', () => {
+    expect(buildTaggedSection('task', 'Review this')).toBe('<task>\nReview this\n</task>');
+    expect(buildTaggedSection('task', '   ')).toBeUndefined();
+  });
+
+  it('builds a consistent JSON output section', () => {
+    const section = buildJsonOutputSection('{"ok": true}');
+
+    expect(section).toContain('<output_format>');
+    expect(section).toContain('Return only valid JSON');
+    expect(section).toContain('{"ok": true}');
+  });
+
+  it('joins optional sections with consistent spacing', () => {
+    expect(joinPromptSections(['one', undefined, 'two'])).toBe('one\n\ntwo');
+  });
+
+  it('builds capped file lists with current-file exclusion', () => {
+    const section = buildFileListSection('changed_files', ['src/a.ts', 'src/b.ts', 'src/c.ts'], {
+      currentFile: 'src/a.ts',
+      maxFiles: 1,
+    });
+
+    expect(section).toContain('<changed_files>');
+    expect(section).not.toContain('src/a.ts');
+    expect(section).toContain('- src/b.ts');
+    expect(section).toContain('... and 1 more');
+  });
+
+  it('formats indexed findings consistently for auxiliary prompts', () => {
+    const text = formatIndexedFindingsForPrompt([makeFinding()], {
+      includeSeverity: true,
+      locationStyle: 'range',
+    });
+
+    expect(text).toBe(
+      '1. [src/db.ts:10-12] (high) "Unsafe query" - User input reaches SQL without parameters.'
+    );
+  });
+});

--- a/src/sdk/prompt-sections.ts
+++ b/src/sdk/prompt-sections.ts
@@ -1,0 +1,170 @@
+import { findingLine, type Finding } from '../types/index.js';
+
+export interface PromptPRContext {
+  /** All files being changed in the PR */
+  changedFiles: string[];
+  /** PR title - explains what the change does */
+  title?: string;
+  /** PR description/body - explains why and provides additional context */
+  body?: string | null;
+  /** Max number of changed files to list. 0 disables the section. Default: 50. */
+  maxContextFiles?: number;
+}
+
+const MAX_BODY_LENGTH = 1000;
+
+/**
+ * Build a tagged prompt section, omitting empty content.
+ */
+export function buildTaggedSection(tag: string, content: string | string[]): string | undefined {
+  const body = Array.isArray(content) ? content.join('\n') : content;
+  if (body.trim().length === 0) return undefined;
+
+  return `<${tag}>
+${body}
+</${tag}>`;
+}
+
+/**
+ * Join prompt sections with consistent spacing, skipping omitted sections.
+ */
+export function joinPromptSections(sections: (string | undefined)[]): string {
+  return sections.filter((section): section is string => Boolean(section)).join('\n\n');
+}
+
+/**
+ * Build a tagged JSON-only output contract.
+ */
+export function buildJsonOutputSection(instructions: string): string {
+  const lines = [
+    'Return only valid JSON. Do not include markdown, prose, code fences, or explanations.',
+  ];
+  const trimmedInstructions = instructions.trim();
+  if (trimmedInstructions.length > 0) {
+    lines.push('', trimmedInstructions);
+  }
+  return `<output_format>
+${lines.join('\n')}
+</output_format>`;
+}
+
+/**
+ * Build tagged pull request context shared by Warden agents.
+ */
+export function buildPullRequestContextSection(prContext?: PromptPRContext): string | undefined {
+  if (!prContext?.title) return undefined;
+
+  const lines = [`<title>${prContext.title}</title>`];
+
+  if (prContext.body) {
+    const body = prContext.body.length > MAX_BODY_LENGTH
+      ? `${prContext.body.slice(0, MAX_BODY_LENGTH)}...`
+      : prContext.body;
+    lines.push('<body>', body, '</body>');
+  }
+
+  return buildTaggedSection('pull_request_context', lines);
+}
+
+export interface FileListSectionOptions {
+  currentFile?: string;
+  maxFiles?: number;
+}
+
+/**
+ * Build a tagged file list section with optional current-file exclusion.
+ */
+export function buildFileListSection(
+  tag: string,
+  files: string[],
+  options: FileListSectionOptions = {}
+): string | undefined {
+  const maxFiles = options.maxFiles ?? 50;
+  const visibleFiles = options.currentFile
+    ? files.filter((f) => f !== options.currentFile)
+    : files;
+  if (visibleFiles.length === 0 || maxFiles === 0) return undefined;
+
+  const displayFiles = visibleFiles.slice(0, maxFiles);
+  const remaining = visibleFiles.length - displayFiles.length;
+  const lines = displayFiles.map((f) => `- ${f}`);
+  if (remaining > 0) {
+    lines.push(`- ... and ${remaining} more`);
+  }
+
+  return buildTaggedSection(tag, lines);
+}
+
+/**
+ * Build tagged changed-file context shared by Warden agents.
+ */
+export function buildChangedFilesSection(
+  prContext: PromptPRContext | undefined,
+  currentFile?: string
+): string | undefined {
+  if (!prContext) return undefined;
+  return buildFileListSection('changed_files', prContext.changedFiles, {
+    currentFile,
+    maxFiles: prContext.maxContextFiles ?? 50,
+  });
+}
+
+interface PromptFindingFormatOptions {
+  includeSeverity?: boolean;
+  includeConfidence?: boolean;
+  includeVerification?: boolean;
+  locationStyle?: 'line' | 'range';
+  snippet?: (finding: Finding) => string | undefined;
+}
+
+function formatFindingLocation(finding: Finding, style: 'line' | 'range'): string {
+  const loc = finding.location;
+  if (!loc) return 'general';
+
+  if (style === 'range' && loc.endLine) {
+    return `${loc.path}:${loc.startLine}-${loc.endLine}`;
+  }
+
+  return `${loc.path}:${findingLine(finding)}`;
+}
+
+/**
+ * Format one finding for prompt lists shared by auxiliary agents.
+ */
+export function formatFindingForPrompt(
+  finding: Finding,
+  options: PromptFindingFormatOptions = {}
+): string {
+  const details: string[] = [];
+  if (options.includeSeverity) details.push(`(${finding.severity})`);
+  if (options.includeConfidence && finding.confidence) {
+    details.push(`[confidence: ${finding.confidence}]`);
+  }
+
+  const prefix = details.length > 0 ? `${details.join(' ')} ` : '';
+  const location = formatFindingLocation(finding, options.locationStyle ?? 'line');
+  let text = `[${location}] ${prefix}"${finding.title}" - ${finding.description}`;
+
+  if (options.includeVerification && finding.verification) {
+    text += ` Verification: ${finding.verification}`;
+  }
+
+  const snippet = options.snippet?.(finding);
+  if (snippet) {
+    text += `\n   Code: ${snippet.split('\n').join('\n   ')}`;
+  }
+
+  return text;
+}
+
+/**
+ * Format findings as a stable 1-based prompt list.
+ */
+export function formatIndexedFindingsForPrompt(
+  findings: Finding[],
+  options: PromptFindingFormatOptions = {}
+): string {
+  return findings.map((finding, index) => {
+    return `${index + 1}. ${formatFindingForPrompt(finding, options)}`;
+  }).join('\n');
+}

--- a/src/sdk/prompt.test.ts
+++ b/src/sdk/prompt.test.ts
@@ -46,32 +46,34 @@ describe('buildHunkSystemPrompt', () => {
 });
 
 describe('buildHunkUserPrompt', () => {
-  describe('Other Files section', () => {
-    it('omits "Other Files" when changedFiles is empty (non-PR context)', () => {
+  describe('changed files section', () => {
+    it('omits changed files when changedFiles is empty (non-PR context)', () => {
       const prContext: PRPromptContext = {
         changedFiles: [],
         title: 'Local changes',
       };
       const result = buildHunkUserPrompt(skill, makeHunk(), prContext);
-      expect(result).not.toContain('Other Files in This PR');
+      expect(result).not.toContain('<changed_files>');
     });
 
-    it('omits "Other Files" when no prContext is provided', () => {
+    it('omits changed files when no prContext is provided', () => {
       const result = buildHunkUserPrompt(skill, makeHunk());
-      expect(result).not.toContain('Other Files in This PR');
+      expect(result).not.toContain('<changed_files>');
     });
 
-    it('includes "Other Files" section for PR contexts with files', () => {
+    it('includes tagged changed files for PR contexts with files', () => {
       const prContext: PRPromptContext = {
         changedFiles: ['src/app.ts', 'src/utils.ts', 'src/index.ts'],
         title: 'Add feature',
       };
       const result = buildHunkUserPrompt(skill, makeHunk('src/app.ts'), prContext);
-      expect(result).toContain('Other Files in This PR');
+      expect(result).toContain('<changed_files>');
       expect(result).toContain('- src/utils.ts');
       expect(result).toContain('- src/index.ts');
       // Current file should be excluded
       expect(result).not.toContain('- src/app.ts');
+      expect(result).toContain('<pull_request_context>');
+      expect(result).toContain('<title>Add feature</title>');
     });
 
     it('caps file list at maxContextFiles with truncation message', () => {
@@ -83,7 +85,7 @@ describe('buildHunkUserPrompt', () => {
       };
       const hunk = makeHunk('src/other.ts'); // not in the list
       const result = buildHunkUserPrompt(skill, hunk, prContext);
-      expect(result).toContain('Other Files in This PR');
+      expect(result).toContain('<changed_files>');
       // Should have first 10 files
       expect(result).toContain('- src/file-0.ts');
       expect(result).toContain('- src/file-9.ts');
@@ -112,7 +114,7 @@ describe('buildHunkUserPrompt', () => {
         maxContextFiles: 0,
       };
       const result = buildHunkUserPrompt(skill, makeHunk('src/app.ts'), prContext);
-      expect(result).not.toContain('Other Files in This PR');
+      expect(result).not.toContain('<changed_files>');
     });
 
     it('uses default cap of 50 when maxContextFiles is not specified', () => {

--- a/src/sdk/prompt.ts
+++ b/src/sdk/prompt.ts
@@ -2,24 +2,15 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { SkillDefinition } from '../config/schema.js';
 import { formatHunkForAnalysis, type HunkWithContext } from '../diff/index.js';
+import {
+  buildChangedFilesSection,
+  buildJsonOutputSection,
+  buildPullRequestContextSection,
+  joinPromptSections,
+  type PromptPRContext,
+} from './prompt-sections.js';
 
-/**
- * Context about the PR being analyzed, for inclusion in prompts.
- *
- * The title and body (like a commit message) help explain the _intent_ of the
- * changes to the agent, enabling it to better understand what the author was
- * trying to accomplish and identify issues that conflict with that intent.
- */
-export interface PRPromptContext {
-  /** All files being changed in the PR */
-  changedFiles: string[];
-  /** PR title - explains what the change does */
-  title?: string;
-  /** PR description/body - explains why and provides additional context */
-  body?: string | null;
-  /** Max number of "other files" to list in the prompt. 0 disables the section. Default: 50. */
-  maxContextFiles?: number;
-}
+export type PRPromptContext = PromptPRContext;
 
 /**
  * Builds the system prompt for hunk-based analysis.
@@ -49,9 +40,7 @@ The following defines the ONLY criteria you should evaluate. Do not report findi
 ${skill.prompt}
 </skill_instructions>`,
 
-    `<output_format>
-IMPORTANT: Your response must be ONLY a valid JSON object. No markdown, no explanation, no code fences.
-
+    buildJsonOutputSection(`
 Example response format:
 {"findings": [{"id": "example-1", "severity": "medium", "confidence": "high", "title": "Issue title", "description": "Description", "location": {"path": "file.ts", "startLine": 10}}]}
 
@@ -79,7 +68,7 @@ Full schema:
 }
 
 Requirements:
-- Return ONLY valid JSON starting with {"findings":
+- Return valid JSON starting with {"findings":
 - "findings" array can be empty if no issues found
 - "location.path" is auto-filled from context - just provide startLine (and optionally endLine). Omit location entirely for general findings not about a specific line.
 - "location.startLine" MUST be within the hunk line range (shown in the "## Hunk" header). If the issue originates in surrounding code, anchor to the nearest changed line in the hunk and note the actual location in the description.
@@ -89,7 +78,7 @@ Requirements:
   - The fix requires changes to a different file or a new file (describe the fix in the description field instead)
 - Keep descriptions concise (2-4 sentences). Start with the root cause, end with the user-visible consequence.
 - Focus your analysis on the code changes in the hunk. Surrounding context and tool results are for understanding only -- all findings must reference lines within the hunk range.
-</output_format>`,
+`),
   ];
 
   const { rootDir } = skill;
@@ -117,44 +106,15 @@ export function buildHunkUserPrompt(
   hunkCtx: HunkWithContext,
   prContext?: PRPromptContext
 ): string {
-  const sections: string[] = [];
-
-  sections.push(`Analyze this code change according to the "${skill.name}" skill criteria.`);
-
-  // Include PR title and description for context on intent
-  if (prContext?.title) {
-    let prSection = `## Pull Request Context\n**Title:** ${prContext.title}`;
-    if (prContext.body) {
-      // Truncate very long PR descriptions to avoid bloating prompts
-      const maxBodyLength = 1000;
-      const body = prContext.body.length > maxBodyLength
-        ? prContext.body.slice(0, maxBodyLength) + '...'
-        : prContext.body;
-      prSection += `\n\n**Description:**\n${body}`;
-    }
-    sections.push(prSection);
-  }
-
-  // Include list of other files being changed in the PR for context
-  const maxContextFiles = prContext?.maxContextFiles ?? 50;
-  const otherFiles = prContext?.changedFiles.filter((f) => f !== hunkCtx.filename) ?? [];
-  if (otherFiles.length > 0 && maxContextFiles > 0) {
-    const displayFiles = otherFiles.slice(0, maxContextFiles);
-    const remaining = otherFiles.length - displayFiles.length;
-    let fileList = displayFiles.map((f) => `- ${f}`).join('\n');
-    if (remaining > 0) {
-      fileList += `\n- ... and ${remaining} more`;
-    }
-    sections.push(`## Other Files in This PR
-The following files are also being changed in this PR (may provide useful context):
-${fileList}`);
-  }
-
-  sections.push(formatHunkForAnalysis(hunkCtx));
-
-  sections.push(
-    `IMPORTANT: Only report findings that are explicitly covered by the skill instructions. Do not report general code quality issues, bugs, or improvements unless the skill specifically asks for them. Return an empty findings array if no issues match the skill's criteria.`
-  );
-
-  return sections.join('\n\n');
+  return joinPromptSections([
+    `<task>
+Analyze this code change according to the "${skill.name}" skill criteria.
+</task>`,
+    buildPullRequestContextSection(prContext),
+    buildChangedFilesSection(prContext, hunkCtx.filename),
+    formatHunkForAnalysis(hunkCtx),
+    `<scope_reminder>
+Only report findings that are explicitly covered by the skill instructions. Do not report general code quality issues, bugs, or improvements unless the skill specifically asks for them. Return an empty findings array if no issues match the skill's criteria.
+</scope_reminder>`,
+  ]);
 }

--- a/src/sdk/runner.ts
+++ b/src/sdk/runner.ts
@@ -57,12 +57,21 @@ export type {
 // Re-export file preparation
 export { prepareFiles } from './prepare.js';
 
+// Re-export verification utilities
+export { verifyFindings } from './verify.js';
+export { postProcessFindings } from './post-process.js';
+export type {
+  PostProcessFindingsOptions,
+  PostProcessFindingsResult,
+} from './post-process.js';
+
 // Re-export analysis functions
 export { analyzeFile, runSkill, generateSummary } from './analyze.js';
 
 // Re-export runtime registry and adapter contracts
 export {
   claudeRuntime,
+  getRuntimeProviderOptions,
   getRuntime,
 } from './runtimes/index.js';
 export type { Runtime, RuntimeName } from './runtimes/index.js';
@@ -83,6 +92,7 @@ export type {
 // Re-export types
 export type {
   AuxiliaryUsageEntry,
+  FindingProcessingEvent,
   SkillRunnerCallbacks,
   SkillRunnerOptions,
   PreparedFile,

--- a/src/sdk/runtimes/index.test.ts
+++ b/src/sdk/runtimes/index.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   claudeRuntime,
   getRuntime,
+  getRuntimeProviderOptions,
 } from './index.js';
 
 describe('runtimes', () => {
@@ -18,6 +19,14 @@ describe('runtimes', () => {
 
   it('rejects unsupported runtimes explicitly', () => {
     expect(() => getRuntime('pi' as never)).toThrow('Unsupported runtime: pi');
+  });
+
+  it('builds provider options at the runtime boundary', () => {
+    expect(getRuntimeProviderOptions('claude', {
+      pathToClaudeCodeExecutable: '/bin/claude',
+    })).toEqual({
+      pathToClaudeCodeExecutable: '/bin/claude',
+    });
   });
 
   it('fails auxiliary calls clearly when Claude auth is missing', async () => {

--- a/src/sdk/runtimes/index.ts
+++ b/src/sdk/runtimes/index.ts
@@ -29,3 +29,21 @@ export function getRuntime(name: RuntimeName = 'claude'): Runtime {
   }
   return runtime;
 }
+
+export interface RuntimeProviderOptionsInput {
+  pathToClaudeCodeExecutable?: string;
+}
+
+/**
+ * Build provider-specific runtime options at the runtime boundary.
+ */
+export function getRuntimeProviderOptions(
+  name: RuntimeName,
+  options: RuntimeProviderOptionsInput
+): unknown {
+  if (name === 'claude') {
+    return { pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable };
+  }
+
+  return undefined;
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -9,6 +9,14 @@ export interface AuxiliaryUsageEntry {
   usage: UsageStats;
 }
 
+export interface FindingProcessingEvent {
+  stage: 'dedupe' | 'verification' | 'merge' | 'fix_gate';
+  action: 'dropped' | 'rejected' | 'revised' | 'merged' | 'stripped_fix';
+  finding: Finding;
+  reason?: string;
+  replacement?: Finding;
+}
+
 /** Default concurrency for file-level parallel processing (standalone SDK usage only) */
 export const DEFAULT_FILE_CONCURRENCY = 5;
 
@@ -76,6 +84,8 @@ export interface SkillRunnerCallbacks {
   onExtractionFailure?: (file: string, lineRange: string, error: string, preview: string) => void;
   /** Called with extraction result details (debug mode) */
   onExtractionResult?: (file: string, lineRange: string, findingsCount: number, method: 'regex' | 'llm' | 'none') => void;
+  /** Called when a finding is dropped, revised, merged, or otherwise changed after analysis. */
+  onFindingProcessing?: (event: FindingProcessingEvent) => void;
   /** Called when hunk analysis fails (SDK error, API error, abort) */
   onHunkFailed?: (file: string, lineRange: string, error: string) => void;
 }
@@ -113,6 +123,8 @@ export interface SkillRunnerOptions {
   maxContextFiles?: number;
   /** Max retries for auxiliary Haiku calls (extraction repair, merging, dedup, fix evaluation). Default: 5 */
   auxiliaryMaxRetries?: number;
+  /** Verify candidate findings in a second read-only pass. Defaults to true. */
+  verifyFindings?: boolean;
 }
 
 /**

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SkillDefinition } from '../config/schema.js';
+import type { Finding, UsageStats } from '../types/index.js';
+import { verifyFindings } from './verify.js';
+import { getRuntime, type Runtime } from './runtimes/index.js';
+
+vi.mock('./runtimes/index.js', () => ({
+  getRuntime: vi.fn(),
+  getRuntimeProviderOptions: vi.fn(() => undefined),
+}));
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: 'ABC-123',
+    severity: 'high',
+    confidence: 'high',
+    title: 'Candidate issue',
+    description: 'Something may be wrong.',
+    location: { path: 'src/app.ts', startLine: 10 },
+    ...overrides,
+  };
+}
+
+function makeSkill(): SkillDefinition {
+  return {
+    name: 'test-skill',
+    description: 'test',
+    prompt: 'Only report real issues.',
+  };
+}
+
+function makeUsage(): UsageStats {
+  return { inputTokens: 10, outputTokens: 5, costUSD: 0.001 };
+}
+
+function mockRuntime(text: string): Runtime {
+  return {
+    name: 'claude',
+    runSkill: vi.fn().mockResolvedValue({
+      result: {
+        status: 'success',
+        text,
+        errors: [],
+        usage: makeUsage(),
+      },
+    }),
+    runAuxiliary: vi.fn(),
+    runSynthesis: vi.fn(),
+  } as unknown as Runtime;
+}
+
+describe('verifyFindings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects findings when the verifier returns reject', async () => {
+    const runtime = mockRuntime('{"verdict":"reject","reason":"guarded upstream"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+    const onFindingProcessing = vi.fn();
+
+    const finding = makeFinding();
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+      model: 'claude-haiku-4-5',
+      prContext: {
+        title: 'Fix guarded path',
+        body: 'Adds a guard before the call.',
+        changedFiles: ['src/app.ts', 'src/guard.ts'],
+      },
+      onFindingProcessing,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(onFindingProcessing).toHaveBeenCalledWith({
+      stage: 'verification',
+      action: 'rejected',
+      finding,
+      reason: 'guarded upstream',
+    });
+    expect(result.usage).toEqual(expect.objectContaining(makeUsage()));
+    expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
+      repoPath: '/repo',
+      skillName: 'test-skill:verification',
+      options: expect.objectContaining({ model: 'claude-haiku-4-5' }),
+      userPrompt: expect.stringContaining('<pull_request_context>'),
+    }));
+    expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: expect.stringContaining('<candidate_finding>'),
+    }));
+    expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: expect.stringContaining('- src/guard.ts'),
+    }));
+  });
+
+  it('keeps the original id when revising a finding', async () => {
+    const revised = makeFinding({
+      id: 'DIFFERENT',
+      severity: 'medium',
+      confidence: 'medium',
+      title: 'Narrower issue',
+    });
+    const runtime = mockRuntime(JSON.stringify({
+      verdict: 'revise',
+      finding: revised,
+      reason: 'impact is narrower',
+    }));
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+    const onFindingProcessing = vi.fn();
+
+    const finding = makeFinding();
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+      onFindingProcessing,
+    });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toEqual(expect.objectContaining({
+      id: 'ABC-123',
+      severity: 'medium',
+      confidence: 'medium',
+      title: 'Narrower issue',
+    }));
+    expect(onFindingProcessing).toHaveBeenCalledWith(expect.objectContaining({
+      stage: 'verification',
+      action: 'revised',
+      finding,
+      replacement: expect.objectContaining({ id: 'ABC-123', title: 'Narrower issue' }),
+      reason: 'impact is narrower',
+    }));
+  });
+
+  it('keeps the original finding when verifier output is unusable', async () => {
+    const finding = makeFinding();
+    const runtime = mockRuntime('not json');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.findings).toEqual([finding]);
+  });
+});

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -304,4 +304,21 @@ describe('verifyFindings', () => {
     expect(maxActive).toBeGreaterThan(1);
     expect(maxActive).toBeLessThanOrEqual(4);
   });
+
+  it('passes skill tool configuration to the verifier runtime', async () => {
+    const runtime = mockRuntime('{"verdict":"keep"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    await verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: {
+        ...makeSkill(),
+        tools: { allowed: ['Read', 'Grep', 'WebFetch'] },
+      },
+    });
+
+    expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
+      tools: { allowed: ['Read', 'Grep', 'WebFetch'] },
+    }));
+  });
 });

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -213,6 +213,22 @@ describe('verifyFindings', () => {
     expect(result.findings).toEqual([]);
   });
 
+  it('accepts reject verdicts with a null finding', async () => {
+    const runtime = mockRuntime(JSON.stringify({
+      verdict: 'reject',
+      finding: null,
+      reason: 'guarded upstream',
+    }));
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const result = await verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
   it('keeps the original finding when verifier output is unusable', async () => {
     const finding = makeFinding();
     const runtime = mockRuntime('not json');

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -266,6 +266,42 @@ describe('verifyFindings', () => {
     await expect(verifyFindings([makeFinding()], {
       repoPath: '/repo',
       skill: makeSkill(),
-    })).rejects.toBeInstanceOf(WardenAuthenticationError);
+    })).rejects.toThrow('invalid api key');
+  });
+
+  it('verifies multiple findings concurrently', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const runtime: Runtime = {
+      name: 'claude',
+      runSkill: vi.fn(async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return {
+          result: {
+            status: 'success',
+            text: '{"verdict":"keep"}',
+            errors: [],
+            usage: makeUsage(),
+          },
+        };
+      }),
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime;
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const findings = Array.from({ length: 6 }, (_, index) => makeFinding({ id: `ABC-${index}` }));
+    const result = await verifyFindings(findings, {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.findings.map((finding) => finding.id)).toEqual(findings.map((finding) => finding.id));
+    expect(runtime.runSkill).toHaveBeenCalledTimes(6);
+    expect(maxActive).toBeGreaterThan(1);
+    expect(maxActive).toBeLessThanOrEqual(4);
   });
 });

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -242,6 +242,62 @@ describe('verifyFindings', () => {
     expect(result.findings).toEqual([finding]);
   });
 
+  it('drops unverified findings when verification is already aborted', async () => {
+    const runtime = mockRuntime('{"verdict":"keep"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+    const abortController = new AbortController();
+    abortController.abort();
+    const onFindingProcessing = vi.fn();
+    const finding = makeFinding();
+
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+      abortController,
+      onFindingProcessing,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(runtime.runSkill).not.toHaveBeenCalled();
+    expect(onFindingProcessing).toHaveBeenCalledWith({
+      stage: 'verification',
+      action: 'rejected',
+      finding,
+      reason: 'verification aborted before start',
+    });
+  });
+
+  it('drops unverified findings when verification aborts before verdict', async () => {
+    const abortController = new AbortController();
+    const runtime: Runtime = {
+      name: 'claude',
+      runSkill: vi.fn(async () => {
+        abortController.abort();
+        throw new Error('aborted');
+      }),
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime;
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+    const onFindingProcessing = vi.fn();
+    const finding = makeFinding();
+
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+      abortController,
+      onFindingProcessing,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(onFindingProcessing).toHaveBeenCalledWith({
+      stage: 'verification',
+      action: 'rejected',
+      finding,
+      reason: 'verification aborted before verdict',
+    });
+  });
+
   it('propagates authentication errors reported by the verifier runtime', async () => {
     vi.mocked(getRuntime).mockReturnValue(mockRuntimeResponse({ authError: 'login required' }));
 

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -132,6 +132,18 @@ describe('verifyFindings', () => {
     }));
   });
 
+  it('accepts verifier JSON when verdict is not the first key', async () => {
+    const runtime = mockRuntime('{"reason":"guarded upstream","verdict":"reject"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const result = await verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
   it('keeps the original finding when verifier output is unusable', async () => {
     const finding = makeFinding();
     const runtime = mockRuntime('not json');

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SkillDefinition } from '../config/schema.js';
 import type { Finding, UsageStats } from '../types/index.js';
+import { WardenAuthenticationError } from './errors.js';
 import { verifyFindings } from './verify.js';
-import { getRuntime, type Runtime } from './runtimes/index.js';
+import { getRuntime, type Runtime, type SkillRunResponse } from './runtimes/index.js';
 
 vi.mock('./runtimes/index.js', () => ({
   getRuntime: vi.fn(),
@@ -33,20 +34,44 @@ function makeUsage(): UsageStats {
   return { inputTokens: 10, outputTokens: 5, costUSD: 0.001 };
 }
 
-function mockRuntime(text: string): Runtime {
+function mockRuntimeResponse(response: SkillRunResponse): Runtime {
   return {
     name: 'claude',
-    runSkill: vi.fn().mockResolvedValue({
-      result: {
-        status: 'success',
-        text,
-        errors: [],
-        usage: makeUsage(),
-      },
-    }),
+    runSkill: vi.fn().mockResolvedValue(response),
     runAuxiliary: vi.fn(),
     runSynthesis: vi.fn(),
   } as unknown as Runtime;
+}
+
+function mockRuntime(text: string): Runtime {
+  return mockRuntimeResponse({
+    result: {
+      status: 'success',
+      text,
+      errors: [],
+      usage: makeUsage(),
+    },
+  });
+}
+
+function mockRuntimeError(error: unknown): Runtime {
+  return {
+    name: 'claude',
+    runSkill: vi.fn().mockRejectedValue(error),
+    runAuxiliary: vi.fn(),
+    runSynthesis: vi.fn(),
+  } as unknown as Runtime;
+}
+
+function makeErrorResult(errors: string[]): SkillRunResponse {
+  return {
+    result: {
+      status: 'provider_error',
+      text: '',
+      errors,
+      usage: makeUsage(),
+    },
+  };
 }
 
 describe('verifyFindings', () => {
@@ -132,6 +157,50 @@ describe('verifyFindings', () => {
     }));
   });
 
+  it('pins revised findings to the original validated anchor', async () => {
+    const revised = makeFinding({
+      id: 'DIFFERENT',
+      severity: 'medium',
+      title: 'Narrower issue',
+      location: { path: 'src/other.ts', startLine: 99 },
+      additionalLocations: [{ path: 'src/other.ts', startLine: 100 }],
+      suggestedFix: {
+        description: 'new fix',
+        diff: 'diff --git a/src/other.ts b/src/other.ts',
+      },
+    });
+    const runtime = mockRuntime(JSON.stringify({
+      verdict: 'revise',
+      finding: revised,
+      reason: 'impact is narrower',
+    }));
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const finding = makeFinding({
+      suggestedFix: {
+        description: 'original fix',
+        diff: 'diff --git a/src/app.ts b/src/app.ts',
+      },
+    });
+    const result = await verifyFindings([finding], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    const verified = result.findings[0];
+    expect(verified).toEqual(expect.objectContaining({
+      id: 'ABC-123',
+      severity: 'medium',
+      title: 'Narrower issue',
+      location: { path: 'src/app.ts', startLine: 10 },
+      suggestedFix: {
+        description: 'original fix',
+        diff: 'diff --git a/src/app.ts b/src/app.ts',
+      },
+    }));
+    expect(verified?.additionalLocations).toBeUndefined();
+  });
+
   it('accepts verifier JSON when verdict is not the first key', async () => {
     const runtime = mockRuntime('{"reason":"guarded upstream","verdict":"reject"}');
     vi.mocked(getRuntime).mockReturnValue(runtime);
@@ -155,5 +224,32 @@ describe('verifyFindings', () => {
     });
 
     expect(result.findings).toEqual([finding]);
+  });
+
+  it('propagates authentication errors reported by the verifier runtime', async () => {
+    vi.mocked(getRuntime).mockReturnValue(mockRuntimeResponse({ authError: 'login required' }));
+
+    await expect(verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    })).rejects.toBeInstanceOf(WardenAuthenticationError);
+  });
+
+  it('propagates authentication errors thrown by the verifier runtime', async () => {
+    vi.mocked(getRuntime).mockReturnValue(mockRuntimeError(new WardenAuthenticationError('bad key')));
+
+    await expect(verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    })).rejects.toBeInstanceOf(WardenAuthenticationError);
+  });
+
+  it('propagates authentication errors returned in verifier result errors', async () => {
+    vi.mocked(getRuntime).mockReturnValue(mockRuntimeResponse(makeErrorResult(['invalid api key'])));
+
+    await expect(verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    })).rejects.toBeInstanceOf(WardenAuthenticationError);
   });
 });

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -3,7 +3,19 @@ import type { SkillDefinition } from '../config/schema.js';
 import { FindingSchema, type Finding, type UsageStats } from '../types/index.js';
 import { aggregateUsage } from './usage.js';
 import { extractBalancedJson } from './extract.js';
-import { getRuntime, getRuntimeProviderOptions, type RuntimeName } from './runtimes/index.js';
+import {
+  WardenAuthenticationError,
+  classifyError,
+  isAuthenticationError,
+  isAuthenticationErrorMessage,
+  isSubprocessError,
+} from './errors.js';
+import {
+  getRuntime,
+  getRuntimeProviderOptions,
+  type RuntimeName,
+  type SkillRunResult,
+} from './runtimes/index.js';
 import type { FindingProcessingEvent } from './types.js';
 import {
   buildChangedFilesSection,
@@ -40,6 +52,10 @@ const VerificationVerdictSchema = z.object({
 type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
 
 const JSON_OBJECT_START = /\{/g;
+
+function isAbortRequested(error: unknown, abortController?: AbortController): boolean {
+  return (abortController?.signal.aborted ?? false) || classifyError(error).code === 'aborted';
+}
 
 function buildVerificationSystemPrompt(skill: SkillDefinition): string {
   return `<role>
@@ -116,7 +132,56 @@ function applyVerdict(finding: Finding, verdict: VerificationVerdict | null): Fi
     return finding;
   }
 
-  return { ...verdict.finding, id: finding.id };
+  // Verification runs after hunk validation, so revisions keep the original
+  // validated anchors and fix payload.
+  const revised = { ...verdict.finding, id: finding.id };
+
+  if (finding.location) {
+    revised.location = finding.location;
+  } else {
+    delete revised.location;
+  }
+
+  if (finding.additionalLocations) {
+    revised.additionalLocations = finding.additionalLocations;
+  } else {
+    delete revised.additionalLocations;
+  }
+
+  if (finding.suggestedFix) {
+    revised.suggestedFix = finding.suggestedFix;
+  } else {
+    delete revised.suggestedFix;
+  }
+
+  if (finding.elapsedMs !== undefined) {
+    revised.elapsedMs = finding.elapsedMs;
+  } else {
+    delete revised.elapsedMs;
+  }
+
+  const result = FindingSchema.safeParse(revised);
+  return result.success ? result.data : finding;
+}
+
+function throwIfAuthenticationFailure(
+  authError: string | undefined,
+  result: SkillRunResult | undefined
+): void {
+  if (authError) {
+    throw new WardenAuthenticationError(authError);
+  }
+
+  if (!result) return;
+
+  const authMessage = result.errors.find(isAuthenticationErrorMessage);
+  if (result.status === 'auth_error') {
+    throw new WardenAuthenticationError(authMessage);
+  }
+
+  if (authMessage) {
+    throw new WardenAuthenticationError();
+  }
 }
 
 function notifyVerdict(
@@ -172,7 +237,7 @@ export async function verifyFindings(
     }
 
     try {
-      const { result } = await runtime.runSkill({
+      const { result, authError } = await runtime.runSkill({
         systemPrompt,
         userPrompt: buildVerificationUserPrompt(finding, options.prContext),
         repoPath: options.repoPath,
@@ -187,6 +252,8 @@ export async function verifyFindings(
         }),
       });
 
+      throwIfAuthenticationFailure(authError, result);
+
       if (result?.usage) {
         usage.push(result.usage);
       }
@@ -199,7 +266,29 @@ export async function verifyFindings(
       if (next) {
         verified.push(next);
       }
-    } catch {
+    } catch (error) {
+      if (isAbortRequested(error, options.abortController)) {
+        verified.push(finding);
+        continue;
+      }
+
+      if (error instanceof WardenAuthenticationError) {
+        throw error;
+      }
+
+      if (isSubprocessError(error)) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new WardenAuthenticationError(
+          `Claude Code subprocess failed (${errorMessage}).\n` +
+          `This usually means the claude CLI cannot run in this environment.`,
+          { cause: error }
+        );
+      }
+
+      if (isAuthenticationError(error)) {
+        throw new WardenAuthenticationError(undefined, { cause: error });
+      }
+
       verified.push(finding);
     }
   }

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -17,6 +17,7 @@ import {
   type SkillRunResult,
 } from './runtimes/index.js';
 import type { FindingProcessingEvent } from './types.js';
+import { runPool } from '../utils/index.js';
 import {
   buildChangedFilesSection,
   buildJsonOutputSection,
@@ -52,6 +53,7 @@ const VerificationVerdictSchema = z.object({
 type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
 
 const JSON_OBJECT_START = /\{/g;
+const VERIFICATION_CONCURRENCY = 4;
 
 function isAbortRequested(error: unknown, abortController?: AbortController): boolean {
   return (abortController?.signal.aborted ?? false) || classifyError(error).code === 'aborted';
@@ -180,7 +182,7 @@ function throwIfAuthenticationFailure(
   }
 
   if (authMessage) {
-    throw new WardenAuthenticationError();
+    throw new WardenAuthenticationError(authMessage);
   }
 }
 
@@ -227,13 +229,10 @@ export async function verifyFindings(
   const runtimeName = options.runtime ?? 'claude';
   const runtime = getRuntime(runtimeName);
   const systemPrompt = buildVerificationSystemPrompt(options.skill);
-  const usage: UsageStats[] = [];
-  const verified: Finding[] = [];
 
-  for (const finding of findings) {
+  const results = await runPool(findings, VERIFICATION_CONCURRENCY, async (finding) => {
     if (options.abortController?.signal.aborted) {
-      verified.push(finding);
-      continue;
+      return { finding };
     }
 
     try {
@@ -254,22 +253,15 @@ export async function verifyFindings(
 
       throwIfAuthenticationFailure(authError, result);
 
-      if (result?.usage) {
-        usage.push(result.usage);
-      }
-
       const verdict = result?.status === 'success'
         ? parseVerificationVerdict(result.text)
         : null;
       const next = applyVerdict(finding, verdict);
       notifyVerdict(options, finding, verdict, next);
-      if (next) {
-        verified.push(next);
-      }
+      return { finding: next ?? undefined, usage: result?.usage };
     } catch (error) {
       if (isAbortRequested(error, options.abortController)) {
-        verified.push(finding);
-        continue;
+        return { finding };
       }
 
       if (error instanceof WardenAuthenticationError) {
@@ -289,9 +281,12 @@ export async function verifyFindings(
         throw new WardenAuthenticationError(undefined, { cause: error });
       }
 
-      verified.push(finding);
+      return { finding };
     }
-  }
+  });
+
+  const verified = results.flatMap((result) => result.finding ? [result.finding] : []);
+  const usage = results.map((result) => result.usage).filter((u): u is UsageStats => u !== undefined);
 
   return {
     findings: verified,

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -1,0 +1,206 @@
+import { z } from 'zod';
+import type { SkillDefinition } from '../config/schema.js';
+import { FindingSchema, type Finding, type UsageStats } from '../types/index.js';
+import { aggregateUsage } from './usage.js';
+import { extractBalancedJson } from './extract.js';
+import { getRuntime, getRuntimeProviderOptions, type RuntimeName } from './runtimes/index.js';
+import type { FindingProcessingEvent } from './types.js';
+import {
+  buildChangedFilesSection,
+  buildJsonOutputSection,
+  buildPullRequestContextSection,
+  buildTaggedSection,
+  joinPromptSections,
+  type PromptPRContext,
+} from './prompt-sections.js';
+
+export interface VerifyFindingsOptions {
+  repoPath: string;
+  skill: SkillDefinition;
+  runtime?: RuntimeName;
+  model?: string;
+  maxTurns?: number;
+  abortController?: AbortController;
+  pathToClaudeCodeExecutable?: string;
+  prContext?: PromptPRContext;
+  onFindingProcessing?: (event: FindingProcessingEvent) => void;
+}
+
+export interface VerifyFindingsResult {
+  findings: Finding[];
+  usage?: UsageStats;
+}
+
+const VerificationVerdictSchema = z.object({
+  verdict: z.enum(['keep', 'revise', 'reject']),
+  finding: FindingSchema.optional(),
+  reason: z.string().optional(),
+});
+
+type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
+
+const VERDICT_JSON_START = /\{\s*"verdict"/;
+
+function buildVerificationSystemPrompt(skill: SkillDefinition): string {
+  return `<role>
+You are Warden's finding verifier. You validate one candidate finding at a time.
+Your job is to deeply trace the code, look for mitigations and intent, then keep, revise, or reject the candidate.
+</role>
+
+<tools>
+Use read-only tools to inspect the repository. Read the reported file and use Grep/Glob to trace callers, imports, wrappers, guards, validators, and related code.
+</tools>
+
+<skill_instructions>
+The candidate was produced for this skill. Use these criteria as the only scope for verification:
+
+${skill.prompt}
+</skill_instructions>
+
+<verification_stance>
+- Keep findings only when the issue is still real after tracing.
+- Revise findings when the issue is real but the severity, confidence, title, description, or verification needs a narrower scope.
+- Reject findings when the path is mitigated, unreachable, intentional, outside skill scope, or not proven from the inspected code.
+- Prefer rejection or lower severity when reachability or impact depends on unproven assumptions.
+</verification_stance>
+
+${buildJsonOutputSection(`
+{"verdict":"keep|revise|reject","finding":{...},"reason":"short reason"}
+
+Use "finding" only for verdict "revise". For revised findings, return the complete Warden finding object and keep the original id.
+`)}`;
+}
+
+function buildVerificationUserPrompt(finding: Finding, prContext?: PromptPRContext): string {
+  return joinPromptSections([
+    buildPullRequestContextSection(prContext),
+    buildChangedFilesSection(prContext, finding.location?.path),
+    buildTaggedSection('candidate_finding', JSON.stringify(finding, null, 2)),
+    `<task>
+Verify this candidate. Return keep, revise, or reject.
+</task>`,
+  ]);
+}
+
+function parseVerificationVerdict(text: string): VerificationVerdict | null {
+  const match = text.match(VERDICT_JSON_START);
+  if (!match || match.index === undefined) return null;
+
+  const json = extractBalancedJson(text, match.index);
+  if (!json) return null;
+
+  try {
+    const parsed = JSON.parse(json);
+    const result = VerificationVerdictSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyVerdict(finding: Finding, verdict: VerificationVerdict | null): Finding | null {
+  if (!verdict || verdict.verdict === 'keep') {
+    return finding;
+  }
+
+  if (verdict.verdict === 'reject') {
+    return null;
+  }
+
+  if (!verdict.finding) {
+    return finding;
+  }
+
+  return { ...verdict.finding, id: finding.id };
+}
+
+function notifyVerdict(
+  options: VerifyFindingsOptions,
+  finding: Finding,
+  verdict: VerificationVerdict | null,
+  next: Finding | null
+): void {
+  if (!verdict) return;
+
+  if (verdict.verdict === 'reject') {
+    options.onFindingProcessing?.({
+      stage: 'verification',
+      action: 'rejected',
+      finding,
+      reason: verdict.reason,
+    });
+    return;
+  }
+
+  if (verdict.verdict === 'revise' && next) {
+    options.onFindingProcessing?.({
+      stage: 'verification',
+      action: 'revised',
+      finding,
+      replacement: next,
+      reason: verdict.reason,
+    });
+  }
+}
+
+/**
+ * Verify candidate findings with a second read-only repo-aware agent pass.
+ */
+export async function verifyFindings(
+  findings: Finding[],
+  options: VerifyFindingsOptions
+): Promise<VerifyFindingsResult> {
+  if (findings.length === 0) {
+    return { findings };
+  }
+
+  const runtimeName = options.runtime ?? 'claude';
+  const runtime = getRuntime(runtimeName);
+  const systemPrompt = buildVerificationSystemPrompt(options.skill);
+  const usage: UsageStats[] = [];
+  const verified: Finding[] = [];
+
+  for (const finding of findings) {
+    if (options.abortController?.signal.aborted) {
+      verified.push(finding);
+      continue;
+    }
+
+    try {
+      const { result } = await runtime.runSkill({
+        systemPrompt,
+        userPrompt: buildVerificationUserPrompt(finding, options.prContext),
+        repoPath: options.repoPath,
+        skillName: `${options.skill.name}:verification`,
+        options: {
+          model: options.model,
+          maxTurns: options.maxTurns,
+          abortController: options.abortController,
+        },
+        providerOptions: getRuntimeProviderOptions(runtimeName, {
+          pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+        }),
+      });
+
+      if (result?.usage) {
+        usage.push(result.usage);
+      }
+
+      const verdict = result?.status === 'success'
+        ? parseVerificationVerdict(result.text)
+        : null;
+      const next = applyVerdict(finding, verdict);
+      notifyVerdict(options, finding, verdict, next);
+      if (next) {
+        verified.push(next);
+      }
+    } catch {
+      verified.push(finding);
+    }
+  }
+
+  return {
+    findings: verified,
+    usage: usage.length > 0 ? aggregateUsage(usage) : undefined,
+  };
+}

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -246,6 +246,7 @@ export async function verifyFindings(
           maxTurns: options.maxTurns,
           abortController: options.abortController,
         },
+        tools: options.skill.tools,
         providerOptions: getRuntimeProviderOptions(runtimeName, {
           pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
         }),

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -52,6 +52,11 @@ const VerificationVerdictSchema = z.object({
 
 type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
 
+interface VerificationTaskResult {
+  finding?: Finding;
+  usage?: UsageStats;
+}
+
 const JSON_OBJECT_START = /\{/g;
 const VERIFICATION_CONCURRENCY = 4;
 
@@ -215,6 +220,20 @@ function notifyVerdict(
   }
 }
 
+function rejectUnverifiedFinding(
+  options: VerifyFindingsOptions,
+  finding: Finding,
+  reason: string
+): VerificationTaskResult {
+  options.onFindingProcessing?.({
+    stage: 'verification',
+    action: 'rejected',
+    finding,
+    reason,
+  });
+  return { finding: undefined };
+}
+
 /**
  * Verify candidate findings with a second read-only repo-aware agent pass.
  */
@@ -230,61 +249,65 @@ export async function verifyFindings(
   const runtime = getRuntime(runtimeName);
   const systemPrompt = buildVerificationSystemPrompt(options.skill);
 
-  const results = await runPool(findings, VERIFICATION_CONCURRENCY, async (finding) => {
-    if (options.abortController?.signal.aborted) {
-      return { finding };
-    }
+  const results = await runPool<Finding, VerificationTaskResult>(
+    findings,
+    VERIFICATION_CONCURRENCY,
+    async (finding) => {
+      if (options.abortController?.signal.aborted) {
+        return rejectUnverifiedFinding(options, finding, 'verification aborted before start');
+      }
 
-    try {
-      const { result, authError } = await runtime.runSkill({
-        systemPrompt,
-        userPrompt: buildVerificationUserPrompt(finding, options.prContext),
-        repoPath: options.repoPath,
-        skillName: `${options.skill.name}:verification`,
-        options: {
-          model: options.model,
-          maxTurns: options.maxTurns,
-          abortController: options.abortController,
-        },
-        tools: options.skill.tools,
-        providerOptions: getRuntimeProviderOptions(runtimeName, {
-          pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
-        }),
-      });
+      try {
+        const { result, authError } = await runtime.runSkill({
+          systemPrompt,
+          userPrompt: buildVerificationUserPrompt(finding, options.prContext),
+          repoPath: options.repoPath,
+          skillName: `${options.skill.name}:verification`,
+          options: {
+            model: options.model,
+            maxTurns: options.maxTurns,
+            abortController: options.abortController,
+          },
+          tools: options.skill.tools,
+          providerOptions: getRuntimeProviderOptions(runtimeName, {
+            pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+          }),
+        });
 
-      throwIfAuthenticationFailure(authError, result);
+        throwIfAuthenticationFailure(authError, result);
 
-      const verdict = result?.status === 'success'
-        ? parseVerificationVerdict(result.text)
-        : null;
-      const next = applyVerdict(finding, verdict);
-      notifyVerdict(options, finding, verdict, next);
-      return { finding: next ?? undefined, usage: result?.usage };
-    } catch (error) {
-      if (isAbortRequested(error, options.abortController)) {
+        const verdict = result?.status === 'success'
+          ? parseVerificationVerdict(result.text)
+          : null;
+        const next = applyVerdict(finding, verdict);
+        notifyVerdict(options, finding, verdict, next);
+        return { finding: next ?? undefined, usage: result?.usage };
+      } catch (error) {
+        if (isAbortRequested(error, options.abortController)) {
+          return rejectUnverifiedFinding(options, finding, 'verification aborted before verdict');
+        }
+
+        if (error instanceof WardenAuthenticationError) {
+          throw error;
+        }
+
+        if (isSubprocessError(error)) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          throw new WardenAuthenticationError(
+            `Claude Code subprocess failed (${errorMessage}).\n` +
+            `This usually means the claude CLI cannot run in this environment.`,
+            { cause: error }
+          );
+        }
+
+        if (isAuthenticationError(error)) {
+          throw new WardenAuthenticationError(undefined, { cause: error });
+        }
+
         return { finding };
       }
-
-      if (error instanceof WardenAuthenticationError) {
-        throw error;
-      }
-
-      if (isSubprocessError(error)) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        throw new WardenAuthenticationError(
-          `Claude Code subprocess failed (${errorMessage}).\n` +
-          `This usually means the claude CLI cannot run in this environment.`,
-          { cause: error }
-        );
-      }
-
-      if (isAuthenticationError(error)) {
-        throw new WardenAuthenticationError(undefined, { cause: error });
-      }
-
-      return { finding };
     }
-  });
+  );
 
   const verified = results.flatMap((result) => result.finding ? [result.finding] : []);
   const usage = results.map((result) => result.usage).filter((u): u is UsageStats => u !== undefined);

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -45,7 +45,7 @@ export interface VerifyFindingsResult {
 
 const VerificationVerdictSchema = z.object({
   verdict: z.enum(['keep', 'revise', 'reject']),
-  finding: FindingSchema.optional(),
+  finding: FindingSchema.nullish(),
   reason: z.string().optional(),
 });
 

--- a/src/sdk/verify.ts
+++ b/src/sdk/verify.ts
@@ -39,7 +39,7 @@ const VerificationVerdictSchema = z.object({
 
 type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
 
-const VERDICT_JSON_START = /\{\s*"verdict"/;
+const JSON_OBJECT_START = /\{/g;
 
 function buildVerificationSystemPrompt(skill: SkillDefinition): string {
   return `<role>
@@ -83,19 +83,24 @@ Verify this candidate. Return keep, revise, or reject.
 }
 
 function parseVerificationVerdict(text: string): VerificationVerdict | null {
-  const match = text.match(VERDICT_JSON_START);
-  if (!match || match.index === undefined) return null;
+  for (const match of text.matchAll(JSON_OBJECT_START)) {
+    if (match.index === undefined) continue;
 
-  const json = extractBalancedJson(text, match.index);
-  if (!json) return null;
+    const json = extractBalancedJson(text, match.index);
+    if (!json) continue;
 
-  try {
-    const parsed = JSON.parse(json);
-    const result = VerificationVerdictSchema.safeParse(parsed);
-    return result.success ? result.data : null;
-  } catch {
-    return null;
+    try {
+      const parsed = JSON.parse(json);
+      const result = VerificationVerdictSchema.safeParse(parsed);
+      if (result.success) {
+        return result.data;
+      }
+    } catch {
+      // Keep scanning in case prose or another object appears before the verdict.
+    }
   }
+
+  return null;
 }
 
 function applyVerdict(finding: Finding, verdict: VerificationVerdict | null): Finding | null {

--- a/src/skill-builder/agentic.ts
+++ b/src/skill-builder/agentic.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { ToolName } from '../config/schema.js';
 import type { UsageStats } from '../types/index.js';
 import { parseJsonFromOutput, type ParseJsonFromOutputResult } from '../sdk/json-output.js';
+import { buildJsonOutputSection, buildTaggedSection, joinPromptSections } from '../sdk/prompt-sections.js';
 import { aggregateUsage, emptyUsage } from '../sdk/usage.js';
 import type { Runtime, SkillRunResult } from '../sdk/runtimes/index.js';
 
@@ -111,22 +112,17 @@ function structuredRepairPrompt<T>(args: {
   output: string;
   reason: string;
 }): string {
-  return `Repair this model output into valid JSON that matches the provided JSON Schema.
-
-Rules:
-- Return JSON only.
-- Remove surrounding prose or markdown only when needed.
-- Preserve the original structured content as much as possible.
-- Do not invent extra fields.
-
-The local parser failed with:
-${args.reason}
-
-JSON Schema:
-${JSON.stringify(z.toJSONSchema(args.schema), null, 2)}
-
-Model output:
-${truncateForRepair(args.output)}`;
+  return joinPromptSections([
+    `<task>
+Repair this model output into valid JSON that matches the provided JSON Schema.
+</task>`,
+    buildJsonOutputSection(`Remove surrounding prose or markdown only when needed.
+Preserve the original structured content as much as possible.
+Do not invent extra fields.`),
+    buildTaggedSection('parse_error', args.reason),
+    buildTaggedSection('json_schema', JSON.stringify(z.toJSONSchema(args.schema), null, 2)),
+    buildTaggedSection('model_output', truncateForRepair(args.output)),
+  ]);
 }
 
 async function repairStructuredSkillBuilderOutput<T>(args: {


### PR DESCRIPTION
Add a default-on second pass that verifies candidate findings before they are reported. The verifier runs through the existing runtime abstraction with the auxiliary model, can keep/revise/reject findings, and can be disabled with `[defaults.verification] enabled = false`.

This also pulls duplicated prompt-section construction into shared helpers and moves SDK/CLI post-analysis work into one `postProcessFindings` pipeline so dedupe, verification, merge, and fix-gate behavior stay aligned. High-verbosity output now logs processing events such as dedupe drops, verification revisions/rejections, cross-location merges, and stripped suggested fixes.

Validated with `pnpm lint`, `pnpm run typecheck`, `pnpm build`, `pnpm test -- --maxWorkers=1`, and `pnpm test:evals`.