### PR TITLE
feat(skills): Add built-in security review skill

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@
 src/*
 !src/internal-skills/
 !src/internal-skills/**
+!src/builtin-skills/
+!src/builtin-skills/**
 
 # GitHub Action bundle (only needed for action, not npm)
 dist/action/

--- a/src/builtin-skills/security-review/SKILL.md
+++ b/src/builtin-skills/security-review/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: security-review
+description: Finds exploitable application security vulnerabilities in code changes. Use for Warden security scans, appsec review, OWASP-style checks, authentication or authorization bugs, injection, XSS, SSRF, path traversal, secrets, unsafe crypto, webhook verification, open redirects, or sensitive data exposure.
+allowed-tools: Read Grep Glob
+---
+
+You are a senior application security reviewer finding real, exploitable vulnerabilities in code changes for Warden's broad default security skill.
+Keep the review simple and high-signal: trace source, boundary, sink, mitigation, and impact before reporting.
+
+## References
+
+Load only matching references:
+
+| Reference | Read When |
+|-----------|-----------|
+| `references/javascript-typescript.md` | Reviewing JavaScript, TypeScript, Node, React, Next.js, or browser code |
+| `references/python.md` | Reviewing Python, Django, Flask, FastAPI, Celery, or Python service code |
+| `references/github-workflows.md` | Reviewing GitHub Actions workflows, local actions, reusable workflows, or workflow-loaded scripts/config |
+
+## Finding Requirements
+
+- Report a finding only when you can show attacker-controlled input, the vulnerable sink or missing guard, the security boundary, and concrete impact.
+- Identify attacker-controlled input: request bodies, query strings, path params, cookies, headers, uploads, webhooks, OAuth callbacks, third-party callbacks, user-written database values, and caller-controlled service inputs.
+- Identify the security boundary: login state, session, tenant, org, team, account, project, role, webhook signature, internal network, filesystem root, cache namespace, or paid quota.
+- Follow imports, wrappers, middleware, validators, serializers, auth helpers, route definitions, shared utilities, sibling handlers, and framework conventions before reporting.
+- Verify mitigations in the effective path. Parameterized queries, exact allowlists, safe URL fetchers, escaping, signature checks, handler-level auth, ownership checks, realpath containment, and quota controls can close the path.
+- Treat pattern matches as leads. A dangerous API is not a vulnerability unless untrusted data can reach it without an effective mitigation.
+- Prefer no finding over speculative hardening advice.
+
+## Investigation Process
+
+1. Read the changed hunk and target file enough to understand the effective execution path.
+2. Confirm the code is production-reachable. Return no findings for generated, vendored, test-only, fixture, example, migration, or build-output code unless it is actually shipped or invoked.
+3. Find security entry points: routes, server actions, RPC handlers, webhooks, service handlers, background jobs, serializers, clients, file operations, and network operations.
+4. Trace suspicious values from source to sink or missing guard.
+5. Read imported guards, validators, auth wrappers, schemas, middleware, shared utilities, and sibling handlers when they decide exploitability.
+6. Check whether mitigations block the real path, not just a nearby path.
+7. Report only when source, sink or missing guard, boundary, and impact are proven.
+
+## What To Report
+
+| Category | Report When |
+|----------|-------------|
+| Authentication | Login, session, token, OAuth, SSO, reset, webhook, or service identity checks can be bypassed, spoofed, replayed, or confused. |
+| Authorization | Tenant, org, team, account, project, role, owner, or resource checks are missing, inverted, stale, or performed on the wrong actor. |
+| Injection and RCE | User input reaches SQL/NoSQL, shell, template, eval, deserialization, expression, or dynamic import sinks without parameterization or allowlisting. |
+| XSS and unsafe HTML | User-controlled data reaches HTML, DOM, script, Markdown HTML, unsafe URLs, or framework escape hatches without context-correct escaping or sanitization. |
+| SSRF and redirects | User-controlled URLs, hosts, redirects, callbacks, proxies, or fetchers can reach internal services, metadata endpoints, or trusted redirect flows. |
+| Filesystem and uploads | User-controlled paths, archive entries, object keys, filenames, or uploads can escape an intended root, overwrite sensitive files, or become executable. |
+| Secrets and data exposure | Real credentials, tokens, private keys, signed URLs, auth headers, cookies, PII, stack traces, or internal fields are exposed to untrusted users, clients, or logs. |
+| Crypto and randomness | Weak hashes, predictable random values, static IVs, ECB mode, timing-unsafe compares, unsigned tokens, or custom crypto protect security-sensitive data. |
+| Abuse controls | Sensitive or expensive operations such as login, MFA, invites, exports, password reset, billing, email, SMS, or paid API calls lack meaningful rate, quota, replay, or idempotency controls. |
+| CI and workflows | Workflow changes let untrusted or caller-controlled code, text, artifacts, caches, or actions reach privileged execution, secrets, write tokens, releases, packages, deployments, or sensitive runners. |
+
+## Severity
+
+| Level | Use For |
+|-------|---------|
+| high | Broad auth bypass, privilege escalation, cross-tenant sensitive data access, RCE, SQL/NoSQL injection over sensitive data, SSRF to internal services or cloud metadata, unsafe deserialization, production credential exposure, privileged CI execution, or destructive unauthorized actions. |
+| medium | XSS with script execution, bounded path traversal, sensitive information disclosure, webhook side effects without verification, open redirects in auth/token flows, weak token validation, meaningful abuse of expensive or sensitive operations, or limited unauthorized data mutation. |
+| low | Concrete defense-in-depth flaw with a plausible exploit path and limited impact. Do not use low for vague best-practice advice. |
+
+- Tie-breaker: choose the lower severity when impact depends on unproven preconditions.
+
+## What Not To Report
+
+- Code fully mitigated by a verified guard in the effective path.
+- Sinks fed only by constants, trusted server-side values, test data, migrations, generated code, vendored code, examples, or build output.
+- Generic dependency CVEs unless the changed code makes the vulnerable behavior reachable.
+- Style, lint, maintainability, performance, missing comments, or generic best-practice recommendations.
+- Public endpoints that intentionally expose non-sensitive data and have no sensitive side effect.
+- Workflow style, actionlint issues, broad permissions, or mutable action refs without a traced path to execution, credential exposure, trusted artifacts, or privileged side effects.
+- Secret-looking placeholders such as `example`, `test`, `dummy`, documented fake keys, or values confined to tests.
+- Framework defaults that already escape, parameterize, validate, or authorize unless the code uses an unsafe escape hatch.
+
+## Finding Format
+
+- Title: name the vulnerability and impact.
+- Description: include source, sink or missing guard, boundary crossed, and attacker-visible consequence.
+- `verification`: list checked files, functions, guards, or sibling paths.
+- `suggestedFix`: include only when the fix is complete for the analyzed file.

--- a/src/builtin-skills/security-review/SPEC.md
+++ b/src/builtin-skills/security-review/SPEC.md
@@ -1,0 +1,77 @@
+# Security Review Skill Specification
+
+## Intent
+
+The `security-review` skill is Warden's broad default application security scanner. It gives teams a usable first-pass security review without importing benchmark prompts or requiring language-specific setup.
+
+It should catch common exploitable vulnerabilities in changed production code while avoiding noisy hardening advice.
+
+## Scope
+
+In scope:
+
+- Authentication, authorization, tenant isolation, identity, and service-boundary bugs.
+- Injection, RCE, unsafe deserialization, XSS, SSRF, path traversal, unsafe redirects, webhook verification, secrets exposure, weak crypto, sensitive data exposure, and meaningful abuse-control gaps.
+- General guidance that applies across web services and application code.
+- Focused notes for JavaScript/TypeScript, Python, and GitHub Actions workflows.
+
+Out of scope:
+
+- Full dependency CVE triage without reachable changed code.
+- Compliance checklists, infrastructure-only policy review, or exhaustive cloud IAM audits.
+- Style, maintainability, performance, or non-security correctness bugs.
+- Benchmark-specific prompt compatibility.
+- Large language-specific catalogs in `SKILL.md`.
+
+## Users And Trigger Context
+
+- Primary users: coding agents and Warden runs reviewing pull requests or local changes.
+- Should trigger for: "security review", "scan for vulnerabilities", "appsec review", "OWASP check", "auth bypass", "XSS", "SQL injection", "SSRF", "path traversal", "secret exposure", or equivalent security-focused review requests.
+- Should not trigger for: generic code review, prompt-writing help, Warden CLI usage, or broad architecture review with no security focus.
+
+## Runtime Contract
+
+- Required first actions:
+  - Identify whether changed files are production code or test/generated/vendor/example code.
+  - Read the target file and any guards, helpers, middleware, validators, serializers, or sibling handlers needed to prove the path.
+  - Load only the matching language reference when it materially improves the review.
+- Required finding evidence:
+  - attacker-controlled source
+  - vulnerable sink or missing guard
+  - crossed security boundary
+  - concrete attacker-visible impact
+  - verification details naming checked files/functions
+- Required outputs:
+  - Warden findings only for high-confidence vulnerabilities.
+  - Empty findings when exploitability is not proven.
+- Non-negotiable constraints:
+  - Do not report pattern-only suspicions.
+  - Do not lower the bar to create coverage.
+  - Do not add language-specific examples to `SKILL.md`; route them to `references/`.
+
+## Reference Architecture
+
+- `SKILL.md` contains the broad review contract, category table, severity rubric, exclusions, and reference routing.
+- `references/javascript-typescript.md` contains JS/TS/Node/React/Next-specific examples and false-positive controls.
+- `references/python.md` contains Python/Django/Flask/FastAPI-specific examples and false-positive controls.
+- `references/github-workflows.md` contains GitHub Actions workflow examples and false-positive controls.
+- `scripts/`, `assets/`, and `references/evidence/` are unused until repeated evidence warrants them.
+
+## Evaluation
+
+- Lightweight validation:
+  - Run the skill validator against `src/builtin-skills/security-review`.
+  - Verify every reference is directly routed from `SKILL.md`.
+  - Run init command tests that install bundled skills.
+- Deeper evaluation:
+  - Add eval cases for SQL injection, XSS, SSRF, authz bypass, secrets, and safe counterexamples.
+  - Compare false positives against sanitized real Warden runs.
+- Acceptance gates:
+  - `SKILL.md` stays concise enough to scan.
+  - Language-specific examples stay in references.
+  - Findings require exploitability evidence, not keyword matches.
+
+## Maintenance Notes
+
+- Add a new language reference only when recurring findings need language-specific calibration.
+- Keep examples minimal and transformed; do not store proprietary code.

--- a/src/builtin-skills/security-review/references/github-workflows.md
+++ b/src/builtin-skills/security-review/references/github-workflows.md
@@ -1,35 +1,126 @@
 # GitHub Workflow Security Notes
 
-Use this when reviewing GitHub Actions workflows, local actions, reusable workflows, or scripts/config loaded by workflows. These examples refine the core skill; they do not add new reporting scope.
+Use this when reviewing GitHub Actions workflows, local actions, reusable workflows, or scripts/config loaded by workflows. This reference adapts the dedicated workflow-security prior art for the broad `security-review` skill; keep findings exploit-oriented, not style-oriented.
 
-## Entry Points
+## Contents
 
-- Review `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `.github/actions/**/action.yml`, `.github/actions/**/action.yaml`, `action.yml`, and `action.yaml`.
-- Follow `uses: ./.github/actions/...`, reusable workflows, composite actions, scripts, Makefiles, package commands, artifacts, and caches.
-- Start from the trigger: `pull_request`, `pull_request_target`, `workflow_run`, `workflow_dispatch`, `workflow_call`, `issue_comment`, labels, discussions, schedules, and pushes.
-- Map who controls code/text: fork PRs, comments, titles, branch names, changed filenames, artifacts, caches, manual inputs, reusable inputs, and checked-out refs.
+- [Review Map](#review-map)
+- [Reportable Patterns](#reportable-patterns)
+- [False-Positive Controls](#false-positive-controls)
+- [Verification Checklist](#verification-checklist)
+- [Minimal Examples](#minimal-examples)
 
-## High-Signal Patterns
+## Review Map
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Pwn request | `pull_request_target` checks out `github.event.pull_request.head.sha` and runs install/test/build/local actions | Use `pull_request` for untrusted code or keep `pull_request_target` metadata-only |
-| Expression injection | `${{ github.event.* }}` or `${{ inputs.* }}` inside `run:`, `bash -c`, `node -e`, `python -c`, or `actions/github-script` | Put value in `env:`, read native variable, quote/validate before use |
-| Manual/reusable input RCE | free-form `workflow_dispatch`/`workflow_call` input reaches release, deploy, publish, signing, PR creation, OIDC, PAT, or secret-bearing shell | Use finite input types, allowlists, argv APIs, and least privilege |
-| Comment command abuse | `issue_comment` or label workflow executes commands without member/team approval, or checks out latest PR head after approval | Verify actor and pin the approved SHA |
-| Artifact/cache trust | privileged `workflow_run`, release, or deploy job executes artifacts/caches from untrusted PR jobs | Treat artifacts as data; validate, sign, partition cache scopes |
-| Artifact secret leak | `upload-artifact` uploads workspace/root after checkout with persisted credentials or secret files | Upload only build outputs; set `persist-credentials: false`; exclude `.git/` and credential files |
-| Self-hosted runner | PR-reachable job runs untrusted code on persistent/internal/self-hosted runner | Keep untrusted PRs on GitHub-hosted runners or require a strong approval gate |
-| Mutable action supply chain | third-party `uses: owner/action@tag` in job with secrets, OIDC, write token, deploy, release, or package power | Pin third-party actions to full commit SHA |
+Start with the effective execution graph:
+
+1. Identify the trigger: `pull_request`, `pull_request_target`, `workflow_run`, `workflow_dispatch`, `workflow_call`, `issue_comment`, `discussion`, `label`, `push`, `release`, or `schedule`.
+2. Mark who controls each input: fork PR code, PR title/body, branch names, changed filenames, comments, labels, discussion text, manual inputs, reusable-workflow inputs, artifacts, caches, local actions, and checked-out refs.
+3. Follow every boundary: `uses: ./.github/actions/...`, `uses: ./.github/workflows/...`, composite action steps, repo-local scripts, Makefiles, package commands, artifacts, caches, and downloaded tools.
+4. Mark privileges at the point of execution: `secrets.*`, PATs, deploy keys, registry tokens, `id-token: write`, `GITHUB_TOKEN` write scopes, release/package/deploy authority, and self-hosted runners.
+5. Report only when untrusted or caller-controlled code/data reaches privileged execution, credentials, trusted artifacts, releases/packages/deployments, or sensitive runners.
+
+In-scope files include `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `.github/actions/**/action.yml`, `.github/actions/**/action.yaml`, repository-root `action.yml`/`action.yaml`, and any scripts/config files loaded by those workflows.
+
+## Reportable Patterns
+
+| Pattern | Report When | Safer Shape |
+|---------|-------------|-------------|
+| Privileged PR checkout | `pull_request_target`, privileged `workflow_run`, or similar trusted context checks out, imports, builds, tests, or executes PR-controlled refs while trusted tokens/secrets are available | Use `pull_request` for untrusted code, or keep `pull_request_target` metadata-only |
+| Expression injection | Attacker/caller-controlled `${{ }}` reaches `run:`, composite shell steps, `bash -c`, `node -e`, `python -c`, `actions/github-script`, `actions/script`, or workflow command files | Move values to `env:`, read native variables, quote/validate, and avoid interpreter strings |
+| Manual or reusable input RCE | Free-form `workflow_dispatch` or `workflow_call` input reaches release, deploy, publish, signing, PR creation, OIDC, PAT, or secret-bearing commands | Use finite input types, allowlists, argv APIs, and least privilege |
+| Comment/chatops abuse | `issue_comment`, discussion, label, or slash-command workflows execute privileged commands without a trusted actor gate, or use comment text as shell/script input | Verify owner/member/collaborator/team permission and parse arguments as data |
+| Approval TOCTOU | Maintainer approval occurs, then the workflow re-resolves `pull_request.head.sha`, `head_ref`, or PR refs at run time before privileged checkout/execution | Pin the exact SHA approved by the maintainer, or require re-approval after every push |
+| Reusable/local action trust crossing | Caller grants secrets/write scopes while a callee or local composite action executes caller-controlled inputs or PR-controlled files | Pass narrow secrets, define callee permissions, validate inputs, keep local actions on trusted code |
+| Artifact/cache trust crossing | Privileged `workflow_run`, release, or deploy job executes or trusts artifacts/caches produced by untrusted PR jobs | Treat artifacts/caches as untrusted data; validate, sign, or partition trust scopes |
+| Artifact credential leak | `upload-artifact` uploads the workspace/root, `.git/`, home credential files, Docker/npm config, or similar after credentials were written | Upload only build outputs; set `persist-credentials: false`; exclude credential paths |
+| Self-hosted runner exposure | PR-reachable or comment-triggered jobs run untrusted code on persistent, internal, signing, deploy, or otherwise sensitive self-hosted runners | Keep untrusted code on GitHub-hosted runners or require a strong approval gate |
+| Mutable action supply chain | Third-party `uses: owner/action@tag`, branch, partial SHA, or mutable reusable workflow runs in a job with secrets, OIDC, write token, release, deploy, package, or signing power | Pin third-party actions and reusable workflows to a 40-character commit SHA |
+| AI agent config poisoning | Privileged workflows run coding/review agents on PR-controlled checkouts or instruction files such as `AGENTS.md`, `CLAUDE.md`, or Copilot instructions | Run agents in unprivileged PR context, protect instruction files, and avoid write/secrets in poisoned contexts |
+
+### Expression Injection Sources
+
+Treat these as untrusted when the trigger is externally reachable, manually triggerable, or callable:
+
+- PR title/body, issue title/body, comment body, review body, discussion title/body, label names, branch names, commit messages, changed filenames, and changed-file lists.
+- `inputs.*` and `github.event.inputs.*` from `workflow_dispatch`.
+- `inputs.*` from `workflow_call`, including values passed through visible caller workflows.
+- Action outputs or env vars derived from the values above.
+
+Usually not injectable by themselves: PR numbers, numeric IDs, full commit SHAs, booleans, base-repository constants, and hardcoded shell-safe `choice` inputs. Re-check them if later code reinterprets the value as shell, JavaScript, Python, package-manager flags, or another code-like language.
+
+Dangerous sinks include:
+
+- `run: echo "${{ github.event.pull_request.title }}"`
+- `actions/github-script` or `actions/script` `script:` bodies containing `${{ github.event.* }}` or `${{ inputs.* }}`
+- `echo "key=${{ github.event.comment.body }}" >> $GITHUB_OUTPUT`, `$GITHUB_ENV`, `$GITHUB_STEP_SUMMARY`, or `$GITHUB_PATH`
+- `npx semver -i ${{ inputs.bump }} "$CURRENT"`, `gh pr create --fill ${{ inputs.pr_options }}`, `docker build -t ${{ inputs.tag }}`, `git checkout ${{ inputs.ref }}`
+- Composite action shell steps that interpolate `${{ inputs.* }}` from an externally reachable caller
+
+### Privileged PR Context
+
+High-signal indicators:
+
+- `on: pull_request_target` plus `actions/checkout` with `ref: ${{ github.event.pull_request.head.sha }}`, `github.head_ref`, `github.event.pull_request.head.ref`, `repository: ${{ github.event.pull_request.head.repo.full_name }}`, `refs/pull/...`, or custom `git fetch` of PR refs.
+- Build/test/package commands after PR checkout: `npm install`, `pnpm install`, `npm test`, `pip install`, `tox`, `pytest`, `make`, `cargo`, `go test`, `bundle`, `gradle`, `mvn`.
+- Local actions, scripts, Makefiles, package lifecycle hooks, or config files loaded from the PR checkout.
+- `persist-credentials` omitted or true before untrusted code runs.
+- Write scopes, secrets, OIDC, package publishing, release creation, deployments, or agent write access available in the same job.
+
+Do not report `pull_request_target` that only labels, comments, or reads metadata without checking out or loading PR-controlled files.
+
+### Reusable Workflows, Artifacts, Caches, And Credentials
+
+Trace cross-file flows before reporting:
+
+- `workflow_call` callers that pass secrets/write permissions into a callee that executes caller-controlled inputs.
+- Reusable workflows that reference `secrets.X` without declaring `X` under `on.workflow_call.secrets`, other than `GITHUB_TOKEN`; this hides the secret surface and pressures callers into `secrets: inherit`.
+- Reusable workflows without top-level or job-level `permissions:` when the callee needs a narrower scope than callers commonly grant.
+- `workflow_run` jobs that download artifacts from untrusted PR workflows and execute scripts, import code, publish packages, or make trusted comments without validation.
+- Caches shared from untrusted PR jobs into privileged jobs, including eviction-and-replace poisoning of expected cache keys.
+- `actions/upload-artifact` whose `path:` includes `.`, `./`, `${{ github.workspace }}`, `.git/`, `~/.docker/config.json`, `~/.npmrc`, `~/.gitconfig`, `~/.aws/credentials`, or other credential-bearing paths after checkout/login/setup steps.
+- `id-token: write` where untrusted refs can satisfy visible cloud OIDC trust policies.
+
+Permissions and secrets are amplifiers. Tie them to the untrusted execution or leak path.
+
+### Mutable Action References
+
+Report mutable third-party actions only when job privilege makes compromise security-relevant. CVE-2025-30066 (`tj-actions/changed-files`) and related 2025 supply-chain incidents showed that tag rewrites can leak secrets at scale.
+
+Severity guide:
+
+| Shape | Severity |
+|-------|----------|
+| Mutable third-party ref in package publishing, release signing, protected-branch push, production deploy, or token-minting job | high |
+| Mutable third-party ref with secrets, OIDC, or non-trivial write-scoped `GITHUB_TOKEN` | medium |
+| Pinned action that downloads and executes mutable remote scripts in a privileged job | medium, or high when the downloaded payload runs inside the privileged step |
+| Mutable third-party ref in public read-only CI with no secrets and no write scopes | no finding unless adjacent to another traced workflow risk |
+
+First-party `actions/*` and `github/*` actions on version tags are not findings by themselves. Same-repo or vendored actions are not third-party supply-chain findings, but can still be unsafe if they are loaded from PR-controlled checkouts.
 
 ## False-Positive Controls
 
