### PR TITLE
docs: Use built-in security review in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Your code is under new management. Agents that review your code - locally or on 
 # Initialize warden in your repository
 npx @sentry/warden init
 
+# Add the built-in baseline security check
+npx @sentry/warden add security-review
+
 # Run a pre-review on current branch changes
 # Uses Claude Code subscription if logged in, or set WARDEN_ANTHROPIC_API_KEY
 npx @sentry/warden

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -4,7 +4,7 @@
 
 Warden watches over your code by running **skills** against your changes. Skills are prompts that define what to look for: security vulnerabilities, API design issues, performance problems, or anything else you want consistent coverage on.
 
-Skills follow the [agentskills.io](https://agentskills.io) specification. They're markdown files with a prompt that tells the AI what to look for. You can use community skills, write your own, or combine both.
+Skills follow the [agentskills.io](https://agentskills.io) specification. They're markdown files with a prompt that tells the AI what to look for. Warden includes a baseline `security-review` skill by default. Treat it as a first pass, not a complete security audit, and add community or custom skills when you need deeper coverage.
 
 - Docs: https://warden.sentry.dev
 - GitHub: https://github.com/getsentry/warden
@@ -50,7 +50,7 @@ Creates `warden.toml` (configuration) and `.github/workflows/warden.yml` (GitHub
 ### Add a Skill
 
 ```bash
-warden add vercel-react-best-practices --remote vercel-labs/agent-skills
+warden add security-review
 ```
 
 ### Run Locally
@@ -115,10 +115,10 @@ Add a skill trigger to your configuration.
 
 ```bash
 warden add                     # Interactive mode
-warden add security-review     # Add local skill
+warden add security-review     # Add baseline security review
 warden add --list              # List available skills
-warden add --remote getsentry/warden-skills --skill security-review
-warden add --remote getsentry/warden-skills@abc123 --skill api-review  # Pinned to commit
+warden add --remote your-org/warden-skills --skill api-review
+warden add --remote your-org/warden-skills@abc123 --skill api-review  # Pinned to commit
 ```
 
 ### warden sync
@@ -327,7 +327,7 @@ createFixPR = true
 Skills can be referenced in multiple ways:
 
 ```toml
-# By name (resolved from .agents/skills/ or .claude/skills/)
+# By name (repo-local first, then built-in skills)
 [[skills]]
 name = "security-review"
 
@@ -337,20 +337,21 @@ name = "./custom-skills/my-review"
 
 # Remote skill (unpinned - checks for updates every 24h)
 [[skills]]
-name = "security-review"
-remote = "getsentry/warden-skills"
+name = "api-review"
+remote = "your-org/warden-skills"
 
 # Remote skill (pinned to commit - cached permanently)
 [[skills]]
-name = "security-review"
-remote = "getsentry/warden-skills@abc123def"
+name = "api-review"
+remote = "your-org/warden-skills@abc123def"
 ```
 
 Resolution order:
 
 1. Remote repository (if `remote` field is specified)
 2. Direct path (if skill contains `/`, `\`, or starts with `.`)
-3. Conventional directories: `.agents/skills/`, `.claude/skills/`
+3. Conventional directories: `.warden/skills/`, `.agents/skills/`, `.claude/skills/`
+4. Built-in skills, including `security-review`
 
 ### Environment Variables
 
@@ -368,6 +369,7 @@ Skills are markdown files that tell Warden what to look for. They follow the [ag
 ### Directory Structure
 
 ```
+.warden/skills/skill-name/SKILL.md   # Warden-local generated skills
 .agents/skills/skill-name/SKILL.md   # Primary (recommended)
 .claude/skills/skill-name/SKILL.md   # Backup (Claude Code convention)
 ```
@@ -378,20 +380,19 @@ A skill has YAML frontmatter for metadata and markdown for the prompt:
 
 ```markdown
 ---
-name: security-review
-description: Review code for security vulnerabilities
+name: api-review
+description: Review API changes for compatibility and contract issues
 allowed-tools: Read Grep Glob
 ---
 
-Review the code for security issues including:
-- SQL injection and parameter binding
-- XSS vulnerabilities in user input handling
-- Hardcoded secrets or credentials
-- Insecure cryptographic practices
-- Path traversal vulnerabilities
+Review API changes for:
+- Breaking response shape changes
+- Missing pagination on list endpoints
+- Inconsistent error response formats
+- New endpoints without authentication checks
 
 Focus on issues in the changed code. For each issue found, report:
-- The specific vulnerability type
+- The specific contract or compatibility risk
 - Why it's a problem
 - How to fix it
 ```

--- a/packages/docs/src/components/HeroFlow.astro
+++ b/packages/docs/src/components/HeroFlow.astro
@@ -1,6 +1,6 @@
 ---
 const skills = [
-  "security-scanning",
+  "security-review",
   "api-design-review",
   "architecture-review",
   "dependency-review",

--- a/packages/docs/src/pages/cli.astro
+++ b/packages/docs/src/pages/cli.astro
@@ -73,12 +73,12 @@ warden init --force    # Overwrite existing files`}
     <Terminal>
       <Code
         code={`warden add                     # Interactive mode
-warden add security-review     # Add local skill
+warden add security-review     # Add baseline security review
 warden add --list              # List available skills
 
 # Remote skills from GitHub repositories
-warden add --remote getsentry/warden-skills --skill security-review
-warden add --remote getsentry/warden-skills@abc123 --skill api-review  # Pinned to commit`}
+warden add --remote your-org/warden-skills --skill api-review
+warden add --remote your-org/warden-skills@abc123 --skill api-review  # Pinned to commit`}
         lang="bash"
         theme="vitesse-black"
       />
@@ -152,7 +152,7 @@ warden setup-app --org my-org  # For an organization`}
 
   <Terminal>
     <Code
-      code={`# By name (resolved from .agents/skills/ or .claude/skills/)
+      code={`# By name (repo-local first, then built-in skills)
 warden --skill security-review
 
 # Relative path
@@ -172,7 +172,8 @@ warden --skill ~/my-skills/security`}
   <ol>
     <li>Remote repository (if <code>remote</code> is specified in trigger config)</li>
     <li>Direct path (if contains <code>/</code>, <code>\</code>, or starts with <code>.</code>)</li>
-    <li>Conventional directories: <code>.agents/skills/</code>, <code>.claude/skills/</code></li>
+    <li>Conventional directories: <code>.warden/skills/</code>, <code>.agents/skills/</code>, <code>.claude/skills/</code></li>
+    <li>Built-in skills, including <code>security-review</code></li>
   </ol>
 
   <h2 id="environment-variables">Environment Variables</h2>

--- a/packages/docs/src/pages/config.astro
+++ b/packages/docs/src/pages/config.astro
@@ -318,7 +318,7 @@ createFixPR = true`}
 
   <Terminal showCopy={true}>
     <Code
-      code={`# By name (resolved from .agents/skills/ or .claude/skills/)
+      code={`# By name (repo-local first, then built-in skills)
 [[skills]]
 name = "security-review"
 
@@ -328,13 +328,13 @@ name = "./custom-skills/my-review"
 
 # Remote skill (unpinned - checks for updates every 24h)
 [[skills]]
-name = "security-review"
-remote = "getsentry/warden-skills"
+name = "api-review"
+remote = "your-org/warden-skills"
 
 # Remote skill (pinned to commit - cached permanently)
 [[skills]]
-name = "security-review"
-remote = "getsentry/warden-skills@abc123def"`}
+name = "api-review"
+remote = "your-org/warden-skills@abc123def"`}
       lang="toml"
       theme="vitesse-black"
     />
@@ -345,7 +345,8 @@ remote = "getsentry/warden-skills@abc123def"`}
   <ol>
     <li>Remote repository (if <code>remote</code> field is specified)</li>
     <li>Direct path (if skill contains <code>/</code>, <code>\</code>, or starts with <code>.</code>)</li>
-    <li>Conventional directories (first match wins)</li>
+    <li>Conventional directories: <code>.warden/skills/</code>, <code>.agents/skills/</code>, <code>.claude/skills/</code></li>
+    <li>Built-in skills, including <code>security-review</code></li>
   </ol>
 
   <h2 id="skill-files">Skill Files</h2>
@@ -357,6 +358,8 @@ remote = "getsentry/warden-skills@abc123def"`}
   <p>Warden discovers skills from these directories (first match wins):</p>
 
   <dl>
+    <dt>.warden/skills/</dt>
+    <dd>Warden-local generated skills</dd>
     <dt>.agents/skills/</dt>
     <dd>Primary skill directory (recommended)</dd>
     <dt>.claude/skills/</dt>
@@ -370,7 +373,7 @@ remote = "getsentry/warden-skills@abc123def"`}
   <Terminal showCopy={true}>
     <Code
       code={`.agents/skills/
-└── security-review/
+└── api-review/
     └── SKILL.md`}
       lang="text"
       theme="vitesse-black"
@@ -382,16 +385,16 @@ remote = "getsentry/warden-skills@abc123def"`}
   <Terminal showCopy={true}>
     <Code
       code={`---
-name: security-review
-description: Review code for security vulnerabilities
+name: api-review
+description: Review API changes for compatibility and contract issues
 allowed-tools: Read Grep Glob
 ---
 
-Review the code for security issues including:
-- SQL injection
-- XSS vulnerabilities
-- Hardcoded secrets
-- Insecure dependencies`}
+Review API changes for:
+- Breaking response shape changes
+- Missing pagination on list endpoints
+- Inconsistent error response formats
+- New endpoints without authentication checks`}
       lang="markdown"
       theme="vitesse-black"
     />

--- a/packages/docs/src/pages/guide.astro
+++ b/packages/docs/src/pages/guide.astro
@@ -40,7 +40,7 @@ const tocItems = [
       <li>Reports findings with severity, location, and optional fixes</li>
     </ol>
 
-    <p>Skills follow the <a href="https://agentskills.io">agentskills.io</a> specification -they're markdown files with a prompt that tells the AI what to look for. You can use community skills, write your own, or combine both.</p>
+    <p>Skills follow the <a href="https://agentskills.io">agentskills.io</a> specification -they're markdown files with a prompt that tells the AI what to look for. Warden includes a baseline <code>security-review</code> skill by default. Treat it as a first pass, not a complete security audit, and add community or custom skills when you need deeper coverage.</p>
 
     <p>Warden works in two contexts:</p>
     <ul>
@@ -174,7 +174,7 @@ warden src/api/`}
 
     <h3>Directory Structure</h3>
 
