### PR TITLE
fix(output): Render GitHub footers as muted text

### DIFF
--- a/src/output/dedup.test.ts
+++ b/src/output/dedup.test.ts
@@ -161,6 +161,11 @@ describe('isWardenComment', () => {
     expect(isWardenComment(body)).toBe(true);
   });
 
+  it('returns true for current muted attribution', () => {
+    const body = `**Issue**\n\nDescription\n\n<sub>Identified by Warden skill · ABC-123</sub>`;
+    expect(isWardenComment(body)).toBe(true);
+  });
+
   it('returns true for current backtick format attribution', () => {
     const body = `**Issue**\n\nDescription\n\nIdentified by Warden \`skill\` · ABC-123`;
     expect(isWardenComment(body)).toBe(true);
@@ -400,6 +405,16 @@ describe('parseWardenSkills', () => {
     expect(parseWardenSkills(body)).toEqual([]);
   });
 
+  it('parses single skill from current muted format', () => {
+    const body = `<sub>Identified by Warden notseer · ABC-123</sub>`;
+    expect(parseWardenSkills(body)).toEqual(['notseer']);
+  });
+
+  it('parses multiple skills from current muted format', () => {
+    const body = `<sub>Identified by Warden skill1, skill2, skill3 · XYZ-789</sub>`;
+    expect(parseWardenSkills(body)).toEqual(['skill1', 'skill2', 'skill3']);
+  });
+
   it('parses new format with severity', () => {
     const body = `**:warning: Issue**\n\nDescription\n\n<sub>Identified by Warden via \`security-review\` · high</sub>`;
     expect(parseWardenSkills(body)).toEqual(['security-review']);
@@ -460,6 +475,20 @@ describe('updateWardenCommentBody', () => {
 
   it('returns null if skill already listed', () => {
     const body = `<sub>warden: skill1, skill2</sub>`;
+    const result = updateWardenCommentBody(body, 'skill1');
+    expect(result).toBeNull();
+  });
+
+  it('adds new skill to current muted attribution', () => {
+    const body = `**Issue**\n\nDescription\n\n<sub>Identified by Warden skill1 · ABC-123</sub>`;
+    const result = updateWardenCommentBody(body, 'skill2');
+    expect(result).toContain('<sub>Identified by Warden skill1, skill2 · ABC-123</sub>');
+    expect(result).not.toContain('`skill1`');
+    expect(result).not.toContain('[skill1]');
+  });
+
+  it('returns null if skill already listed in current muted attribution', () => {
+    const body = `<sub>Identified by Warden skill1, skill2 · ABC-123</sub>`;
     const result = updateWardenCommentBody(body, 'skill1');
     expect(result).toBeNull();
   });

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -144,30 +144,46 @@ export function parseWardenComment(body: string): { title: string; description: 
 
 /**
  * Check if a comment body is a Warden-generated comment.
- * Supports current format (Identified by Warden `skill`), and legacy formats:
- * bracket (<sub>Identified by Warden [skill]</sub>), via (<sub>Identified by Warden via `skill`</sub>),
- * old (<sub>warden: skill</sub>).
+ * Supports current muted format (<sub>Identified by Warden skill</sub>), and
+ * legacy formats: backtick (Identified by Warden `skill`), bracket
+ * (<sub>Identified by Warden [skill]</sub>), via
+ * (<sub>Identified by Warden via `skill`</sub>), old
+ * (<sub>warden: skill</sub>).
  */
 export function isWardenComment(body: string): boolean {
   return (
+    body.includes('<sub>Identified by Warden ') ||
     body.includes('Identified by Warden `') ||
     body.includes('<sub>warden:') ||
-    body.includes('<sub>Identified by Warden via') ||
-    body.includes('<sub>Identified by Warden [') ||
     body.includes('<!-- warden:v1:')
   );
 }
 
+function parsePlainSkillList(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 /**
  * Parse skill names from a Warden comment's attribution line.
- * Supports four formats:
- * - Current: "Identified by Warden `skill1`, `skill2` · id"
+ * Supports five formats:
+ * - Current: "<sub>Identified by Warden skill1, skill2 · id</sub>"
+ * - Legacy backtick: "Identified by Warden `skill1`, `skill2` · id"
  * - Legacy bracket: "<sub>Identified by Warden [skill1], [skill2] · id</sub>"
  * - Legacy via: "<sub>Identified by Warden via `skill1`, `skill2` · severity</sub>"
  * - Legacy old: "<sub>warden: skill1, skill2</sub>"
  */
 export function parseWardenSkills(body: string): string[] {
-  // Try current backtick format (no "via"): Identified by Warden `skill1`, `skill2` · id
+  // Try current muted format: <sub>Identified by Warden skill1, skill2 · id</sub>
+  const plainSubMatch = body.match(/<sub>Identified by Warden (?!via\s)([^`[\]<]+?)(?:\s*·|<\/sub>)/);
+  if (plainSubMatch?.[1]) {
+    const skills = parsePlainSkillList(plainSubMatch[1]);
+    if (skills.length > 0) return skills;
+  }
+
+  // Try legacy backtick format (no "via"): Identified by Warden `skill1`, `skill2` · id
   const backtickMatch = body.match(/Identified by Warden ((?:`[^`]+`(?:, )?)+)/);
   if (backtickMatch?.[1]) {
     const skills = [...backtickMatch[1].matchAll(/`([^`]+)`/g)]
@@ -207,8 +223,10 @@ export function parseWardenSkills(body: string): string[] {
 
 /**
  * Update a Warden comment body to add a new skill to the attribution.
- * Current format: Changes "Identified by Warden `skill1` · id"
- *                 to "Identified by Warden `skill1`, `skill2` · id"
+ * Current format: Changes "<sub>Identified by Warden skill1 · id</sub>"
+ *                 to "<sub>Identified by Warden skill1, skill2 · id</sub>"
+ * Legacy backtick: Changes "Identified by Warden `skill1` · id"
+ *                  to "Identified by Warden `skill1`, `skill2` · id"
  * Legacy bracket: Changes "<sub>Identified by Warden [skill1] · id</sub>"
  *                 to "<sub>Identified by Warden [skill1], [skill2] · id</sub>"
  * Legacy via: Changes "<sub>Identified by Warden via `skill1` · severity</sub>"
@@ -229,7 +247,19 @@ export function updateWardenCommentBody(body: string, newSkill: string): string 
     return null;
   }
 
-  // Check if it's the current backtick format (no <sub>, no "via"): Identified by Warden `skill` · id
+  // Check if it's the current muted format: <sub>Identified by Warden skill · id</sub>
+  const plainSubFormatMatch = body.match(/<sub>Identified by Warden (?!via\s)[^`[\]<]+<\/sub>/);
+  if (plainSubFormatMatch) {
+    const allSkills = [...existingSkills, newSkill].join(', ');
+    const subTagMatch = body.match(/<sub>Identified by Warden (?!via\s)([^<]*?)(\s*·[^<]*)?<\/sub>/);
+    const suffix = subTagMatch?.[2] || '';
+    return body.replace(
+      /<sub>Identified by Warden (?!via\s)[^<]+<\/sub>/,
+      () => `<sub>Identified by Warden ${allSkills}${suffix}</sub>`
+    );
+  }
+
+  // Check if it's the legacy backtick format (no <sub>, no "via"): Identified by Warden `skill` · id
   const backtickFormatMatch = body.match(/Identified by Warden `[^`]+`/) && !body.includes('<sub>Identified by Warden');
   if (backtickFormatMatch) {
     const existingSkillsFormatted = existingSkills.map((s) => `\`${s}\``).join(', ');

--- a/src/output/github-checks.test.ts
+++ b/src/output/github-checks.test.ts
@@ -426,6 +426,6 @@ describe('updateCoreCheck', () => {
 
     const request = update.mock.calls[0]![0] as { output: { summary: string } };
     expect(request.output.summary).toContain('| find-warden-bugs | 0 | 1.0s | $26.19 |');
-    expect(request.output.summary).toContain('**Cost:** $26.19 (+verification: $6.19)');
+    expect(request.output.summary).toContain('<sub>⏱ 1.0s · 3.0k in / 680 out · $26.19 (+verification: $6.19)</sub>');
   });
 });

--- a/src/output/github-checks.ts
+++ b/src/output/github-checks.ts
@@ -383,17 +383,17 @@ function renderStatsFooter(
 
   const parts: string[] = [];
   if (durationMs !== undefined) {
-    parts.push(`**Duration:** ${formatDuration(durationMs)}`);
+    parts.push(`⏱ ${formatDuration(durationMs)}`);
   }
   if (usage) {
-    parts.push(`**Tokens:** ${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out`);
+    parts.push(`${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out`);
   }
   if (cost !== undefined) {
     const auxSuffix = auxiliaryUsage ? formatAuxiliarySuffix(auxiliaryUsage) : '';
-    parts.push(`**Cost:** ${formatCost(cost)}${auxSuffix}`);
+    parts.push(`${formatCost(cost)}${auxSuffix}`);
   }
 
-  return ['---', parts.join(' · ')];
+  return ['---', `<sub>${parts.join(' · ')}</sub>`];
 }
 
 /**

--- a/src/output/renderer.test.ts
+++ b/src/output/renderer.test.ts
@@ -69,7 +69,11 @@ describe('renderSkillReport', () => {
     const result = renderSkillReport(report);
 
     expect(result.review).toBeDefined();
-    expect(result.review!.comments[0]!.body).toContain('Identified by Warden `code-review` · `f1`');
+    expect(result.review!.comments[0]!.body).toContain(
+      '<sub>Identified by Warden code-review · f1</sub>'
+    );
+    expect(result.review!.comments[0]!.body).not.toContain('`code-review`');
+    expect(result.review!.comments[0]!.body).not.toContain('`f1`');
   });
 
   it('does not include confidence in attribution footnote', () => {
@@ -95,7 +99,7 @@ describe('renderSkillReport', () => {
 
     expect(result.review).toBeDefined();
     expect(result.review!.comments[0]!.body).toContain(
-      'Identified by Warden `security-review` · `f1`'
+      '<sub>Identified by Warden security-review · f1</sub>'
     );
     expect(result.review!.comments[0]!.body).not.toContain('confidence');
   });
@@ -736,7 +740,7 @@ describe('renderSkillReport', () => {
     expect(result.review!.comments).toHaveLength(0);
     expect(result.review!.body).toContain('General Issue');
     expect(result.review!.body).toContain('Applies to whole project');
-    expect(result.review!.body).toContain('Identified by Warden `security-review`');
+    expect(result.review!.body).toContain('<sub>Identified by Warden security-review</sub>');
     expect(result.summaryComment).toContain('General Issue');
     expect(result.summaryComment).toContain('General');
   });
@@ -1278,7 +1282,7 @@ describe('renderFindingsBody', () => {
     expect(body).toContain('**SQL Injection**');
     expect(body).toContain('(`src/db.ts:42`)');
     expect(body).toContain('User input in query');
-    expect(body).toContain('Identified by Warden `security-review`');
+    expect(body).toContain('<sub>Identified by Warden security-review</sub>');
   });
 
   it('renders findings without location', () => {

--- a/src/output/renderer.ts
+++ b/src/output/renderer.ts
@@ -91,8 +91,8 @@ function renderReview(
       body += '\n</details>';
     }
 
-    // Add attribution footnote with skill name and finding ID
-    body += `\n\nIdentified by Warden \`${report.skill}\` · \`${finding.id}\``;
+    // Add attribution footer with skill name and finding ID
+    body += `\n\n${renderAttributionFooter(report.skill, finding.id)}`;
 
     // Add deduplication marker
     const contentHash = generateContentHash(finding.title, finding.description);
@@ -167,6 +167,11 @@ function renderSuggestion(description: string, diff: string): string {
 
 function renderHiddenFindingsLink(hiddenCount: number, checkRunUrl: string): string {
   return `[View ${hiddenCount} additional ${pluralize(hiddenCount, 'finding')} in Checks](${checkRunUrl})`;
+}
+
+function renderAttributionFooter(skill: string, findingId?: string): string {
+  const idSuffix = findingId ? ` · ${escapeHtml(findingId)}` : '';
+  return `<sub>Identified by Warden ${escapeHtml(skill)}${idSuffix}</sub>`;
 }
 
 function renderSummaryComment(
@@ -271,7 +276,7 @@ export function renderFindingsBody(findings: Finding[], skill: string): string {
     lines.push(escapeHtml(finding.description));
     lines.push('');
   }
-  lines.push(`Identified by Warden \`${skill}\``);
+  lines.push(renderAttributionFooter(skill));
   return lines.join('\n');
 }
 


### PR DESCRIPTION
GitHub Action review footers now render attribution as muted subtext instead of normal text with code spans. This keeps finding comments visually consistent with the smaller stats footer while leaving existing legacy attribution formats readable for deduplication.

**Footer Rendering**

Warden attribution now uses plain text inside `<sub>`, including finding IDs, and check-run stats use the same compact muted footer style.

**Dedup Compatibility**

Existing Warden comments with backtick, bracket, via, and old `warden:` footer formats are still parsed and updateable.