### PR TITLE
Add Codex runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ npx @sentry/warden add code-review
 # Uses Claude Code subscription if logged in, or set WARDEN_ANTHROPIC_API_KEY
 npx @sentry/warden
 
+# To use your local Codex subscription instead, set defaults.runtime in warden.toml:
+# [defaults]
+# runtime = "codex"
+# Then authenticate once with:
+# codex login
+
 # Fix issues automatically
 npx @sentry/warden --fix
 ```

--- a/packages/docs/src/pages/config.astro
+++ b/packages/docs/src/pages/config.astro
@@ -182,6 +182,8 @@ maxFindings = 20`}
     <dd>Model for all skills</dd>
     <dt>maxTurns</dt>
     <dd>Max agentic turns per hunk. Default: 50</dd>
+    <dt>runtime</dt>
+    <dd>Runtime backend. Use <code>claude</code> for Claude Code or <code>codex</code> for local Codex subscription auth.</dd>
     <dt>auxiliary</dt>
     <dd>Model defaults for auxiliary structured calls such as extraction repair, review deduplication, and fix evaluation</dd>
     <dt>synthesis</dt>
@@ -209,6 +211,7 @@ maxFindings = 20`}
   <Terminal showCopy={true}>
     <Code
       code={`[defaults]
+runtime = "claude"
 model = "claude-sonnet-4-5"
 maxTurns = 30
 failOn = "high"
@@ -228,6 +231,7 @@ model = "claude-opus-4-5"`}
   </Terminal>
 
   <p><strong>Model precedence:</strong> trigger &gt; skill &gt; defaults &gt; CLI flag (<code>-m</code>) &gt; env var (<code>WARDEN_MODEL</code>). Most specific wins.</p>
+  <p><strong>Local Codex:</strong> set <code>runtime = "codex"</code> and run <code>codex login</code>. Warden will use <code>codex exec</code> locally.</p>
   <p><strong>Synthesis fallback:</strong> <code>defaults.synthesis.model</code> falls back to <code>defaults.auxiliary.model</code> when not set.</p>
 
   <h2 id="chunking">Chunking</h2>

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -130,6 +130,12 @@ describe('parseCliArgs', () => {
     expect(result.helpTarget).toBe('improve');
   });
 
+  it('parses init runtime option', () => {
+    const result = parseCliArgs(['init', '--runtime', 'codex']);
+    expect(result.command).toBe('init');
+    expect(result.options.initRuntime).toBe('codex');
+  });
+
   it('resolves explicit help targets', () => {
     const result = parseCliArgs(['help', 'runs', 'show']);
     expect(result.command).toBe('help');

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { SeverityThresholdSchema, ConfidenceThresholdSchema } from '../types/index.js';
 import type { SeverityThreshold, ConfidenceThreshold } from '../types/index.js';
 import { getVersion } from '../utils/index.js';
+import { RuntimeNameSchema } from '../sdk/runtimes/types.js';
 import type { HelpTarget } from './help.js';
 
 export const CLIOptionsSchema = z.object({
@@ -35,6 +36,8 @@ export const CLIOptionsSchema = z.object({
   fix: z.boolean().default(false),
   /** Overwrite existing files (for init command) */
   force: z.boolean().default(false),
+  /** Runtime to scaffold in generated config (for init command) */
+  initRuntime: RuntimeNameSchema.optional(),
   /** List available skills (for add command) */
   list: z.boolean().default(false),
   /** Force interpretation of ambiguous targets as git refs */
@@ -279,6 +282,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       'min-confidence': { type: 'string' },
       fix: { type: 'boolean', default: false },
       force: { type: 'boolean', short: 'f', default: false },
+      runtime: { type: 'string' },
       list: { type: 'boolean', short: 'l', default: false },
       remote: { type: 'string' },
       offline: { type: 'boolean', default: false },
@@ -349,6 +353,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       options: parseCliOptions({
         ...sharedOptions(values, verboseCount),
         force: Boolean(values.force),
+        initRuntime: typeof values.runtime === 'string' ? values.runtime : undefined,
       }),
     };
   }

--- a/src/cli/auth-flow.test.ts
+++ b/src/cli/auth-flow.test.ts
@@ -68,7 +68,7 @@ describe('runSkills auth flow', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('checks auth before returning success for no matching skills', async () => {
+  it('skips auth when no skills match', async () => {
     verifyAuthMock.mockImplementation(() => {
       throw new Error('bad auth');
     });
@@ -79,7 +79,7 @@ describe('runSkills auth flow', () => {
       new Reporter({ isTTY: false, supportsColor: false, columns: 80 }, Verbosity.Quiet)
     );
 
-    expect(exitCode).toBe(1);
-    expect(verifyAuthMock).toHaveBeenCalledWith({ apiKey: undefined });
+    expect(exitCode).toBe(0);
+    expect(verifyAuthMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync, readlinkSync, lstatSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -68,6 +68,15 @@ describe('init command', () => {
 
       const content = readFileSync(join(tempDir, 'warden.toml'), 'utf-8');
       expect(content).toContain('version = 1');
+      expect(content).toContain('runtime = "claude"');
+    });
+
+    it('creates warden.toml with Codex runtime when requested', async () => {
+      const reporter = createMockReporter();
+      await runInit(createOptions({ initRuntime: 'codex' }), reporter);
+
+      const content = readFileSync(join(tempDir, 'warden.toml'), 'utf-8');
+      expect(content).toContain('runtime = "codex"');
     });
 
     it('creates workflow with correct content', async () => {
@@ -83,6 +92,23 @@ describe('init command', () => {
       expect(content).toContain('ref: ${{ github.event.pull_request.head.sha }}');
       expect(content).toContain('WARDEN_ANTHROPIC_API_KEY');
       expect(content).toContain(`getsentry/warden@v${getMajorVersion()}`);
+    });
+
+    it('prints Codex local setup next steps when Codex runtime is requested', async () => {
+      const messages: string[] = [];
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation((message) => {
+        messages.push(String(message));
+      });
+      const reporter = createMockReporter();
+
+      await runInit(createOptions({ initRuntime: 'codex' }), reporter);
+
+      const output = messages.join('\n');
+      expect(output).toContain('codex login');
+      expect(output).toContain('warden run --no-color');
+      expect(output).not.toContain('WARDEN_ANTHROPIC_API_KEY');
+
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -19,6 +19,7 @@ import { ICON_CHECK, ICON_SKIPPED } from '../output/icons.js';
 import type { Reporter } from '../output/reporter.js';
 import type { CLIOptions } from '../args.js';
 import { getMajorVersion } from '../../utils/index.js';
+import type { RuntimeName } from '../../sdk/runtimes/types.js';
 
 const INSTALLABLE_BUNDLED_SKILLS = new Set([
   'warden',
@@ -64,7 +65,7 @@ function renderSkipped(reporter: Reporter, reason: string): void {
 /**
  * Template for warden.toml configuration file.
  */
-function generateWardenToml(): string {
+function generateWardenToml(runtime: RuntimeName): string {
   return `# Warden Configuration
 # https://github.com/getsentry/warden
 #
