### PR TITLE
fix(config): Warn on duplicate layered skills

### DIFF
--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -187,6 +187,7 @@ async function initializeWorkflow(
     const layered = loadLayeredWardenConfig(repoPath, {
       baseConfigPath: inputs.baseConfigPath,
       configPath: inputs.configPath,
+      onWarning: (message) => console.log(`::warning::${message}`),
     });
     // The org base config is an enforced baseline. Repo config extends the run
     // with additional repo-local triggers, but does not override these

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -59,6 +59,7 @@ export async function runScheduleWorkflow(
     const layered = loadLayeredWardenConfig(repoPath, {
       baseConfigPath: inputs.baseConfigPath,
       configPath: inputs.configPath,
+      onWarning: (message) => console.log(`::warning::${message}`),
     });
     skillRootsByName = buildSkillRootsByName(repoPath, layered, inputs.baseSkillRoot);
     scheduleTriggers = resolveLayeredSkillConfigs(layered, undefined, skillRootsByName)

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -617,7 +617,7 @@ describe('mergeWardenConfigs', () => {
     });
   });
 
-  it('rejects duplicate skill names across layers', () => {
+  it('uses base skills and warns for duplicate skill names across layers', () => {
     const baseConfig: WardenConfig = {
       version: 1,
       skills: [{
@@ -634,10 +634,19 @@ describe('mergeWardenConfigs', () => {
       }],
     };
 
-    expect(() => mergeWardenConfigs(baseConfig, repoConfig)).toThrow(ConfigLoadError);
-    expect(() => mergeWardenConfigs(baseConfig, repoConfig)).toThrow(
-      'Duplicate skill names: shared-skill'
-    );
+    const warnings: string[] = [];
+    const merged = mergeWardenConfigs(baseConfig, repoConfig, {
+      baseConfigPath: '.warden-org/warden.toml',
+      repoConfigPath: 'warden.toml',
+      onWarning: (message) => warnings.push(message),
+    });
+
+    expect(merged.skills).toHaveLength(1);
+    expect(merged.skills[0]?.name).toBe('shared-skill');
+    expect(warnings).toEqual([
+      'Skill "shared-skill" is defined in both .warden-org/warden.toml and warden.toml. ' +
+      'Using the base config skill and ignoring the repo config duplicate.',
+    ]);
   });
 });
 
@@ -832,7 +841,7 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved[1]?.maxContextFiles).toBeUndefined();
   });
 
