### PR TITLE
meta(config): Configure Sentry MCP server

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.sentry]
+url = "https://mcp.sentry.dev/mcp/sentry/warden"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,6 @@
 {
   "mcpServers": {
     "sentry": {
-      "type": "http",
       "url": "https://mcp.sentry.dev/mcp/sentry/warden"
     }
   }

--- a/agents.toml
+++ b/agents.toml
@@ -39,3 +39,7 @@ source = "getsentry/skills"
 [[skills]]
 name = "pr-writer"
 source = "getsentry/skills"
+
+[[mcp]]
+name = "sentry"
+url = "https://mcp.sentry.dev/mcp/sentry/warden"


### PR DESCRIPTION
Configure Warden's Sentry MCP server across local agent tooling. Codex, Cursor, and agents.toml now point at the same non-experimental MCP URL, and the shared .mcp.json entry drops the experimental query parameter so all clients use the same endpoint.