### PR TITLE
fix(config): Allow base configs to use built-in skills

### DIFF
--- a/src/action/triggers/executor.test.ts
+++ b/src/action/triggers/executor.test.ts
@@ -113,6 +113,30 @@ const mockContext: EventContext = {
     );
   });
 
+  it('resolves built-in base skills without the repo root', async () => {
+    const mockReport = createReport();
+
+    vi.mocked(resolveSkillAsync).mockResolvedValue({
+      name: 'test-skill',
+      description: 'Test skill',
+      prompt: 'Review code',
+    });
+    vi.mocked(runSkillTask).mockImplementation(async (taskOptions) => {
+      await taskOptions.resolveSkill();
+      return { name: 'test-trigger', report: mockReport };
+    });
+    vi.mocked(createSkillCheck).mockResolvedValue({ checkRunId: 123, url: 'https://github.com/check/123' });
+    vi.mocked(updateSkillCheck).mockResolvedValue(undefined);
+
+    await executeTrigger({ ...mockTrigger, useBuiltinSkill: true }, mockDeps);
+
+    expect(resolveSkillAsync).toHaveBeenCalledWith(
+      'test-skill',
+      undefined,
+      { remote: undefined }
+    );
+  });
+
   it('uses trigger-level execution defaults instead of merged config defaults', async () => {
     const mockReport = createReport();
 

--- a/src/action/triggers/executor.ts
+++ b/src/action/triggers/executor.ts
@@ -127,13 +127,14 @@ export async function executeTrigger(
       const minConfidence = trigger.minConfidence ?? 'medium';
       const requestChanges = trigger.requestChanges ?? deps.globalRequestChanges;
       const failCheck = trigger.failCheck ?? deps.globalFailCheck;
+      const skillRoot = trigger.useBuiltinSkill ? undefined : (trigger.skillRoot ?? context.repoPath);
 
       try {
         const taskOptions: SkillTaskOptions = {
           name: trigger.name,
           displayName: trigger.skill,
           failOn,
-          resolveSkill: () => resolveSkillAsync(trigger.skill, trigger.skillRoot ?? context.repoPath, {
+          resolveSkill: () => resolveSkillAsync(trigger.skill, skillRoot, {
             remote: trigger.remote,
           }),
           context: filterContextByPaths(context, trigger.filters),

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -168,7 +168,8 @@ export async function runScheduleWorkflow(
       console.log(`Found ${context.pullRequest.files.length} files matching patterns`);
 
       // Run skill
-      const skill = await resolveSkillAsync(resolved.skill, resolved.skillRoot ?? repoPath, {
+      const skillRoot = resolved.useBuiltinSkill ? undefined : (resolved.skillRoot ?? repoPath);
+      const skill = await resolveSkillAsync(resolved.skill, skillRoot, {
         remote: resolved.remote,
       });
       const usesClaudeRuntime = (resolved.runtime ?? 'claude') === 'claude';

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -666,6 +666,26 @@ describe('buildSkillRootsByName', () => {
     expect(buildSkillRootsByName('/repo', layered)).toBeUndefined();
   });
 
+  it('resolves built-in base skills without baseSkillRoot', () => {
+    const layered = {
+      config: {
+        version: 1 as const,
+        skills: [{ name: 'security-review' }],
+      },
+      baseConfig: {
+        version: 1 as const,
+        skills: [{ name: 'security-review' }],
+      },
+    };
+
+    const roots = buildSkillRootsByName('/repo', layered);
+    const [resolved] = resolveLayeredSkillConfigs(layered, undefined, roots);
+
+    expect(roots).toEqual({ base: { 'security-review': undefined } });
+    expect(resolved?.useBuiltinSkill).toBe(true);
+    expect(resolved?.skillRoot).toBeUndefined();
+  });
+
   it('requires baseSkillRoot when base config defines local skills', () => {
     const layered = {
       config: {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,9 +2,11 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join, normalize } from 'node:path';
 import { parse as parseToml } from 'smol-toml';
 import { Sentry } from '../sentry.js';
+import { isBuiltinSkillName } from '../skills/loader.js';
 import {
   WardenConfigSchema,
   type WardenConfig,
+  type SkillConfig,
   type ScheduleConfig,
   type TriggerType,
   type Defaults,
@@ -243,7 +245,10 @@ export function buildSkillRootsByName(
 
   if (layered.baseConfig) {
     const localBaseSkills = layered.baseConfig.skills.filter((skill) => !skill.remote);
-    if (localBaseSkills.length > 0 && !baseSkillRoot) {
+    const localBaseSkillsRequiringRoot = localBaseSkills.filter(
+      (skill) => !isBuiltinSkillName(skill.name)
+    );
+    if (localBaseSkillsRequiringRoot.length > 0 && !baseSkillRoot) {
       throw new ConfigLoadError(
         'base-skill-root is required when the base config defines local skills'
       );
@@ -256,6 +261,12 @@ export function buildSkillRootsByName(
       }
       for (const skill of localBaseSkills) {
         baseRoots[skill.name] = resolvedBaseSkillRoot;
+      }
+    } else {
+      for (const skill of localBaseSkills) {
+        if (isBuiltinSkillName(skill.name)) {
+          baseRoots[skill.name] = undefined;
+        }
       }
     }
   }
@@ -335,6 +346,8 @@ export interface ResolvedTrigger {
   remote?: string;
   /** Repository root to use when resolving local skill names or paths */
   skillRoot?: string;
+  /** Resolve from package built-ins instead of repo-local skill directories */
+  useBuiltinSkill?: boolean;
   /** Path filters */
   filters: { paths?: string[]; ignorePaths?: string[] };
   // Flattened output fields (merged: trigger > skill > defaults)
@@ -368,6 +381,21 @@ export interface ResolvedTrigger {
   maxContextFiles?: number;
   /** Schedule-specific configuration */
   schedule?: ScheduleConfig;
+}
+
+function resolveSkillSource(
+  skill: SkillConfig,
+  skillRootsByName?: Record<string, string | undefined>
+): Pick<ResolvedTrigger, 'skillRoot' | 'useBuiltinSkill'> {
+  if (!skillRootsByName || !Object.hasOwn(skillRootsByName, skill.name)) {
+    return {};
+  }
+
+  const skillRoot = skillRootsByName[skill.name];
+  return {
+    skillRoot,
+    useBuiltinSkill: !skill.remote && skillRoot === undefined,
+  };
 }
 
 /**
@@ -412,6 +440,7 @@ export function resolveSkillConfigs(
   const verifyFindings = defaults?.verification?.enabled !== false;
 
   for (const skill of config.skills) {
+    const skillSource = resolveSkillSource(skill, skillRootsByName);
     const baseModel =
       emptyToUndefined(skill.model) ??
       emptyToUndefined(defaults?.agent?.model) ??
@@ -438,7 +467,7 @@ export function resolveSkillConfigs(
         skill: skill.name,
         type: '*',
         remote: skill.remote,
-        skillRoot: skillRootsByName?.[skill.name],
+        ...skillSource,
         filters,
         failOn: skill.failOn ?? defaults?.failOn,
         reportOn: skill.reportOn ?? defaults?.reportOn,
@@ -465,7 +494,7 @@ export function resolveSkillConfigs(
           type: trigger.type,
           actions: trigger.actions,
           remote: skill.remote,
-          skillRoot: skillRootsByName?.[skill.name],
+          ...skillSource,
           filters,
           // 3-level merge: trigger > skill > defaults
           failOn: trigger.failOn ?? skill.failOn ?? defaults?.failOn,

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -90,6 +90,29 @@ function resolvePackageRoot(): string {
 }
 
 /**
+ * Return true when a skill name resolves to a package-native built-in skill.
+ */
+export function isBuiltinSkillName(name: string): boolean {
+  if (isPathLike(name)) {
+    return false;
+  }
+
+  const packageRoot = resolvePackageRoot();
+  for (const dir of BUILTIN_SKILL_DIRECTORIES) {
+    const dirPath = join(packageRoot, dir);
+
+    if (
+      existsSync(join(dirPath, name, 'SKILL.md')) ||
+      existsSync(join(dirPath, `${name}.md`))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Clear the skills cache. Useful for testing or when skills may have changed.
  */
 export function clearSkillsCache(): void {


### PR DESCRIPTION
Allow org base configs to reference package built-in skills without requiring base-skill-root. This keeps base configs that use built-ins like security-review from failing during workflow initialization.

**Skill Resolution**

Built-in base skills are marked for package built-in resolution when no base-skill-root is supplied, so they do not fall back to target repo-local skill directories.

Fixes WARDEN-R