-    <p>Create a skill in one of these directories (first match wins):</p>
+    <p>Create a custom skill in one of these directories (first match wins):</p>
 
     <Terminal showCopy={true}>
       <Code
@@ -192,20 +192,19 @@ warden src/api/`}
     <Terminal showCopy={true}>
       <Code
         code={`---
-name: security-review
-description: Review code for security vulnerabilities
+name: api-review
+description: Review API changes for compatibility and contract issues
 allowed-tools: Read Grep Glob
 ---
 
-Review the code for security issues including:
-- SQL injection and parameter binding
-- XSS vulnerabilities in user input handling
-- Hardcoded secrets or credentials
-- Insecure cryptographic practices
-- Path traversal vulnerabilities
+Review API changes for:
+- Breaking response shape changes
+- Missing pagination on list endpoints
+- Inconsistent error response formats
+- New endpoints without authentication checks
 
 Focus on issues in the changed code. For each issue found, report:
-- The specific vulnerability type
+- The specific contract or compatibility risk
 - Why it's a problem
 - How to fix it`}
         lang="markdown"
@@ -243,7 +242,19 @@ Focus on issues in the changed code. For each issue found, report:
 
     <h2 id="adding-skills">Adding Skills</h2>
 
-    <p>Warden can fetch and install skills from remote GitHub repositories.</p>
+    <p>Use built-in skills by name. Add local or remote skills when your codebase needs more specialized checks.</p>
+
+    <h3>Add the Baseline Security Review</h3>
+
+    <p><code>security-review</code> ships with Warden as a baseline first pass, so no local skill file or remote repository is required:</p>
+
+    <Terminal showCopy={true}>
+      <Code
+        code={`warden add security-review`}
+        lang="bash"
+        theme="vitesse-black"
+      />
+    </Terminal>
 
     <h3>Add a Remote Skill</h3>
 
@@ -273,7 +284,7 @@ Focus on issues in the changed code. For each issue found, report:
 
     <Terminal showCopy={true}>
       <Code
-        code={`warden add security-review`}
+        code={`warden add api-review`}
         lang="bash"
         theme="vitesse-black"
       />

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -8,20 +8,22 @@ import { Code } from 'astro:components';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 const skillExample = `---
-name: security-scanning
+name: security-review
+description: Finds exploitable application security vulnerabilities in code changes.
+allowed-tools: Read Grep Glob
 ---
 