-  it('uses layer-specific skill roots when both layers define the same skill name', () => {
+  it('ignores repo layer duplicates when resolving skills', () => {
     const baseConfig: WardenConfig = {
       version: 1,
       skills: [{
@@ -862,13 +871,62 @@ describe('resolveLayeredSkillConfigs', () => {
       }
     );
 
-    expect(resolved).toHaveLength(2);
+    expect(resolved).toHaveLength(1);
     expect(resolved[0]?.skillRoot).toBe('/repo/.warden-org');
-    expect(resolved[1]?.skillRoot).toBe('/repo');
   });
 });
 
 describe('loadLayeredWardenConfig', () => {
+  it('loads base skill and skips repo duplicate with a warning', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-config-'));
+    const warnings: string[] = [];
+
+    try {
+      mkdirSync(join(tempDir, '.warden-org'));
+      writeFileSync(
+        join(tempDir, '.warden-org', 'warden.toml'),
+        [
+          'version = 1',
+          '',
+          '[[skills]]',
+          'name = "security-review"',
+          '',
+        ].join('\n')
+      );
+      writeFileSync(
+        join(tempDir, 'warden.toml'),
+        [
+          'version = 1',
+          '',
+          '[[skills]]',
+          'name = "security-review"',
+          '',
+          '[[skills]]',
+          'name = "repo-only"',
+          '',
+        ].join('\n')
+      );
+
+      const layered = loadLayeredWardenConfig(tempDir, {
+        baseConfigPath: '.warden-org/warden.toml',
+        configPath: 'warden.toml',
+        onWarning: (message) => warnings.push(message),
+      });
+
+      expect(layered.config.skills.map((skill) => skill.name)).toEqual([
+        'security-review',
+        'repo-only',
+      ]);
+      expect(layered.repoConfig?.skills.map((skill) => skill.name)).toEqual(['repo-only']);
+      expect(warnings).toEqual([
+        'Skill "security-review" is defined in both .warden-org/warden.toml and warden.toml. ' +
+        'Using the base config skill and ignoring the repo config duplicate.',
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects using the same file for the base and repo config', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'warden-config-'));
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -159,13 +159,52 @@ function inheritRepoLayerDefaults(base?: Defaults, repo?: Defaults): Defaults | 
   return Object.keys(inherited).length > 0 ? inherited : undefined;
 }
 
-export function mergeWardenConfigs(base: WardenConfig, overlay: WardenConfig): WardenConfig {
+export interface MergeWardenConfigOptions {
+  baseConfigPath?: string;
+  repoConfigPath?: string;
+  onWarning?: (message: string) => void;
+}
+
+function withoutBaseDuplicateSkills(
+  base: WardenConfig,
+  repo: WardenConfig,
+  options: MergeWardenConfigOptions = {}
+): WardenConfig {
+  const baseSkillNames = new Set(base.skills.map((skill) => skill.name));
+  const skipped = new Set<string>();
+  const skills = repo.skills.filter((skill) => {
+    if (!baseSkillNames.has(skill.name)) {
+      return true;
+    }
+
+    skipped.add(skill.name);
+    return false;
+  });
+
+  for (const skillName of skipped) {
+    const basePath = options.baseConfigPath ?? 'base config';
+    const repoPath = options.repoConfigPath ?? 'repo config';
+    options.onWarning?.(
+      `Skill "${skillName}" is defined in both ${basePath} and ${repoPath}. ` +
+      'Using the base config skill and ignoring the repo config duplicate.'
+    );
+  }
+
+  return skipped.size > 0 ? { ...repo, skills } : repo;
+}
+
+export function mergeWardenConfigs(
+  base: WardenConfig,
+  overlay: WardenConfig,
+  options: MergeWardenConfigOptions = {}
+): WardenConfig {
+  const effectiveOverlay = withoutBaseDuplicateSkills(base, overlay, options);
   const mergedConfig = {
     version: 1 as const,
-    defaults: mergeDefaults(base.defaults, overlay.defaults),
-    skills: [...base.skills, ...overlay.skills],
-    runner: mergeRunnerConfig(base.runner, overlay.runner),
-    logs: mergeLogsConfig(base.logs, overlay.logs),
+    defaults: mergeDefaults(base.defaults, effectiveOverlay.defaults),
+    skills: [...base.skills, ...effectiveOverlay.skills],
+    runner: mergeRunnerConfig(base.runner, effectiveOverlay.runner),
+    logs: mergeLogsConfig(base.logs, effectiveOverlay.logs),
   };
 
   const result = WardenConfigSchema.safeParse(mergedConfig);
@@ -180,6 +219,7 @@ export function mergeWardenConfigs(base: WardenConfig, overlay: WardenConfig): W
 export interface LayeredConfigOptions {
   baseConfigPath?: string;
   configPath?: string;
+  onWarning?: (message: string) => void;
 }
 
 export interface LoadedLayeredConfig {
@@ -265,7 +305,11 @@ export function loadLayeredWardenConfig(
     return { config: baseConfig, baseConfig };
   }
 
-  const repoConfig = loadWardenConfigFile(repoConfigPath);
+  const repoConfig = withoutBaseDuplicateSkills(baseConfig, loadWardenConfigFile(repoConfigPath), {
+    baseConfigPath: options.baseConfigPath,
+    repoConfigPath: options.configPath ?? 'warden.toml',
+    onWarning: options.onWarning,
+  });
   return {
     config: mergeWardenConfigs(baseConfig, repoConfig),
     baseConfig,
@@ -455,9 +499,10 @@ export function resolveLayeredSkillConfigs(
   skillRootsByName?: LayeredSkillRootsByName
 ): ResolvedTrigger[] {
   if (layered.baseConfig && layered.repoConfig) {
+    const repoConfig = withoutBaseDuplicateSkills(layered.baseConfig, layered.repoConfig);
     const repoConfigWithInheritedDefaults: WardenConfig = {
-      ...layered.repoConfig,
-      defaults: inheritRepoLayerDefaults(layered.baseConfig.defaults, layered.repoConfig.defaults),
+      ...repoConfig,
+      defaults: inheritRepoLayerDefaults(layered.baseConfig.defaults, repoConfig.defaults),
     };
 
     return [


### PR DESCRIPTION
Layered config duplicate skill names now keep the base config skill and ignore the repo duplicate instead of failing config load. The action workflows surface the ignored repo entry as a GitHub Actions warning, so the run keeps moving while the conflicting config remains visible.

**Layered Skill Conflicts**

Base config skills remain the enforced baseline. Repo config entries with the same skill name are skipped before trigger resolution, while duplicate names inside a single config file still fail schema validation.

Fixes #302
Fixes WARDEN-Q