### PR TITLE
build(deps): Bump dotagents lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@anthropic-ai/sdk": "^0.72.1",
     "@inquirer/select": "^5.0.4",
     "@octokit/rest": "^22.0.1",
-    "@sentry/dotagents-lib": "^1.15.0",
+    "@sentry/dotagents-lib": "^1.16.1",
     "@sentry/node": "^10.38.0",
     "chalk": "^5.6.2",
     "dotenv": "^17.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@sentry/dotagents-lib':
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.16.1
+        version: 1.16.1
       '@sentry/node':
         specifier: ^10.38.0
         version: 10.38.0
@@ -1501,8 +1501,8 @@ packages:
     resolution: {integrity: sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==}
     engines: {node: '>=18'}
 
-  '@sentry/dotagents-lib@1.15.0':
-    resolution: {integrity: sha512-PokAf2FtV/VWKO8N3HzyGSjiIpE/9ViJ/ZyqP4bTG5h6nfAcZF/7O1Y6N3PCKWfd7oZjqGQflNMBBlCwzpDoaQ==}
+  '@sentry/dotagents-lib@1.16.1':
+    resolution: {integrity: sha512-SWyV4/Kmkas5ObEc6b2vHjdjW0X9uzEPA7736tTxPankaL9XKT9hM0pGtNp/khwv/vtcxWbFE2GzDZJs+RZOig==}
     engines: {node: '>=20'}
 
   '@sentry/node-core@10.38.0':
@@ -4470,7 +4470,7 @@ snapshots:
 
   '@sentry/core@10.38.0': {}
 
-  '@sentry/dotagents-lib@1.15.0':
+  '@sentry/dotagents-lib@1.16.1':
     dependencies:
       yaml: 2.8.3
 


### PR DESCRIPTION
Bump `@sentry/dotagents-lib` to `1.16.1` so Warden consumes the cache serialization fix from the dotagents patch release. This should stop parallel trigger startup from racing while cloning the same remote skill repository into an empty cache path.

Fixes WARDEN-M