@@ -79,6 +80,8 @@ version = 1
 
 # Default settings inherited by all skills
 [defaults]
+# Runtime backend: claude or codex
+runtime = "${runtime}"
 # Severity levels: critical, high, medium, low, info
 # failOn: minimum severity that fails the check
 failOn = "high"
@@ -135,6 +138,30 @@ jobs:
         with:
           anthropic-api-key: \${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
 `;
+}
+
+function renderNextSteps(reporter: Reporter, repoRoot: string, runtime: RuntimeName): void {
+  reporter.bold('Next steps:');
+  reporter.text(`  1. Add built-in reviews: ${chalk.cyan('warden add security-review')}`);
+  reporter.text(`     ${chalk.cyan('warden add code-review')}`);
+
+  if (runtime === 'codex') {
+    reporter.text(`  2. Run ${chalk.cyan('codex login')} locally`);
+    reporter.text(`  3. Test locally: ${chalk.cyan('warden run --no-color')}`);
+    reporter.text('  4. Commit warden.toml when ready');
+    return;
+  }
+
+  reporter.text(`  2. Set ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} in .env.local`);
+  reporter.text(`  3. Add ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} to organization or repository secrets`);
+
+  // Show GitHub secrets URL if available
+  const githubUrl = getGitHubRepoUrl(repoRoot);
+  if (githubUrl) {
+    reporter.text(`     ${chalk.dim(githubUrl + '/settings/secrets/actions')}`);
+  }
+
+  reporter.text('  4. Commit and open a PR to test');
 }
 
 /**
@@ -290,6 +317,7 @@ function ensureClaudeSymlink(repoRoot: string, force: boolean, reporter: Reporte
  */
 export async function runInit(options: CLIOptions, reporter: Reporter): Promise<number> {
   const cwd = process.cwd();
+  const runtime = options.initRuntime ?? 'claude';
 
   // Find repo root
   let repoRoot: string;
@@ -312,7 +340,7 @@ export async function runInit(options: CLIOptions, reporter: Reporter): Promise<
   if (existing.hasWardenToml && !options.force) {
     renderSkipped(reporter, 'already exists');
   } else {
-    writeFileSync(wardenTomlPath, generateWardenToml(), 'utf-8');
+    writeFileSync(wardenTomlPath, generateWardenToml(runtime), 'utf-8');
     renderCreated(reporter);
     filesCreated++;
   }
@@ -404,20 +432,7 @@ export async function runInit(options: CLIOptions, reporter: Reporter): Promise<
     return 0;
   }
 
-  // Print next steps
-  reporter.bold('Next steps:');
-  reporter.text(`  1. Add built-in reviews: ${chalk.cyan('warden add security-review')}`);
-  reporter.text(`     ${chalk.cyan('warden add code-review')}`);
-  reporter.text(`  2. Set ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} in .env.local`);
-  reporter.text(`  3. Add ${chalk.cyan('WARDEN_ANTHROPIC_API_KEY')} to organization or repository secrets`);
-
-  // Show GitHub secrets URL if available
-  const githubUrl = getGitHubRepoUrl(repoRoot);
-  if (githubUrl) {
-    reporter.text(`     ${chalk.dim(githubUrl + '/settings/secrets/actions')}`);
-  }
-
-  reporter.text('  4. Commit and open a PR to test');
+  renderNextSteps(reporter, repoRoot, runtime);
 
   return 0;
 }

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -33,6 +33,7 @@ describe('renderHelp', () => {
     const output = renderHelp('init');
 
     expect(output).toContain('-v, --verbose');
+    expect(output).toContain('--runtime <claude|codex>');
     expect(output).toContain('--debug');
     expect(output).toContain('--log');
   });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -22,6 +22,7 @@ type HelpOptionId =
   | 'log'
   | 'color'
   | 'force'
+  | 'runtime'
   | 'list'
   | 'remote'
   | 'regenerate'
@@ -164,6 +165,10 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
     label: '-f, --force',
     description: 'Overwrite existing files or bypass caches',
   },
+  runtime: {
+    label: '--runtime <claude|codex>',
+    description: 'Runtime to scaffold in warden.toml',
+  },
   list: {
     label: '--list',
     description: 'List available skills',
@@ -260,9 +265,10 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
     summary: 'Initialize Warden configuration',
     description: 'Create a starter warden.toml and GitHub workflow in the current repository.',
     usage: ['warden init [options]'],
-    options: ['cwd', 'force', ...SHARED_COMMAND_OPTIONS],
+    options: ['cwd', 'force', 'runtime', ...SHARED_COMMAND_OPTIONS],
     examples: [
       'warden init',
+      'warden init --runtime codex',
       'warden init --force',
     ],
   },

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -11,7 +11,7 @@ import { resolveSkillAsync, SkillLoaderError } from '../skills/loader.js';
 import { matchTrigger, filterContextByPaths, shouldFail, countFindingsAtOrAbove } from '../triggers/matcher.js';
 import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, Finding } from '../types/index.js';
 import { filterFindings } from '../types/index.js';
-import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
+import { DEFAULT_CONCURRENCY, getAnthropicApiKey, getOpenAIApiKey } from '../utils/index.js';
 import { isRepoRelativePath, normalizePath } from '../utils/path.js';
 import { parseCliArgs, showVersion, classifyTargets, type CLIOptions } from './args.js';
 import { showHelp } from './help.js';
@@ -57,6 +57,7 @@ import {
   generatedSkillDefinitionRootExists,
   resolveGeneratedSkillTarget,
 } from '../skill-builder/definition.js';
+import type { RuntimeName } from '../sdk/runtimes/index.js';
 
 /**
  * Global abort controller for graceful shutdown on SIGINT.
@@ -701,6 +702,41 @@ export function resolveCliLogModel(
   return resolveCliDefaultModel(config, cliModel) ?? MODEL_DEFAULT_SENTINEL;
 }
 
+function getRuntimeApiKey(runtime: RuntimeName | undefined): string | undefined {
+  return runtime === 'codex' ? getOpenAIApiKey() : getAnthropicApiKey();
+}
+
+function verifyRuntimesForLocalRun(
+  runtimes: Iterable<RuntimeName | undefined>,
+  repoPath: string,
+  options: CLIOptions,
+  reporter: Reporter,
+): boolean {
+  const verified = new Set<RuntimeName>();
+  for (const runtime of runtimes) {
+    const runtimeName = runtime ?? 'claude';
+    if (verified.has(runtimeName)) continue;
+    verified.add(runtimeName);
+    const apiKey = getRuntimeApiKey(runtimeName);
+    if (!apiKey) {
+      reporter.debug(`No API key found. Using ${runtimeName === 'codex' ? 'Codex' : 'Claude Code'} subscription auth.`);
+    }
+    try {
+      verifyAuth({ apiKey, runtime: runtimeName });
+    } catch (error: unknown) {
+      const message = (error as WardenAuthenticationError).message;
+      reporter.error(message);
+      emitEmptyRunLog(repoPath, options, {
+        code: 'auth_failed',
+        message,
+        timestamp: new Date().toISOString(),
+      });
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Process skill task results into reports and check for failures.
  * Exported for testing; callers inside main.ts use it directly.
@@ -851,32 +887,12 @@ export async function runSkills(
   const cwd = process.cwd();
   const startTime = Date.now();
 
-  // Get API key (optional - SDK can use Claude Code subscription auth)
-  const apiKey = getAnthropicApiKey();
-  if (!apiKey) {
-    reporter.debug('No API key found. Using Claude Code subscription auth.');
-  }
-
   // Try to find repo root for config loading
   let repoPath: string | undefined;
   try {
     repoPath = getRepoRoot(cwd);
   } catch {
     // Not in a git repo - that's fine for file mode
-  }
-
-  // Pre-flight: verify auth will work before starting analysis
-  try {
-    verifyAuth({ apiKey });
-  } catch (error: unknown) {
-    const message = (error as WardenAuthenticationError).message;
-    reporter.error(message);
-    emitEmptyRunLog(repoPath ?? cwd, options, {
-      code: 'auth_failed',
-      message,
-      timestamp: new Date().toISOString(),
-    });
-    return 1;
   }
 
   // Resolve config path
@@ -964,6 +980,15 @@ export async function runSkills(
     return 0;
   }
 
+  if (!verifyRuntimesForLocalRun(
+    skillsToRun.map((skill) => skill.runtime),
+    repoPath ?? cwd,
+    options,
+    reporter,
+  )) {
+    return 1;
+  }
+
   // Build skill tasks
   // Model precedence: defaults.agent.model > defaults.model > CLI flag > WARDEN_MODEL env var > SDK default
   // sdkModel is undefined when no model is explicitly configured (lets SDK use its default).
@@ -971,7 +996,6 @@ export async function runSkills(
   const sdkModel = defaultModel;
   const logModel = resolveCliLogModel(config, options.model);
   const runnerOptions: SkillRunnerOptions = {
-    apiKey,
     model: sdkModel,
     runtime: config?.defaults?.runtime ?? 'claude',
     auxiliaryModel: defaultAuxiliaryModel,
@@ -991,7 +1015,10 @@ export async function runSkills(
     remote,
     failOn: options.failOn,
     context: filterContextByPaths(context, filters),
-    runnerOptions: mergeSkillRunnerOptions(runnerOptions, skillOptions),
+    runnerOptions: {
+      ...mergeSkillRunnerOptions(runnerOptions, skillOptions),
+      apiKey: getRuntimeApiKey(skillOptions.runtime ?? runnerOptions.runtime),
+    },
   }));
   let tasks: SkillTaskOptions[];
   const concurrency = options.parallel ?? DEFAULT_CONCURRENCY;
@@ -1273,22 +1300,12 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
     triggersToRun.map((t) => ({ name: t.name, skill: t.skill }))
   );
 
-  // Get API key (optional - SDK can use Claude Code subscription auth)
-  const apiKey = getAnthropicApiKey();
-  if (!apiKey) {
-    reporter.debug('No API key found. Using Claude Code subscription auth.');
-  }
-
-  try {
-    verifyAuth({ apiKey });
-  } catch (error: unknown) {
-    const message = (error as WardenAuthenticationError).message;
-    reporter.error(message);
-    emitEmptyRunLog(repoPath, options, {
-      code: 'auth_failed',
-      message,
-      timestamp: new Date().toISOString(),
-    });
+  if (!verifyRuntimesForLocalRun(
+    triggersToRun.map((trigger) => trigger.runtime),
+    repoPath,
+    options,
+    reporter,
+  )) {
     return 1;
   }
 
@@ -1303,7 +1320,7 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
     minConfidence: trigger.minConfidence ?? effectiveMinConfidence,
     context: filterContextByPaths(context, trigger.filters),
     runnerOptions: {
-      apiKey,
+      apiKey: getRuntimeApiKey(trigger.runtime),
       model: trigger.model,
       runtime: trigger.runtime,
       auxiliaryModel: trigger.auxiliaryModel,

--- a/src/sdk/auth.test.ts
+++ b/src/sdk/auth.test.ts
@@ -27,6 +27,12 @@ describe('verifyAuth', () => {
     expect(mockExec).toHaveBeenCalledWith('claude', ['--version'], { timeout: 5000 });
   });
 
+  it('checks for codex binary when Codex runtime has no API key', () => {
+    mockExec.mockReturnValue('codex-cli 1.0.0');
+    verifyAuth({ runtime: 'codex' });
+    expect(mockExec).toHaveBeenCalledWith('codex', ['login', 'status'], { timeout: 5000 });
+  });
+
   it('throws WardenAuthenticationError when claude binary is missing', () => {
     mockExec.mockImplementation(() => {
       throw new ExecError('claude --version', null, 'spawn claude ENOENT', null);
@@ -45,6 +51,21 @@ describe('verifyAuth', () => {
       expect(error).toBeInstanceOf(WardenAuthenticationError);
       expect((error as Error).message).toContain('Claude Code CLI not found');
       expect((error as Error).message).toContain('WARDEN_ANTHROPIC_API_KEY');
+    }
+  });
+
+  it('includes Codex login guidance when the codex binary is missing', () => {
+    mockExec.mockImplementation(() => {
+      throw new ExecError('codex --version', null, 'spawn codex ENOENT', null);
+    });
+    try {
+      verifyAuth({ runtime: 'codex' });
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(WardenAuthenticationError);
+      expect((error as Error).message).toContain('Codex CLI not found');
+      expect((error as Error).message).toContain('codex login');
+      expect((error as Error).message).toContain('WARDEN_OPENAI_API_KEY');
     }
   });
 

--- a/src/sdk/auth.ts
+++ b/src/sdk/auth.ts
@@ -1,5 +1,6 @@
 import { ExecError, execFileNonInteractive } from '../utils/exec.js';
 import { WardenAuthenticationError } from './errors.js';
+import type { RuntimeName } from './runtimes/index.js';
 
 /**
  * Pre-flight auth check: verify that authentication will work before starting analysis.
@@ -13,10 +14,19 @@ import { WardenAuthenticationError } from './errors.js';
  * Subtler failures (binary exists but sandbox blocks IPC) are caught by the
  * isSubprocessError() handler in analyzeHunk().
  */
-export function verifyAuth({ apiKey }: { apiKey?: string }): void {
-  // Direct API auth — no subprocess needed
+export function verifyAuth({ apiKey, runtime = 'claude' }: { apiKey?: string; runtime?: RuntimeName }): void {
+  // Direct API auth — no subprocess needed.
   if (apiKey) return;
 
+  if (runtime === 'codex') {
+    verifyCodexAuth();
+    return;
+  }
+
+  verifyClaudeAuth();
+}
+
+function verifyClaudeAuth(): void {
   try {
     execFileNonInteractive('claude', ['--version'], { timeout: 5000 });
   } catch (error) {
@@ -39,6 +49,31 @@ export function verifyAuth({ apiKey }: { apiKey?: string }): void {
       `Claude Code CLI found but failed to execute: ${detail}\n` +
       'Check that the claude binary has correct permissions and can run in this environment.',
       { cause: error }
+    );
+  }
+}
+
+function verifyCodexAuth(): void {
+  try {
+    execFileNonInteractive('codex', ['login', 'status'], { timeout: 5000 });
+  } catch (error) {
+    const isNotFound =
+      error instanceof ExecError
+        ? error.stderr.includes('ENOENT')
+        : (error as NodeJS.ErrnoException).code === 'ENOENT';
+    if (isNotFound) {
+      throw new WardenAuthenticationError(
+        'Codex CLI not found on PATH.\n' +
+        'Install Codex and run `codex login` to use your OpenAI subscription.',
+        { cause: error, runtime: 'codex' }
+      );
+    }
+    const detail =
+      error instanceof ExecError ? error.stderr : (error as Error).message;
+    throw new WardenAuthenticationError(
+      `Codex CLI is not ready for local subscription auth: ${detail}\n` +
+      'Run `codex login` and confirm `codex login status` succeeds.',
+      { cause: error, runtime: 'codex' }
     );
   }
 }

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -64,6 +64,10 @@ const AUTH_ERROR_GUIDANCE = `
 
 https://console.anthropic.com/ for API keys`;
 