-- `pull_request_target` with default checkout of base code and metadata-only steps is not a pwn request.
-- Plain `pull_request` normally has restricted token and no base secrets for forks; trace downstream artifacts before reporting.
-- `${{ }}` in `if:`, ordinary `with:`, or `env:` is not a sink unless later interpreted by shell/script/action code. `actions/github-script` `script:` is a code sink.
-- Numeric IDs, full SHAs, booleans, base-repo constants, and hardcoded shell-safe `choice` inputs are usually not injectable.
-- Broad `permissions:` alone is an amplifier. Report only with a path to untrusted execution, credential exposure, artifact trust, or privileged side effect.
-- First-party `actions/*` and `github/*` refs on tags are not mutable-action findings by themselves.
+- Broad `permissions:` alone is not a vulnerability. Report it only as part of untrusted execution, credential exposure, artifact trust, or privileged side effect.
+- Plain `pull_request` normally has restricted token and no base secrets for forks. Trace downstream artifacts/caches before escalating.
+- `${{ }}` in `if:`, ordinary `with:`, or `env:` is not a sink unless the receiving action or a later shell/script interprets it as code. `actions/github-script` `with: script:` is a code sink.
+- `env:` is only safe when the later shell/script uses native variables with quoting or validation. `echo '${{ env.BODY }}'` is still expression expansion.
+- Hardcoded `choice`, `boolean`, `number`, and `environment` workflow inputs are usually safe when used only in `if:`, ordinary `with:`, or safely quoted `env:` contexts.
+- Comment/body parsing is not a bug unless it triggers meaningful execution or privileged state change.
+- `CONTRIBUTOR` is not equivalent to `MEMBER`, `OWNER`, or `COLLABORATOR` for chatops authorization.
+- `persist-credentials: false` reduces `.git/config` token theft, but does not protect unrelated secrets, PATs, OIDC, or registry credentials.
+- Do not invent external action internals. If source is unavailable, report the unresolved trust assumption as medium confidence at most.
+
+## Verification Checklist
+
+Before reporting:
+
+1. Confirm the trigger can be reached by the attacker or lower-privileged caller you name.
+2. Identify the exact attacker-controlled or caller-controlled value.
+3. Identify the sink: shell/script execution, local action, package lifecycle hook, artifact/cache trust, credential-bearing upload, mutable action, or sensitive runner.
+4. Follow local actions, reusable workflows, scripts, package commands, and workflow-produced artifacts/caches.
+5. Confirm secrets, token scopes, OIDC, deploy/release/package authority, or runner sensitivity at the sink.
+6. Check actor gates, branch/fork guards, finite input types, SHA pinning, `persist-credentials: false`, artifact path narrowing, and cloud trust-policy constraints.
+7. Anchor the finding to the changed workflow line, and name the crossed boundary plus concrete impact.
 
 ## Minimal Examples
 
