### PR TITLE
fix(cli): Label built-in skill sources

### DIFF
--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -1,10 +1,11 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { CLIOptions } from './args.js';
 import {
   createSkillTasks,
+  formatSkillSource,
   mergeSkillRunnerOptions,
   processTaskResults,
   resolveInvocationCwd,
@@ -20,6 +21,7 @@ import type { SkillReport } from '../types/index.js';
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -37,6 +39,10 @@ function makeReport(overrides: Partial<SkillReport> = {}): SkillReport {
 
 function createTestReporter(): Reporter {
   return new Reporter({ isTTY: false, supportsColor: false, columns: 80 }, Verbosity.Quiet);
+}
+
+function createVisibleTestReporter(): Reporter {
+  return new Reporter({ isTTY: true, supportsColor: false, columns: 80 }, Verbosity.Normal);
 }
 
 function createCliOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
@@ -84,6 +90,50 @@ describe('createSkillTasks', () => {
     expect(skill.rootDir).toContain('src/builtin-skills/security-review');
   });
 
+  it('shows a built-in source label instead of the package cache path', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'warden-main-repo-'));
+    const packageRoot = mkdtempSync(join(tmpdir(), 'warden-main-package-'));
+    tempDirs.push(repoRoot, packageRoot);
+
+    const rootDir = join(
+      packageRoot,
+      'node_modules',
+      '@sentry',
+      'warden',
+      'src',
+      'builtin-skills',
+      'security-review'
+    );
+    mkdirSync(rootDir, { recursive: true });
+    writeFileSync(join(rootDir, 'SKILL.md'), `---
+name: security-review
+description: Review security issues.
+---
+
+Review security issues.
+`, 'utf-8');
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spec: RunSkillSpec = {
+      name: rootDir,
+      skill: rootDir,
+      context: {} as RunSkillSpec['context'],
+      runnerOptions: {},
+    };
+
+    await createSkillTasks({
+      specs: [spec],
+      repoPath: repoRoot,
+      options: createCliOptions({ quiet: false }),
+      parallel: 1,
+      reporter: createVisibleTestReporter(),
+    });
+
+    const output = errorSpy.mock.calls.map(([message]) => String(message)).join('\n');
+    expect(output).toContain('  Source   built-in (@sentry/warden)');
+    expect(output).not.toContain(rootDir);
+  });
+
   it('reports missing generated artifacts for explicit generated skill paths', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'warden-main-'));
     tempDirs.push(repoRoot);
@@ -112,6 +162,22 @@ prompt: |-
     })).rejects.toThrow(
       'Generated skill ./skills/security is missing generated artifacts. Run "warden build ./skills/security" first.',
     );
+  });
+});
+
+describe('formatSkillSource', () => {
+  it('formats repo-local skill sources relative to the repo root', () => {
+    expect(formatSkillSource(
+      { rootDir: '/repo/.agents/skills/security-review' },
+      '/repo'
+    )).toBe('.agents/skills/security-review');
+  });
+
+  it('keeps external custom skill sources as absolute paths', () => {
+    expect(formatSkillSource(
+      { rootDir: '/external/skills/security-review' },
+      '/repo'
+    )).toBe('/external/skills/security-review');
   });
 });
 

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -179,6 +179,13 @@ describe('formatSkillSource', () => {
       '/repo'
     )).toBe('/external/skills/security-review');
   });