+const CODEX_AUTH_ERROR_GUIDANCE = `
+  codex login                              # Use OpenAI subscription auth
+  export WARDEN_OPENAI_API_KEY=sk-...      # Or use API key`;
+
 /** IPC/subprocess failure error codes (EPIPE, ECONNRESET, etc.) */
 const IPC_ERROR_CODES = ['EPIPE', 'ECONNRESET', 'ECONNREFUSED', 'ENOTCONN'];
 
@@ -85,10 +89,13 @@ export function isSubprocessError(error: unknown): boolean {
 }
 
 export class WardenAuthenticationError extends Error {
-  constructor(sdkError?: string, options?: { cause?: unknown }) {
+  constructor(sdkError?: string, options?: { cause?: unknown; runtime?: 'claude' | 'codex' }) {
+    const guidance = options?.runtime === 'codex'
+      ? CODEX_AUTH_ERROR_GUIDANCE
+      : AUTH_ERROR_GUIDANCE;
     const message = sdkError
-      ? `Authentication failed: ${sdkError}\n${AUTH_ERROR_GUIDANCE}`
-      : `Authentication required.${AUTH_ERROR_GUIDANCE}`;
+      ? `Authentication failed: ${sdkError}\n${guidance}`
+      : `Authentication required.${guidance}`;
     super(message, options);
     this.name = 'WardenAuthenticationError';
   }

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -188,7 +188,7 @@ export async function extractFindingsWithLLM(
       : { apiKey: apiKeyOrOptions, maxRetries };
   const { apiKey, runtime, model } = options;
 
-  if (!apiKey) {
+  if (!apiKey && (runtime ?? 'claude') === 'claude') {
     return {
       success: false,
       error: 'no_api_key_for_fallback',
@@ -505,7 +505,7 @@ export async function mergeCrossLocationFindings(
 
   // Early exit: need at least 2 located findings to merge
   const withLocations = findings.filter((f) => f.location);
-  if (withLocations.length < 2 || !apiKey) {
+  if (withLocations.length < 2 || (!apiKey && (options?.runtime ?? 'claude') === 'claude')) {
     return { findings, mergedCount: 0 };
   }
 

--- a/src/sdk/json-output.ts
+++ b/src/sdk/json-output.ts
@@ -67,7 +67,7 @@ async function repairJsonOutput<T>(
   reason: string,
   repair: JsonOutputRepairOptions,
 ): Promise<ParseJsonFromOutputResult<T>> {
-  if (!repair.apiKey) {
+  if (!repair.apiKey && (repair.runtimeName ?? repair.runtime?.name ?? 'claude') === 'claude') {
     return {
       success: false,
       error: `${reason}; repair_skipped: missing_api_key`,

--- a/src/sdk/runner.ts
+++ b/src/sdk/runner.ts
@@ -70,6 +70,7 @@ export { analyzeFile, runSkill, generateSummary } from './analyze.js';
 
 // Re-export runtime registry and adapter contracts
 export {
+  codexRuntime,
   claudeRuntime,
   getRuntimeProviderOptions,
   getRuntime,

--- a/src/sdk/runtimes/codex.test.ts
+++ b/src/sdk/runtimes/codex.test.ts
@@ -1,0 +1,76 @@
+import { EventEmitter } from 'node:events';
+import { writeFileSync } from 'node:fs';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { codexRuntime } from './codex.js';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'node:child_process';
+
+const mockSpawn = vi.mocked(spawn);
+
+function mockCodexProcess(onSpawn: (args: string[]) => void): ReturnType<typeof spawn> {
+  const child = new EventEmitter() as ReturnType<typeof spawn>;
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  Object.assign(child, {
+    stdin,
+    stdout,
+    stderr,
+    kill: vi.fn(),
+  });
+  mockSpawn.mockImplementation((_file, args) => {
+    const cliArgs = args as string[];
+    queueMicrotask(() => {
+      onSpawn(cliArgs);
+      child.emit('close', 0, null);
+    });
+    return child;
+  });
+  return child;
+}
+
+describe('codexRuntime.runSkill', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  it('runs codex exec in read-only mode and normalizes the final message', async () => {
+    mockCodexProcess((args) => {
+      const outputPath = args[args.indexOf('--output-last-message') + 1];
+      writeFileSync(outputPath!, '{"findings":[]}');
+    });
+
+    const result = await codexRuntime.runSkill({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      repoPath: '/repo',
+      skillName: 'test-skill',
+      options: { model: 'gpt-5.3-codex' },
+      providerOptions: { pathToCodexExecutable: '/bin/codex' },
+    });
+
+    expect(mockSpawn).toHaveBeenCalledWith('/bin/codex', expect.arrayContaining([
+      'exec',
+      '--cd',
+      '/repo',
+      '--sandbox',
+      'read-only',
+      '--ephemeral',
+      '--model',
+      'gpt-5.3-codex',
+      '-',
+    ]), expect.objectContaining({
+      cwd: '/repo',
+    }));
+    expect(result.result).toMatchObject({
+      status: 'success',
+      text: '{"findings":[]}',
+      responseModel: 'gpt-5.3-codex',
+    });
+  });
+});

--- a/src/sdk/runtimes/codex.ts
+++ b/src/sdk/runtimes/codex.ts
@@ -1,0 +1,363 @@
+/**
+ * Codex runtime adapter.
+ *
+ * This adapter targets local subscription auth by shelling out to `codex exec`.
+ * It keeps Warden's normal hunk preparation, parsing, verification, and
+ * reporting pipeline intact while letting Codex own repo-aware tool use.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { z } from 'zod';
+import { Sentry } from '../../sentry.js';
+import { isAuthenticationErrorMessage } from '../errors.js';
+import { extractJson } from '../haiku.js';
+import { buildJsonOutputSection, joinPromptSections } from '../prompt-sections.js';
+import { emptyUsage } from '../usage.js';
+import type {
+  AuxiliaryRunRequest,
+  AuxiliaryRunResult,
+  Runtime,
+  SkillRunRequest,
+  SkillRunResponse,
+  SkillRunResult,
+  SynthesisRunRequest,
+} from './types.js';
+
+interface CodexExecResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface CodexProviderOptions {
+  pathToCodexExecutable?: string;
+}
+
+const DEFAULT_CODEX_EXECUTABLE = 'codex';
+
+function getCodexProviderOptions(providerOptions: unknown): CodexProviderOptions {
+  if (!providerOptions || typeof providerOptions !== 'object') {
+    return {};
+  }
+
+  const { pathToCodexExecutable } = providerOptions as { pathToCodexExecutable?: unknown };
+  return {
+    pathToCodexExecutable: typeof pathToCodexExecutable === 'string'
+      ? pathToCodexExecutable
+      : undefined,
+  };
+}
+
+function buildCodexPrompt(systemPrompt: string, userPrompt: string): string {
+  return joinPromptSections([
+    `<system>
+${systemPrompt}
+</system>`,
+    `<runtime_constraints>
+Run as a read-only Warden analysis task. Inspect the repository as needed, but do not modify files.
+Return the response requested by Warden's prompt.
+</runtime_constraints>`,
+    `<user>
+${userPrompt}
+</user>`,
+  ]);
+}
+
+function buildStructuredPrompt(prompt: string, schema: z.ZodType): string {
+  return joinPromptSections([
+    prompt,
+    buildJsonOutputSection(`Return only JSON that validates against this JSON Schema:
+${JSON.stringify(z.toJSONSchema(schema), null, 2)}`),
+  ]);
+}
+
+function runCodexExec(args: string[], input: string, options: {
+  executable: string;
+  cwd: string;
+  abortController?: AbortController;
+}): Promise<CodexExecResult> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(options.executable, args, {
+        cwd: options.cwd,
+        env: process.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const abort = (): void => {
+      child.kill('SIGTERM');
+    };
+
+    if (options.abortController?.signal.aborted) {
+      abort();
+    }
+    options.abortController?.signal.addEventListener('abort', abort, { once: true });
+
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.on('error', (error) => {
+      options.abortController?.signal.removeEventListener('abort', abort);
+      reject(error);
+    });
+    child.on('close', (exitCode, signal) => {
+      options.abortController?.signal.removeEventListener('abort', abort);
+      resolve({
+        exitCode,
+        signal,
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+      });
+    });
+
+    child.stdin.end(input);
+  });
+}
+
+function parseCodexUsage(stdout: string) {
+  const usage = emptyUsage();
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line) as {
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          cached_input_tokens?: number;
+          reasoning_output_tokens?: number;
+          total_cost_usd?: number;
+        };
+      };
+      if (!event.usage) continue;
+      usage.inputTokens += event.usage.input_tokens ?? 0;
+      usage.outputTokens += event.usage.output_tokens ?? 0;
+      usage.cacheReadInputTokens = (usage.cacheReadInputTokens ?? 0) + (event.usage.cached_input_tokens ?? 0);
+      usage.costUSD += event.usage.total_cost_usd ?? 0;
+    } catch {
+      // Codex JSONL event shapes may evolve; usage is best-effort only.
+    }
+  }
+  return usage;
+}
+
+function resultFromCodex(args: {
+  text: string;
+  stdout: string;
+  model?: string;
+  durationMs: number;
+}): SkillRunResult {
+  return {
+    status: 'success',
+    text: args.text,
+    errors: [],
+    usage: parseCodexUsage(args.stdout),
+    responseModel: args.model,
+    durationMs: args.durationMs,
+  };
+}
+
+function failureFromCodex(args: {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  stdout: string;
+  model?: string;
+  aborted: boolean;
+  durationMs: number;
+}): SkillRunResult {
+  const diagnostic = [args.stderr.trim(), args.stdout.trim()].filter(Boolean).join('\n').trim();
+  const status = args.aborted
+    ? 'aborted'
+    : isAuthenticationErrorMessage(diagnostic)
+      ? 'auth_error'
+      : 'provider_error';
+  return {
+    status,
+    text: '',
+    errors: [diagnostic || `Codex exited with code ${args.exitCode ?? 'null'}${args.signal ? ` (${args.signal})` : ''}`],
+    usage: parseCodexUsage(args.stdout),
+    responseModel: args.model,
+    durationMs: args.durationMs,
+  };
+}
+
+async function runCodexPrompt(args: {
+  prompt: string;
+  repoPath: string;
+  model?: string;
+  maxTurns?: number;
+  abortController?: AbortController;
+  executable: string;
+}): Promise<SkillRunResponse> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'warden-codex-'));
+  const outputPath = join(tempDir, 'last-message.txt');
+  const cliArgs = [
+    'exec',
+    '--cd',
+    args.repoPath,
+    '--sandbox',
+    'read-only',
+    '--skip-git-repo-check',
+    '--ephemeral',
+    '--output-last-message',
+    outputPath,
+    '--color',
+    'never',
+    '--json',
+  ];
+  if (args.model) {
+    cliArgs.push('--model', args.model);
+  }
+  cliArgs.push('-');
+
+  const startedAt = Date.now();
+  try {
+    const result = await runCodexExec(cliArgs, args.prompt, {
+      executable: args.executable,
+      cwd: args.repoPath,
+      abortController: args.abortController,
+    });
+    const durationMs = Date.now() - startedAt;
+    if (result.exitCode !== 0 || result.signal) {
+      return {
+        result: failureFromCodex({
+          exitCode: result.exitCode,
+          signal: result.signal,
+          stderr: result.stderr,
+          stdout: result.stdout,
+          model: args.model,
+          aborted: args.abortController?.signal.aborted ?? false,
+          durationMs,
+        }),
+        authError: isAuthenticationErrorMessage(result.stderr) ? result.stderr.trim() : undefined,
+        stderr: result.stderr.trim() || undefined,
+      };
+    }
+
+    const text = await readFile(outputPath, 'utf-8');
+    return {
+      result: resultFromCodex({
+        text,
+        stdout: result.stdout,
+        model: args.model,
+        durationMs,
+      }),
+      stderr: result.stderr.trim() || undefined,
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function runStructured<T>(
+  request: {
+    kind: 'auxiliary' | 'synthesis';
+    prompt: string;
+    schema: z.ZodType<T>;
+    model?: string;
+    maxTokens?: number;
+    tools?: unknown[];
+    executable?: string;
+  }
+): Promise<AuxiliaryRunResult<T>> {
+  if (request.tools) {
+    return {
+      success: false,
+      error: 'Codex auxiliary tool calls are not supported',
+      usage: emptyUsage(),
+    };
+  }
+
+  const response = await runCodexPrompt({
+    prompt: buildStructuredPrompt(request.prompt, request.schema),
+    repoPath: process.cwd(),
+    model: request.model,
+    maxTurns: 1,
+    executable: request.executable ?? DEFAULT_CODEX_EXECUTABLE,
+  });
+  const usage = response.result?.usage ?? emptyUsage();
+  if (!response.result || response.result.status !== 'success') {
+    return {
+      success: false,
+      error: response.authError ?? response.result?.errors.join('; ') ?? 'Codex returned no result',
+      usage,
+    };
+  }
+
+  const json = extractJson(response.result.text);
+  if (!json) {
+    return { success: false, error: 'No JSON found in response', usage };
+  }
+
+  try {
+    const parsed = JSON.parse(json);
+    const validated = request.schema.safeParse(parsed);
+    if (!validated.success) {
+      return { success: false, error: `Validation failed: ${validated.error.message}`, usage };
+    }
+    return { success: true, data: validated.data, usage };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: message, usage };
+  }
+}
+
+export const codexRuntime: Runtime = {
+  name: 'codex',
+
+  async runSkill(request: SkillRunRequest): Promise<SkillRunResponse> {
+    const { pathToCodexExecutable } = getCodexProviderOptions(request.providerOptions);
+    const { maxTurns = 50, model, abortController } = request.options;
+    return Sentry.startSpan(
+      {
+        op: 'gen_ai.invoke_agent',
+        name: `invoke_agent ${request.skillName}`,
+        attributes: {
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.provider.name': 'openai',
+          'gen_ai.agent.name': request.skillName,
+          'gen_ai.request.model': model ?? 'codex-default',
+          'warden.request.max_turns': maxTurns,
+        },
+      },
+      async (span) => {
+        const prompt = buildCodexPrompt(request.systemPrompt, request.userPrompt);
+        span.setAttribute('gen_ai.request.messages', JSON.stringify([
+          { role: 'system', content: request.systemPrompt },
+          { role: 'user', content: request.userPrompt },
+        ]));
+        const response = await runCodexPrompt({
+          prompt,
+          repoPath: request.repoPath,
+          model,
+          maxTurns,
+          abortController,
+          executable: pathToCodexExecutable ?? DEFAULT_CODEX_EXECUTABLE,
+        });
+        if (response.result?.text) {
+          span.setAttribute('gen_ai.response.text', JSON.stringify([response.result.text]));
+        }
+        return response;
+      },
+    );
+  },
+
+  async runAuxiliary<T>(request: AuxiliaryRunRequest<T>): Promise<AuxiliaryRunResult<T>> {
+    return runStructured({ kind: 'auxiliary', ...request });
+  },
+
+  async runSynthesis<T>(request: SynthesisRunRequest<T>): Promise<AuxiliaryRunResult<T>> {
+    return runStructured({ kind: 'synthesis', ...request });
+  },
+};

--- a/src/sdk/runtimes/index.test.ts
+++ b/src/sdk/runtimes/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
+  codexRuntime,
   claudeRuntime,
   getRuntime,
   getRuntimeProviderOptions,
@@ -21,11 +22,21 @@ describe('runtimes', () => {
     expect(() => getRuntime('pi' as never)).toThrow('Unsupported runtime: pi');
   });
 
+  it('exposes Codex as a runtime provider', () => {
+    expect(getRuntime('codex')).toBe(codexRuntime);
+    expect(codexRuntime.name).toBe('codex');
+  });
+
   it('builds provider options at the runtime boundary', () => {
     expect(getRuntimeProviderOptions('claude', {
       pathToClaudeCodeExecutable: '/bin/claude',
     })).toEqual({
       pathToClaudeCodeExecutable: '/bin/claude',
+    });
+    expect(getRuntimeProviderOptions('codex', {
+      pathToCodexExecutable: '/bin/codex',
+    })).toEqual({
+      pathToCodexExecutable: '/bin/codex',
     });
   });
 

--- a/src/sdk/runtimes/index.ts
+++ b/src/sdk/runtimes/index.ts
@@ -1,11 +1,14 @@
+import { codexRuntime } from './codex.js';
 import { claudeRuntime } from './claude.js';
 import type { Runtime, RuntimeName } from './types.js';
 
 const RUNTIMES: Partial<Record<RuntimeName, Runtime>> = {
   claude: claudeRuntime,
+  codex: codexRuntime,
 };
 
 export { claudeRuntime } from './claude.js';
+export { codexRuntime } from './codex.js';
 export type {
   AuxiliaryRunRequest,
   AuxiliaryRunResult,
@@ -32,6 +35,7 @@ export function getRuntime(name: RuntimeName = 'claude'): Runtime {
 
 export interface RuntimeProviderOptionsInput {
   pathToClaudeCodeExecutable?: string;
+  pathToCodexExecutable?: string;
 }
 
 /**
@@ -43,6 +47,9 @@ export function getRuntimeProviderOptions(
 ): unknown {
   if (name === 'claude') {
     return { pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable };
+  }
+  if (name === 'codex') {
+    return { pathToCodexExecutable: options.pathToCodexExecutable };
   }
 
   return undefined;

--- a/src/sdk/runtimes/types.ts
+++ b/src/sdk/runtimes/types.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import type { ToolConfig } from '../../config/schema.js';
 import type { UsageStats } from '../../types/index.js';
 
-export const RuntimeNameSchema = z.enum(['claude']);
+export const RuntimeNameSchema = z.enum(['claude', 'codex']);
 export type RuntimeName = z.infer<typeof RuntimeNameSchema>;
 
 export type SkillRunStatus =

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { escapeHtml, getAnthropicApiKey } from './index.js';
+import { escapeHtml, getAnthropicApiKey, getOpenAIApiKey } from './index.js';
 
 describe('escapeHtml', () => {
   it('escapes angle brackets outside code', () => {
@@ -80,5 +80,35 @@ describe('getAnthropicApiKey', () => {
 
   it('returns undefined when neither key is set', () => {
     expect(getAnthropicApiKey()).toBeUndefined();
+  });
+});
+
+describe('getOpenAIApiKey', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['WARDEN_OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns WARDEN_OPENAI_API_KEY when set', () => {
+    process.env['WARDEN_OPENAI_API_KEY'] = 'warden-openai-key';
+    expect(getOpenAIApiKey()).toBe('warden-openai-key');
+  });
+
+  it('returns WARDEN_OPENAI_API_KEY over OPENAI_API_KEY when both set', () => {
+    process.env['WARDEN_OPENAI_API_KEY'] = 'warden-openai-key';
+    process.env['OPENAI_API_KEY'] = 'openai-key';
+    expect(getOpenAIApiKey()).toBe('warden-openai-key');
+  });
+
+  it('falls back to OPENAI_API_KEY when Warden key is not set', () => {
+    process.env['OPENAI_API_KEY'] = 'openai-key';
+    expect(getOpenAIApiKey()).toBe('openai-key');
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,3 +58,11 @@ export function escapeHtml(text: string): string {
 export function getAnthropicApiKey(): string | undefined {
   return process.env['WARDEN_ANTHROPIC_API_KEY'] ?? process.env['ANTHROPIC_API_KEY'];
 }
+
+/**
+ * Get the OpenAI API key from environment variables.
+ * Checks WARDEN_OPENAI_API_KEY first, then falls back to OPENAI_API_KEY.
+ */
+export function getOpenAIApiKey(): string | undefined {
+  return process.env['WARDEN_OPENAI_API_KEY'] ?? process.env['OPENAI_API_KEY'];
+}


### PR DESCRIPTION
## Summary

- add a Codex runtime adapter that runs local reviews through `codex exec`
- allow Codex subscription auth via `codex login` or `WARDEN_OPENAI_API_KEY`
- add `warden init --runtime codex` and Codex-specific local setup guidance
- document the `runtime = "codex"` configuration path

## Testing

- `corepack pnpm lint`
- `corepack pnpm exec tsc -p tsconfig.build.json`
- `corepack pnpm test`
- `node dist/cli/index.js init --runtime codex --no-color`