-You are a security expert analyzing code changes.
+You are a senior application security reviewer finding real, exploitable
+vulnerabilities in code changes for Warden's baseline security skill.
 
-## What to Report
-- SQL injection via unsanitized input
-- Cross-site scripting (XSS)
-- Hardcoded secrets or credentials
-- Command injection vulnerabilities
+## Finding Requirements
+- Report only when you can show attacker-controlled input,
+  the vulnerable sink or missing guard, the security boundary,
+  and concrete impact.
+- Treat pattern matches as leads. A dangerous API is not a
+  vulnerability unless untrusted data can reach it.
+- Prefer no finding over speculative hardening advice.`;
 
-## What NOT to Report
-- Code style or formatting
-- Performance optimizations`;
 ---
 
 <Base title="Home" description="Define skills in Markdown. Compose them into agents that review every change.">
@@ -93,15 +95,15 @@ You are a security expert analyzing code changes.
 
   <section class="section skill-showcase" id="whats-a-skill">
     <h2>Its Just Skills</h2>
-    <p>The PR feedback above comes from skills. Skills are a known standard: a SKILL.md file tells Warden what to look for.</p>
-    <Terminal title=".agents/skills/security-scanning/SKILL.md">
+    <p>The PR feedback above comes from skills. Warden ships with a baseline <code>security-review</code> skill. It is a first pass, not a complete security audit, and it is still just a SKILL.md file telling Warden what to look for.</p>
+    <Terminal title="built-in security-review/SKILL.md">
       <Code
         code={skillExample}
         lang="markdown"
         theme="vitesse-black"
       />
     </Terminal>
