### PR TITLE
fix(sentry): Tag action errors with repository

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -24,7 +24,7 @@
  * - ALL triggers failed (no successful analysis)
  */
 
-import { initSentry, Sentry, flushSentry } from '../sentry.js';
+import { initSentry, Sentry, flushSentry, setRepositoryScope } from '../sentry.js';
 initSentry('action');
 
 import { Octokit } from '@octokit/rest';
@@ -44,6 +44,8 @@ async function run(): Promise<void> {
   if (!eventName || !eventPath || !repoPath) {
     setFailed('This action must be run in a GitHub Actions environment');
   }
+
+  setRepositoryScope(process.env['GITHUB_REPOSITORY']);
 
   // Set up authentication environment variables
   setupAuthEnv(inputs);

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -6,7 +6,7 @@
 
 import { readFileSync } from 'node:fs';
 import type { Octokit } from '@octokit/rest';
-import { Sentry, logger, emitStaleResolutionMetric, setGlobalAttributes, emitRunMetric } from '../../sentry.js';
+import { Sentry, logger, emitStaleResolutionMetric, setRepositoryScope, emitRunMetric } from '../../sentry.js';
 import {
   buildSkillRootsByName,
   loadLayeredWardenConfig,
@@ -169,6 +169,7 @@ async function initializeWorkflow(
     Sentry.captureException(error, { tags: { operation: 'build_event_context' } });
     setFailed(`Failed to build event context: ${error}`);
   }
+  setRepositoryScope(context.repository.fullName);
 
   logGroup('Loading configuration');
   if (inputs.baseConfigPath) {
@@ -791,7 +792,6 @@ export async function runPRWorkflow(
         });
       }
 
-      setGlobalAttributes({ 'warden.repository': context.repository.fullName });
       emitRunMetric();
 
       const traceId = span.spanContext().traceId;

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -20,6 +20,7 @@ import { shouldFail, countFindingsAtOrAbove, countSeverity } from '../../trigger
 import { resolveSkillAsync } from '../../skills/loader.js';
 import { filterFindings } from '../../types/index.js';
 import type { SkillReport } from '../../types/index.js';
+import { setRepositoryScope } from '../../sentry.js';
 import type { ActionInputs } from '../inputs.js';
 import {
   setOutput,
@@ -43,6 +44,9 @@ export async function runScheduleWorkflow(
   inputs: ActionInputs,
   repoPath: string
 ): Promise<void> {
+  const githubRepository = process.env['GITHUB_REPOSITORY'];
+  setRepositoryScope(githubRepository);
+
   logGroup('Loading configuration');
   if (inputs.baseConfigPath) {
     console.log(`Base config path: ${inputs.baseConfigPath}`);
@@ -107,7 +111,6 @@ export async function runScheduleWorkflow(
   }
 
   // Get repo info from environment
-  const githubRepository = process.env['GITHUB_REPOSITORY'];
   if (!githubRepository) {
     setFailed('GITHUB_REPOSITORY environment variable not set');
   }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -48,6 +48,21 @@ export function setGlobalAttributes(attrs: Record<string, string | number | bool
 }
 
 /**
+ * Set repository metadata on the global Sentry scope.
+ */
+export function setRepositoryScope(repository: string | undefined): void {
+  if (!repository || !initialized) return;
+
+  try {
+    Sentry.setTag('repository', repository);
+  } catch {
+    // Never break the workflow
+  }
+
+  setGlobalAttributes({ 'warden.repository': repository });
+}
+
+/**
  * Get the trace ID from the active span, if available.
  * Useful for correlating runs to Sentry traces in logs and output.
  */


### PR DESCRIPTION
Action Sentry events now get a searchable repository tag before PR config loading can fail. This makes early action failures triageable by repository while preserving the existing `warden.repository` metric attribute.

**Repository Scope**

The action records `repository` as a Sentry tag through a shared helper that also keeps `warden.repository` on global metric attributes. PR workflows set it from parsed event context before config loading, and schedule workflows set it from `GITHUB_REPOSITORY` before early exits.

Validated by the commit hook with `tsc --noEmit`.

Refs #302
Refs WARDEN-Q