+
+  it('keeps the repo root source path instead of rendering an empty source', () => {
+    expect(formatSkillSource(
+      { rootDir: '/repo' },
+      '/repo'
+    )).toBe('/repo');
+  });
 });
 
 describe('mergeSkillRunnerOptions', () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,6 +12,7 @@ import { matchTrigger, filterContextByPaths, shouldFail, countFindingsAtOrAbove 
 import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, Finding } from '../types/index.js';
 import { filterFindings } from '../types/index.js';
 import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
+import { normalizePath } from '../utils/path.js';
 import { parseCliArgs, showVersion, classifyTargets, type CLIOptions } from './args.js';
 import { showHelp } from './help.js';
 import { buildLocalEventContext, buildFileEventContext } from './context.js';
@@ -513,17 +514,13 @@ type SkillRunnerOptionOverrides = Pick<
 
 const BUILTIN_SKILL_SOURCE = 'built-in (@sentry/warden)';
 
-function normalizePathForDisplay(path: string): string {
-  return path.replace(/\\/g, '/');
-}
-
 function isLocalPath(relativePath: string): boolean {
   return relativePath === ''
     || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
 }
 
 function isBuiltinSkillRoot(rootDir: string, repoPath?: string): boolean {
-  const normalizedRoot = normalizePathForDisplay(rootDir);
+  const normalizedRoot = normalizePath(rootDir);
   if (
     normalizedRoot.includes('/node_modules/@sentry/warden/src/builtin-skills/')
     || normalizedRoot.includes('/node_modules/@sentry/warden/dist/builtin-skills/')
@@ -535,7 +532,7 @@ function isBuiltinSkillRoot(rootDir: string, repoPath?: string): boolean {
     return false;
   }
 
-  const relativeRoot = normalizePathForDisplay(relative(repoPath, rootDir));
+  const relativeRoot = normalizePath(relative(repoPath, rootDir));
   return (
     relativeRoot === 'src/builtin-skills'
     || relativeRoot.startsWith('src/builtin-skills/')

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import { Sentry, flushSentry, setGlobalAttributes, emitRunMetric, getTraceId } from '../sentry.js';
 import { emptyToUndefined, loadWardenConfig, resolveSkillConfigs } from '../config/loader.js';
@@ -12,7 +12,7 @@ import { matchTrigger, filterContextByPaths, shouldFail, countFindingsAtOrAbove 
 import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, Finding } from '../types/index.js';
 import { filterFindings } from '../types/index.js';
 import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
-import { normalizePath } from '../utils/path.js';
+import { isRepoRelativePath, normalizePath } from '../utils/path.js';
 import { parseCliArgs, showVersion, classifyTargets, type CLIOptions } from './args.js';
 import { showHelp } from './help.js';
 import { buildLocalEventContext, buildFileEventContext } from './context.js';
@@ -514,11 +514,6 @@ type SkillRunnerOptionOverrides = Pick<
 
 const BUILTIN_SKILL_SOURCE = 'built-in (@sentry/warden)';
 
-function isLocalPath(relativePath: string): boolean {
-  return relativePath === ''
-    || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
-}
-
 function isBuiltinSkillRoot(rootDir: string, repoPath?: string): boolean {
   const normalizedRoot = normalizePath(rootDir);
   if (
@@ -558,8 +553,8 @@ export function formatSkillSource(
     return skill.rootDir;
   }
 
-  const relativeRoot = relative(repoPath, skill.rootDir);
-  return isLocalPath(relativeRoot) ? relativeRoot : skill.rootDir;
+  const relativeRoot = normalizePath(relative(repoPath, skill.rootDir));
+  return isRepoRelativePath(relativeRoot) ? relativeRoot : skill.rootDir;
 }
 
 /** Apply per-skill runner overrides on top of the shared execution defaults. */

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import { Sentry, flushSentry, setGlobalAttributes, emitRunMetric, getTraceId } from '../sentry.js';
 import { emptyToUndefined, loadWardenConfig, resolveSkillConfigs } from '../config/loader.js';
@@ -511,6 +511,60 @@ type SkillRunnerOptionOverrides = Pick<
   'model' | 'maxTurns' | 'runtime' | 'auxiliaryModel' | 'synthesisModel' | 'auxiliaryMaxRetries' | 'verifyFindings'
 >;
 
+const BUILTIN_SKILL_SOURCE = 'built-in (@sentry/warden)';
+
+function normalizePathForDisplay(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+function isLocalPath(relativePath: string): boolean {
+  return relativePath === ''
+    || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
+}
+
+function isBuiltinSkillRoot(rootDir: string, repoPath?: string): boolean {
+  const normalizedRoot = normalizePathForDisplay(rootDir);
+  if (
+    normalizedRoot.includes('/node_modules/@sentry/warden/src/builtin-skills/')
+    || normalizedRoot.includes('/node_modules/@sentry/warden/dist/builtin-skills/')
+  ) {
+    return true;
+  }
+
+  if (!repoPath) {
+    return false;
+  }
+
+  const relativeRoot = normalizePathForDisplay(relative(repoPath, rootDir));
+  return (
+    relativeRoot === 'src/builtin-skills'
+    || relativeRoot.startsWith('src/builtin-skills/')
+    || relativeRoot === 'dist/builtin-skills'
+    || relativeRoot.startsWith('dist/builtin-skills/')
+  );
+}
+
+/** Format a skill source path for the CLI run header. */
+export function formatSkillSource(
+  skill: Pick<SkillDefinition, 'rootDir'>,
+  repoPath?: string
+): string | undefined {
+  if (!skill.rootDir) {
+    return undefined;
+  }
+
+  if (isBuiltinSkillRoot(skill.rootDir, repoPath)) {
+    return BUILTIN_SKILL_SOURCE;
+  }
+
+  if (!repoPath) {
+    return skill.rootDir;
+  }
+
+  const relativeRoot = relative(repoPath, skill.rootDir);
+  return isLocalPath(relativeRoot) ? relativeRoot : skill.rootDir;
+}
+
 /** Apply per-skill runner overrides on top of the shared execution defaults. */
 export function mergeSkillRunnerOptions(
   base: SkillRunnerOptions,
@@ -539,9 +593,7 @@ function renderSkillRunHeader(args: {
   model?: string;
 }): void {
   const { reporter, skill, repoPath, runtimeName, model } = args;
-  const source = skill.rootDir && repoPath && skill.rootDir.startsWith(repoPath)
-    ? skill.rootDir.slice(repoPath.length + 1)
-    : skill.rootDir;
+  const source = formatSkillSource(skill, repoPath);
 
   reporter.blank();
   reporter.text(`  Skill    ${skill.name}`);


### PR DESCRIPTION
Built-in skills now show `built-in (@sentry/warden)` in the direct-run header instead of leaking the installed package cache path. Local repo skills continue to show repo-relative paths, while external custom skill paths remain absolute.

**CLI Source Display**

`formatSkillSource` centralizes header source rendering so built-in package roots are detected across source and dist layouts without changing the runner resource root.

Before:
```text
  Source   /Users/.../node_modules/@sentry/warden/src/builtin-skills/security-review
```

After:
```text
  Source   built-in (@sentry/warden)
```