-    <p class="skill-showcase-note">That's a trivial example, but it's a working skill. No build step. No schema. No SDK.</p>
+    <p class="skill-showcase-note">Use it by name. No local skill file, build step, schema, or SDK required.</p>
     <p class="skill-showcase-detail">Real skills can include detailed reference material, code examples, style guides, architectural constraints, or anything else you'd put in a design doc. The prompt is the skill.</p>
   </section>
 
@@ -126,7 +128,7 @@ You are a security expert analyzing code changes.
 <span class="cli-green">Created</span> .github/workflows/warden.yml
 
 <span class="cli-bold">Next steps:</span>
-  1. Add a skill: <span class="cli-cyan">warden add &lt;skill-name&gt;</span>
+  1. Add a skill: <span class="cli-cyan">warden add security-review</span>
   2. <span class="cli-cyan">export WARDEN_ANTHROPIC_API_KEY=sk-ant-...</span>
   3. Add <span class="cli-cyan">WARDEN_ANTHROPIC_API_KEY</span> to repository secrets
      <span class="cli-dim">https://github.com/your-org/your-repo/settings/secrets/actions</span>
@@ -136,9 +138,9 @@ You are a security expert analyzing code changes.
 
     <div class="step">
       <h3>Load Skills</h3>
-      <p>Add skills for what matters to your codebase. Local or from any GitHub repo.</p>
-      <Terminal showCopy={true} copyText="warden add api-design-review --remote yourcompany/skills">
-        <pre class="cli-output"><span class="cli-dim">$</span> warden add api-design-review --remote yourcompany/skills</pre>
+      <p>Start with the baseline security check. Add custom or remote skills when your codebase needs deeper coverage.</p>
+      <Terminal showCopy={true} copyText="warden add security-review">
+        <pre class="cli-output"><span class="cli-dim">$</span> warden add security-review</pre>
       </Terminal>
       <p>Create your own skills or find ones driven by the community at <a href="https://skills.sh">skills.sh</a>.</p>
     </div>