@@ -45,23 +136,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: npm install
-      - run: npm test
+      - run: pnpm install
+      - run: pnpm test
 ```
 
-Risk: fork controls package scripts and test code. Require: unprivileged trigger or no PR-controlled checkout under trusted token/secrets.
+Risk: fork code controls package scripts while the job has trusted-repository permissions.
 
-**Report: expression injection**
+**Report: github-script injection**
 
 ```yaml
-on: issue_comment
+on: issues
 jobs:
-  triage:
+  comment:
     steps:
-      - run: echo "${{ github.event.comment.body }}" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              body: `hello ${{ github.event.issue.title }}`
+            })
 ```
 
-Risk: comment body is parsed by shell and GitHub output file format. Require: env variable plus safe quoting or structured parsing.
+Risk: the issue title is expanded into JavaScript before `actions/github-script` runs.
 
 **Report: workspace artifact leak**
 
@@ -73,7 +169,7 @@ steps:
       path: .
 ```
 
-Risk: `.git/config` can contain persisted credentials. Require: `persist-credentials: false` and narrow artifact paths.
+Risk: `.git/config` can contain persisted checkout credentials, and public-repo artifacts can expose them.
 
 **Do not report: metadata-only target workflow**
 
@@ -87,4 +183,4 @@ jobs:
       - run: gh pr edit "$PR" --add-label needs-review
 ```
 
-No PR-controlled code or text reaches execution. Broad token is not enough without the exploit path.
+No PR-controlled code or text reaches execution. Broad token scope alone is not enough.

--- a/src/builtin-skills/security-review/references/github-workflows.md
+++ b/src/builtin-skills/security-review/references/github-workflows.md
@@ -1,0 +1,90 @@
+# GitHub Workflow Security Notes
+
+Use this when reviewing GitHub Actions workflows, local actions, reusable workflows, or scripts/config loaded by workflows. These examples refine the core skill; they do not add new reporting scope.
+
+## Entry Points
+
+- Review `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `.github/actions/**/action.yml`, `.github/actions/**/action.yaml`, `action.yml`, and `action.yaml`.
+- Follow `uses: ./.github/actions/...`, reusable workflows, composite actions, scripts, Makefiles, package commands, artifacts, and caches.
+- Start from the trigger: `pull_request`, `pull_request_target`, `workflow_run`, `workflow_dispatch`, `workflow_call`, `issue_comment`, labels, discussions, schedules, and pushes.
+- Map who controls code/text: fork PRs, comments, titles, branch names, changed filenames, artifacts, caches, manual inputs, reusable inputs, and checked-out refs.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Pwn request | `pull_request_target` checks out `github.event.pull_request.head.sha` and runs install/test/build/local actions | Use `pull_request` for untrusted code or keep `pull_request_target` metadata-only |
+| Expression injection | `${{ github.event.* }}` or `${{ inputs.* }}` inside `run:`, `bash -c`, `node -e`, `python -c`, or `actions/github-script` | Put value in `env:`, read native variable, quote/validate before use |
+| Manual/reusable input RCE | free-form `workflow_dispatch`/`workflow_call` input reaches release, deploy, publish, signing, PR creation, OIDC, PAT, or secret-bearing shell | Use finite input types, allowlists, argv APIs, and least privilege |
+| Comment command abuse | `issue_comment` or label workflow executes commands without member/team approval, or checks out latest PR head after approval | Verify actor and pin the approved SHA |
+| Artifact/cache trust | privileged `workflow_run`, release, or deploy job executes artifacts/caches from untrusted PR jobs | Treat artifacts as data; validate, sign, partition cache scopes |
+| Artifact secret leak | `upload-artifact` uploads workspace/root after checkout with persisted credentials or secret files | Upload only build outputs; set `persist-credentials: false`; exclude `.git/` and credential files |
+| Self-hosted runner | PR-reachable job runs untrusted code on persistent/internal/self-hosted runner | Keep untrusted PRs on GitHub-hosted runners or require a strong approval gate |
+| Mutable action supply chain | third-party `uses: owner/action@tag` in job with secrets, OIDC, write token, deploy, release, or package power | Pin third-party actions to full commit SHA |
+
+## False-Positive Controls
+
+- `pull_request_target` with default checkout of base code and metadata-only steps is not a pwn request.
+- Plain `pull_request` normally has restricted token and no base secrets for forks; trace downstream artifacts before reporting.
+- `${{ }}` in `if:`, ordinary `with:`, or `env:` is not a sink unless later interpreted by shell/script/action code. `actions/github-script` `script:` is a code sink.
+- Numeric IDs, full SHAs, booleans, base-repo constants, and hardcoded shell-safe `choice` inputs are usually not injectable.
+- Broad `permissions:` alone is an amplifier. Report only with a path to untrusted execution, credential exposure, artifact trust, or privileged side effect.
+- First-party `actions/*` and `github/*` refs on tags are not mutable-action findings by themselves.
+
+## Minimal Examples
+
+**Report: privileged PR checkout**
+
+```yaml
+on: pull_request_target
+permissions: write-all
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install
+      - run: npm test
+```
+
+Risk: fork controls package scripts and test code. Require: unprivileged trigger or no PR-controlled checkout under trusted token/secrets.
+
+**Report: expression injection**
+
+```yaml
+on: issue_comment
+jobs:
+  triage:
+    steps:
+      - run: echo "${{ github.event.comment.body }}" >> $GITHUB_OUTPUT
+```
+
+Risk: comment body is parsed by shell and GitHub output file format. Require: env variable plus safe quoting or structured parsing.
+
+**Report: workspace artifact leak**
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: actions/upload-artifact@v4
+    with:
+      path: .
+```
+
+Risk: `.git/config` can contain persisted credentials. Require: `persist-credentials: false` and narrow artifact paths.
+
+**Do not report: metadata-only target workflow**
+
+```yaml
+on: pull_request_target
+permissions:
+  pull-requests: write
+jobs:
+  label:
+    steps:
+      - run: gh pr edit "$PR" --add-label needs-review
+```
+
+No PR-controlled code or text reaches execution. Broad token is not enough without the exploit path.

--- a/src/builtin-skills/security-review/references/javascript-typescript.md
+++ b/src/builtin-skills/security-review/references/javascript-typescript.md
@@ -1,0 +1,69 @@
+# JavaScript And TypeScript Security Notes
+
+Use this when reviewing JavaScript, TypeScript, Node, React, Next.js, or browser code. These examples refine the core skill; they do not add new reporting scope.
+
+## Server-Side Entry Points
+
+- Next.js route handlers, Server Actions, API routes, tRPC/RPC handlers, Express/Fastify/Koa routes, webhook handlers, queue consumers, and CLI/service functions can be security boundaries.
+- Treat Server Actions as callable server entry points. UI visibility, hidden form fields, and client components are not authorization.
+- Next.js `middleware.ts` is not enough proof of authorization for sensitive mutations. Verify handler-level auth and resource-level authorization.
+- For service handlers, do not trust caller-controlled headers such as `x-user-id`, `x-org-id`, `x-forwarded-*`, or internal-only flags unless a trusted gateway verifies them.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Server Action authz | `"use server"` mutation trusts `userId`, `teamId`, `role`, hidden fields, or form args | Load session in the action, scope by server-side tenant, enforce permission |
+| SQL injection | `prisma.$queryRawUnsafe(\`...${id}\`)`, string-built SQL, concatenated `where` clauses | Tagged templates, query parameters, ORM filters scoped to the authenticated tenant |
+| Command injection | `exec("git " + branch)`, `spawn(cmd, args, {shell: true})` with user input | `execFile`/`spawn` with fixed binary, fixed argument positions, and strict allowlists |
+| XSS | `innerHTML`, `dangerouslySetInnerHTML`, `unsafeHTML`, unsafe Markdown HTML, inline script JSON with user data | Text rendering, vetted sanitizer, escaping `<` in inline JSON, no dangerous URL schemes |
+| SSRF | `fetch(req.query.url)`, image/preview/proxy fetchers using user URLs, redirect-following after first-hop validation | Exact host allowlist, private-IP blocking, DNS rebinding defenses, redirect revalidation or manual redirects |
+| Open redirect | `redirect(searchParams.get("next"))`, prefix/substring URL checks in login or OAuth flows | Relative-path allowlist or exact origin/path allowlist after URL normalization |
+| Path traversal | `path.join(root, userPath)` without realpath containment, archive extraction by entry name | Normalize and resolve real paths, verify containment, generate server-side filenames |
+| Webhook forgery | State-changing webhook parses JSON before verifying signature or skips timestamp/replay checks | Verify raw body signature, timestamp freshness, replay/idempotency, and provider secret before side effects |
+| Secrets exposure | Secrets in client components, `NEXT_PUBLIC_*`, serialized props, logs, or error responses | Server-only reads, redacted logs, safe error messages, no hardcoded production fallback |
+
+## False-Positive Controls
+
+- React text interpolation escapes by default. Report only escape hatches or dangerous URL/script contexts.
+- Prisma/Drizzle/Knex query builders can parameterize values. Verify the specific API before reporting SQL injection.
+- `crypto.randomUUID()` and `crypto.getRandomValues()` are suitable for security randomness; `Math.random()` is not.
+- `jsonwebtoken.verify` can be safe when algorithms, issuer/audience, expiry, and key selection are pinned appropriately.
+- DOMPurify or equivalent sanitizers can mitigate HTML injection when configured for the target context.
+
+## Minimal Examples
+
+**Report: cross-tenant lookup**
+
+```ts
+const invoice = await db.invoice.findUnique({ where: { id: params.invoiceId } });
+```
+
+Require: server-derived tenant scope such as `accountId: session.accountId`, plus permission checks.
+
+**Report: Server Action trusts caller fields**
+
+```ts
+"use server";
+export async function setRole(userId: string, role: string) {
+  await db.user.update({ where: { id: userId }, data: { role } });
+}
+```
+
+Require: load session in the action and prove caller can mutate that tenant user.
+
+**Report: inline JSON script breakout**
+
+```tsx
+<script dangerouslySetInnerHTML={{ __html: `window.__DATA__=${JSON.stringify(data)}` }} />
+```
+
+Risk: `</script>` breakout. Require: escape `<` or `</script` before embedding.
+
+**Do not report: parameterized query**
+
+```ts
+await db.$queryRaw`SELECT * FROM invoices WHERE id = ${invoiceId} AND account_id = ${accountId}`;
+```
+
+This is not SQL injection if the tagged template parameterizes values and `accountId` is trusted from the authenticated session.

--- a/src/builtin-skills/security-review/references/python.md
+++ b/src/builtin-skills/security-review/references/python.md
@@ -1,0 +1,70 @@
+# Python Security Notes
+
+Use this when reviewing Python, Django, Flask, FastAPI, Celery, or Python service code. These examples refine the core skill; they do not add new reporting scope.
+
+## Server-Side Entry Points
+
+- Django views, DRF viewsets, Flask/FastAPI routes, GraphQL resolvers, webhook handlers, Celery tasks, management commands, and service-layer functions can cross trust boundaries.
+- For background jobs and tasks, verify the caller, queue, payload signing, tenant context, and idempotency before assuming input is trusted.
+- Decorators can prove authentication only if they wrap the effective handler. Still verify object-level authorization.
+- DRF/FastAPI auth dependencies prove identity, not ownership of route params or body IDs.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| SQL injection | `cursor.execute(f"...{request.GET['q']}...")`, string-built raw SQL | Parameterized queries, ORM filters, strict enum allowlists for identifiers |
+| Command injection | `os.system`, `subprocess.run(..., shell=True)`, shell strings with request data | `subprocess.run([fixed_binary, fixed_arg])`, strict allowlists, no shell |
+| Path traversal | `open(base / request.args["name"])`, `send_file(user_path)`, unsafe archive extraction | `Path.resolve()` containment checks, generated filenames, safe storage APIs |
+| SSRF | `requests.get(request.GET["url"])`, preview/proxy fetchers, redirect-following after first-hop validation | Exact host allowlist, block private/link-local IPs, disable or revalidate redirects |
+| Open redirect | `redirect(request.GET["next"])`, login/callback redirects with weak host checks | Relative-path allowlist or framework helper with exact allowed hosts |
+| Unsafe deserialization | `pickle.loads`, `yaml.load` without `SafeLoader`, model/job loaders on uploaded data | JSON or typed schemas, `yaml.safe_load`, signed trusted artifacts only |
+| XSS | Jinja/Django `|safe`, `Markup`, disabled autoescape, raw HTML from user content | Autoescaping, vetted sanitizer, context-correct escaping |
+| Authz bypass | `Model.objects.get(id=request.GET["id"])` on tenant data | Scope by authenticated user/org/account and enforce permissions before returning or mutating |
+| Task trust confusion | Celery task mutates `invoice_id`, `user_id`, or `account_id` queued from a request without rechecking scope | Pass server-derived actor/tenant context and re-check before mutation |
+| Secrets exposure | Logging tokens, cookies, auth headers, signed URLs, stack traces, or env secrets | Redacted logging, generic errors, server-only secret access |
+
+## False-Positive Controls
+
+- Django and SQLAlchemy ORM filters usually parameterize values. Raw SQL and string-built identifiers need closer review.
+- Django and Jinja autoescape ordinary template interpolation by default. Report only unsafe filters, raw HTML, or disabled autoescape.
+- `secrets` and `os.urandom` are suitable for security randomness; `random` is not.
+- `yaml.safe_load` is the safe default for untrusted YAML; `yaml.load` may still be safe only when an explicit safe loader is used.
+- `Path.resolve()` containment checks can mitigate traversal when they compare the resolved child against the resolved allowed root.
+
+## Minimal Examples
+
+**Report: object-level authorization bypass**
+
+```python
+invoice = Invoice.objects.get(id=request.GET["invoice_id"])
+return JsonResponse({"total": invoice.total, "email": invoice.customer.email})
+```
+
+Require: authenticated account/org scope and permission before returning sensitive data.
+
+**Report: task loses tenant context**
+
+```python
+@shared_task
+def approve_invoice(invoice_id: str):
+    Invoice.objects.filter(id=invoice_id).update(status="approved")
+```
+
+Require: reload trusted actor/tenant context and enforce permission.
+
+**Report: unsafe uploaded state**
+
+```python
+state = pickle.loads(base64.b64decode(request.POST["state"]))
+```
+
+Risk: unsafe deserialization. Require: trusted, signature-verified artifact before deserialization.
+
+**Do not report: scoped ORM query**
+
+```python
+invoice = Invoice.objects.get(id=invoice_id, account_id=request.user.account_id)
+```
+
+This is not an authorization bypass if `request.user.account_id` is trusted and the caller is authenticated for that account.

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -130,6 +130,7 @@ describe('init command', () => {
       expect(existsSync(join(tempDir, '.agents', 'skills', 'warden', 'SPEC.md'))).toBe(true);
       expect(existsSync(join(tempDir, '.agents', 'skills', 'warden-sweep', 'SKILL.md'))).toBe(true);
       expect(existsSync(join(tempDir, '.agents', 'skills', 'warden-sweep', 'SPEC.md'))).toBe(true);
+      expect(existsSync(join(tempDir, '.agents', 'skills', 'security-review', 'SKILL.md'))).toBe(false);
       expect(existsSync(join(tempDir, '.agents', 'skills', 'skill-writer', 'SKILL.md'))).toBe(false);
     });
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -69,7 +69,7 @@ function generateWardenToml(): string {
 # https://github.com/getsentry/warden
 #
 # Warden reviews code using AI-powered skills triggered by GitHub events.
-# Skills live in .agents/skills/ or .claude/skills/
+# Built-in skills are available by name. Custom skills live in .agents/skills/ or .claude/skills/
 #
 # Add skills with: warden add <skill-name>
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -85,7 +85,7 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
   },
   skill: {
     label: '--skill <name|path>',
-    description: 'Run only this skill by name or path',
+    description: 'Run only this skill by name or path; names fall back to built-ins',
   },
   config: {
     label: '--config <path>',

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -60,6 +60,30 @@ function createCliOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
 }
 
 describe('createSkillTasks', () => {
+  it('resolves explicit built-in skills from the package after repo-local paths', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-main-'));
+    tempDirs.push(repoRoot);
+
+    const spec: RunSkillSpec = {
+      name: 'security-review',
+      skill: 'security-review',
+      context: {} as RunSkillSpec['context'],
+      runnerOptions: {},
+    };
+
+    const [task] = await createSkillTasks({
+      specs: [spec],
+      repoPath: repoRoot,
+      options: createCliOptions(),
+      parallel: 1,
+      reporter: createTestReporter(),
+    });
+
+    const skill = await task!.resolveSkill();
+    expect(skill.name).toBe('security-review');
+    expect(skill.rootDir).toContain('src/builtin-skills/security-review');
+  });
+
   it('reports missing generated artifacts for explicit generated skill paths', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'warden-main-'));
     tempDirs.push(repoRoot);

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -14,6 +14,9 @@ describe('npm package contents', () => {
     expect(ignored.ignores('SPEC.md')).toBe(true);
     expect(ignored.ignores('src/skill-builder/skill.ts')).toBe(true);
     expect(ignored.ignores('src/internal-skills/skill-writer/SKILL.md')).toBe(false);
+    expect(ignored.ignores('src/builtin-skills/security-review/SKILL.md')).toBe(false);
+    expect(ignored.ignores('src/builtin-skills/security-review/references/javascript-typescript.md')).toBe(false);
+    expect(ignored.ignores('src/builtin-skills/security-review/references/github-workflows.md')).toBe(false);
     expect(ignored.ignores('skills/warden/SPEC.md')).toBe(false);
     expect(ignored.ignores('.warden/skills/security/SKILL.md')).toBe(true);
     expect(ignored.ignores('.codex/config.toml')).toBe(true);

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -13,9 +13,11 @@ import {
   resolveSkillAsync,
   resolveSkillPath,
   SkillLoaderError,
+  BUILTIN_SKILL_DIRECTORIES,
   SKILL_DIRECTORIES,
   AGENT_DIRECTORIES,
   AGENT_MARKER_FILE,
+  discoverAllSkills,
 } from './loader.js';
 
 describe('loadSkillFromFile', () => {
@@ -35,6 +37,36 @@ describe('resolveSkillAsync', () => {
     const skill = await resolveSkillAsync('testing-guidelines', repoRoot);
     expect(skill.name).toBe('testing-guidelines');
     expect(skill.description).toBeDefined();
+  });
+
+  it('resolves package-native built-in skills by name', async () => {
+    const skill = await resolveSkillAsync('security-review');
+    expect(skill.name).toBe('security-review');
+    expect(skill.rootDir).toContain('src/builtin-skills/security-review');
+  });
+
+  it('lets repo-local skills override built-in skills', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-builtin-override-'));
+    try {
+      const skillDir = join(repoRoot, '.agents', 'skills', 'security-review');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: security-review
+description: Custom repo security policy
+---
+
+Custom prompt.
+`,
+      );
+
+      const skill = await resolveSkillAsync('security-review', repoRoot);
+      expect(skill.description).toBe('Custom repo security policy');
+      expect(skill.rootDir).toBe(skillDir);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it('throws for unknown skills', async () => {
@@ -123,6 +155,23 @@ describe('SKILL_DIRECTORIES', () => {
       '.agents/skills',
       '.claude/skills',
     ]);
+  });
+});
+
+describe('BUILTIN_SKILL_DIRECTORIES', () => {
+  it('contains package-native skill assets under src', () => {
+    expect(BUILTIN_SKILL_DIRECTORIES).toEqual([
+      'src/builtin-skills',
+    ]);
+  });
+
+  it('discovers built-in skills without a repo root', async () => {
+    const skills = await discoverAllSkills();
+    const skill = skills.get('security-review');
+
+    expect(skill).toBeDefined();
+    expect(skill!.directory).toBe('built-in');
+    expect(skill!.path).toContain('src/builtin-skills/security-review');
   });
 });
 

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { dirname, extname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { loadSkillMd, SkillLoadError } from '@sentry/dotagents-lib';
 import type { SkillDefinition } from '../config/schema.js';
 import { isPathLike, resolvePathTarget } from '../utils/path.js';
@@ -45,6 +46,16 @@ export const SKILL_DIRECTORIES = [
 ] as const;
 
 /**
+ * Package-native Warden skills, resolved by name without installation.
+ *
+ * Repo-local conventional skills take precedence over these defaults so teams
+ * can override built-ins with their own policy.
+ */
+export const BUILTIN_SKILL_DIRECTORIES = [
+  'src/builtin-skills',
+] as const;
+
+/**
  * Conventional agent directories, checked in priority order.
  *
  * Agents are discovered from these directories in order:
@@ -68,6 +79,14 @@ export const AGENT_MARKER_FILE = 'AGENT.md';
  */
 export function resolveSkillPath(nameOrPath: string, repoRoot?: string): string {
   return resolvePathTarget(nameOrPath, repoRoot);
+}
+
+/**
+ * Resolve the package root from source or compiled dist locations.
+ */
+function resolvePackageRoot(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  return join(dirname(__filename), '..', '..');
 }
 
 /**
@@ -234,7 +253,7 @@ export async function loadSkillsFromDirectory(
  */
 export interface DiscoveredSkill {
   skill: SkillDefinition;
-  /** Relative directory path where the skill was found (e.g., "./.agents/skills") */
+  /** Source label where the skill was found (e.g., "./.agents/skills" or "built-in") */
   directory: string;
   /** Full path to the skill */
   path: string;
@@ -245,14 +264,15 @@ export interface DiscoveredSkill {
  * Scans directories in order; first occurrence of a name wins.
  */
 async function discoverFromDirectories(
-  repoRoot: string,
+  rootDir: string,
   directories: readonly string[],
   options?: LoadSkillsOptions,
+  sourceLabel?: (dir: string) => string,
 ): Promise<Map<string, DiscoveredSkill>> {
   const result = new Map<string, DiscoveredSkill>();
 
   for (const dir of directories) {
-    const dirPath = join(repoRoot, dir);
+    const dirPath = join(rootDir, dir);
     if (!existsSync(dirPath)) continue;
 
     const loaded = await loadSkillsFromDirectory(dirPath, options);
@@ -260,7 +280,7 @@ async function discoverFromDirectories(
       if (!result.has(name)) {
         result.set(name, {
           skill: entry.skill,
-          directory: `./${dir}`,
+          directory: sourceLabel ? sourceLabel(dir) : `./${dir}`,
           path: join(dirPath, entry.entry),
         });
       }
@@ -268,6 +288,15 @@ async function discoverFromDirectories(
   }
 
   return result;
+}
+
+async function discoverBuiltinSkills(options?: LoadSkillsOptions): Promise<Map<string, DiscoveredSkill>> {
+  return discoverFromDirectories(
+    resolvePackageRoot(),
+    BUILTIN_SKILL_DIRECTORIES,
+    options,
+    () => 'built-in',
+  );
 }
 
 /**
@@ -281,10 +310,18 @@ export async function discoverAllSkills(
   repoRoot?: string,
   options?: LoadSkillsOptions
 ): Promise<Map<string, DiscoveredSkill>> {
-  if (!repoRoot) {
-    return new Map();
+  const discovered = repoRoot
+    ? await discoverFromDirectories(repoRoot, SKILL_DIRECTORIES, options)
+    : new Map<string, DiscoveredSkill>();
+
+  const builtin = await discoverBuiltinSkills(options);
+  for (const [name, entry] of builtin) {
+    if (!discovered.has(name)) {
+      discovered.set(name, entry);
+    }
   }
-  return discoverFromDirectories(repoRoot, SKILL_DIRECTORIES, options);
+
+  return discovered;
 }
 
 export interface ResolveSkillOptions {
@@ -298,6 +335,7 @@ export interface ResolveSkillOptions {
 interface ResolveConfig {
   markerFile: string;
   directories: readonly string[];
+  builtinDirectories?: readonly string[];
   label: string;
   kind: 'skill' | 'agent';
 }
@@ -311,6 +349,7 @@ interface ResolveConfig {
  *    - Directory: load marker file from it
  *    - File: load the .md file directly
  * 3. Conventional directories (if repoRoot provided)
+ * 4. Package-native built-in directories (skills only)
  */
 async function resolveEntry(
   nameOrPath: string,
@@ -361,12 +400,30 @@ async function resolveEntry(
     }
   }
 
+  if (config.builtinDirectories) {
+    const packageRoot = resolvePackageRoot();
+    for (const dir of config.builtinDirectories) {
+      const dirPath = join(packageRoot, dir);
+
+      const markerPath = join(dirPath, nameOrPath, config.markerFile);
+      if (existsSync(markerPath)) {
+        return loadSkillFromMarkdown(markerPath);
+      }
+
+      const mdPath = join(dirPath, `${nameOrPath}.md`);
+      if (existsSync(mdPath)) {
+        return loadSkillFromMarkdown(mdPath);
+      }
+    }
+  }
+
   throw new SkillLoaderError(`${config.label} not found: ${nameOrPath}`);
 }
 
 const SKILL_RESOLVE_CONFIG: ResolveConfig = {
   markerFile: 'SKILL.md',
   directories: SKILL_DIRECTORIES,
+  builtinDirectories: BUILTIN_SKILL_DIRECTORIES,
   label: 'Skill',
   kind: 'skill',
 };
@@ -390,6 +447,8 @@ const AGENT_RESOLVE_CONFIG: ResolveConfig = {
  *    - .warden/skills/{name}/SKILL.md or .warden/skills/{name}.md
  *    - .agents/skills/{name}/SKILL.md or .agents/skills/{name}.md
  *    - .claude/skills/{name}/SKILL.md or .claude/skills/{name}.md
+ * 4. Package-native built-in skills
+ *    - src/builtin-skills/{name}/SKILL.md or src/builtin-skills/{name}.md
  */
 export async function resolveSkillAsync(
   nameOrPath: string,

--- a/warden.toml
+++ b/warden.toml
@@ -9,18 +9,9 @@ reportOn = "medium"
 ignorePaths = ["dist/**", "evals/**"]
 
 [[skills]]
-name = "find-warden-bugs"
-paths = ["src/**/*.ts"]
-ignorePaths = ["src/**/*.test.ts"]
-
-[[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-
-[[skills]]
-name = "wrdn-gha-workflows"
-remote = "getsentry/warden-skills"
+name = "security-review"
 paths = [
+  "src/**/*.ts",
   ".github/workflows/*.yml",
   ".github/workflows/*.yaml",
   ".github/actions/**/*.yml",
@@ -28,6 +19,7 @@ paths = [
   "action.yml",
   "action.yaml",
 ]
+ignorePaths = ["src/**/*.test.ts"]
 
 [[skills.triggers]]
 type = "pull_request"


### PR DESCRIPTION
Adds a package-native security-review skill that ships with Warden and can be run by name without installing helper skills into a repo. This repo's Warden workflow config now uses that generic built-in skill for TypeScript and GitHub Actions workflow security review.

**Built-In Resolution**

Named skill resolution checks repo-local skill directories first, then falls back to Warden's bundled src/builtin-skills directory. Teams can override built-ins with repo policy while native defaults remain available from the npm package.

**Security Review Skill**

The bundled skill is compact and trace-first: source, boundary, sink, mitigation, and impact are required before reporting. JavaScript/TypeScript, Python, and GitHub Actions workflow details live in focused reference files.

**Workflow Config**

warden.toml now uses security-review instead of Warden-specific skills for pull request security paths, including .github workflows and local actions.

Validated with focused resolver, CLI, package, config, and strict skill checks.