@@ -158,7 +160,7 @@ Analyzing changes from origin/main to HEAD...
   <span class="cli-green">+</span> src/auth/session.ts <span class="cli-dim">(1 chunk)</span>
   <span class="cli-yellow">~</span> src/middleware/cors.ts <span class="cli-dim">(1 chunk)</span>
 
-┌─ <span class="cli-bold">security-scanning</span> ────────────────────────────────────── <span class="cli-dim">6.1s</span> ─┐
+┌─ <span class="cli-bold">security-review</span> ──────────────────────────────────────── <span class="cli-dim">6.1s</span> ─┐
 │ <span class="cli-bold">2 findings:</span> <span class="cli-red">●</span> 1 high  <span class="cli-yellow">●</span> 1 medium                                │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │

--- a/skills/warden/references/cli-reference.md
+++ b/skills/warden/references/cli-reference.md
@@ -42,7 +42,7 @@ Ambiguous targets (no path separator, no extension) are resolved by checking if 
 
 | Option | Description |
 |--------|-------------|
-| `--skill <name>` | Run only this skill (default: run all built-in skills) |
+| `--skill <name>` | Run only this skill by name or path; names fall back to built-ins |
 | `--config <path>` | Path to warden.toml (default: `./warden.toml`) |
 | `-m, --model <model>` | Model to use (fallback when not set in config) |
 | `--json` | Output results as JSON |
@@ -114,7 +114,7 @@ warden init
 
 # Interactive skill selection
 warden add
-warden add <skill-name>
+warden add security-review
 warden add --list
 
 # Remote skills

--- a/skills/warden/references/creating-skills.md
+++ b/skills/warden/references/creating-skills.md
@@ -7,9 +7,12 @@ Skills are markdown files that tell Warden what to look for. They follow the [ag
 Warden searches these directories in order (first match wins):
 
 ```
+.warden/skills/{name}/SKILL.md   # Warden-local generated skills
 .agents/skills/{name}/SKILL.md   # Primary (recommended)
 .claude/skills/{name}/SKILL.md   # Backup (Claude Code convention)
 ```
+
+If no repo-local skill matches, names fall back to Warden's built-in skills such as `security-review`.
 
 ## SKILL.md Format
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -71,7 +71,7 @@ function generateWardenToml(): string {
 # Warden reviews code using AI-powered skills triggered by GitHub events.
 # Built-in skills are available by name. Custom skills live in .agents/skills/ or .claude/skills/
 #
-# Add skills with: warden add <skill-name>
+# Add skills with: warden add security-review
 
 version = 1
 
@@ -84,7 +84,7 @@ failOn = "high"
 reportOn = "medium"
 
 # Skills define what to analyze and when to run
-# Add skills with: warden add <skill-name>
+# Add skills with: warden add security-review
 #
 # Example skill with path filters and triggers:
 #
@@ -402,7 +402,7 @@ export async function runInit(options: CLIOptions, reporter: Reporter): Promise<
 
   // Print next steps
   reporter.bold('Next steps:');
-  reporter.text(`  1. Add a skill: ${chalk.cyan('warden add <skill-name>')}`);
+  reporter.text(`  1. Add a skill: ${chalk.cyan('warden add security-review')}`);
   reporter.text(`  2. Set ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} in .env.local`);
   reporter.text(`  3. Add ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} to organization or repository secrets`);
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -277,7 +277,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
     examples: [
       'warden add',
       'warden add security-review',
-      'warden add --remote getsentry/skills --skill security-review',
+      'warden add --remote your-org/warden-skills --skill api-review',
     ],
   },
   sync: {


### PR DESCRIPTION
Update public onboarding examples to use Warden's built-in `security-review` skill as the first sample. The docs now describe it as a baseline first pass, not a complete security audit, and separate built-in usage from custom and remote skill examples so users are not guided toward creating local skills that shadow the built-in.

**CLI Onboarding**

`warden init`, the README, homepage, and CLI help now point users to `warden add security-review` while calling it a baseline security check.

**Skill Examples**

Custom skill examples use `api-review`, while skill resolution docs call out repo-local precedence and built-in fallback.

Validated with `pnpm -C packages/docs build`, `pnpm test src/cli/help.test.ts src/cli/commands/init.test.ts`, and `git diff --check`.
