### PR TITLE
fix(telemetry): Fill finding analytics gaps

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,11 +65,19 @@ fields=timestamp,trace_id,github.event.name,cicd.pipeline.run.id,cicd.pipeline.r
 sort=-timestamp
 ```
 
+Workflow run spans for a repository.
+
+```text
+dataset=spans query='span.op:workflow.run vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
+fields=timestamp,trace,span_id,span.duration,github.event.name,cicd.pipeline.run.id,cicd.pipeline.run.url.full,warden.trigger.count,warden.finding.count,error.type
+sort=-timestamp
+```
+
 Skill execution timeline for a slow or failing skill.
 
 ```text
 dataset=spans query='span.op:skill.run gen_ai.agent.name:"<skill_name>"'
-fields=timestamp,trace,span_id,span.duration,gen_ai.agent.name,warden.trigger.name,warden.file.count,error.type
+fields=timestamp,trace,span_id,span.duration,gen_ai.agent.name,warden.trigger.name,warden.file.count,warden.finding.count,error.type
 sort=-timestamp
 ```
 
@@ -92,11 +100,15 @@ fields=timestamp,trace,span_id,span.duration,gen_ai.conversation.id,gen_ai.reque
 sort=-timestamp
 ```
 
-Tool calls inside a Claude Code SDK turn.
+Structured auxiliary calls use `span.op:gen_ai.chat` and include
+`warden.ai.task` (`extraction`, `deduplication`, `fix_quality`,
+`fix_evaluation`, `consolidation`, or `skill_build`) when available.
+
+Tool calls inside a Claude Code SDK turn or structured tool loop.
 
 ```text
 dataset=spans query='span.op:gen_ai.execute_tool gen_ai.tool.name:"<tool_name>"'
-fields=timestamp,trace,span_id,span.duration,gen_ai.tool.name,tool.elapsed_seconds,error.type
+fields=timestamp,trace,span_id,span.duration,gen_ai.agent.name,warden.ai.task,gen_ai.tool.name,tool.elapsed_seconds,error.type
 sort=-timestamp
 ```
 
@@ -119,17 +131,49 @@ sort=-timestamp
 Repository-level health and cost.
 
 ```text
-dataset=metrics query='metric:warden.workflow.runs OR metric:warden.findings OR metric:warden.skill.duration OR metric:warden.gen_ai.cost.usd vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
-fields=timestamp,metric,vcs.owner.name,vcs.repository.name,cicd.pipeline.run.id,gen_ai.agent.name,gen_ai.request.model,warden.finding.severity,value
+dataset=metrics query='metric:warden.workflow.runs OR metric:warden.skill.duration OR metric:warden.gen_ai.cost.usd vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
+fields=timestamp,metric,vcs.owner.name,vcs.repository.name,cicd.pipeline.run.id,gen_ai.agent.name,gen_ai.request.model,value
 sort=-timestamp
 ```
 
-Total findings for a skill, optionally scoped to a repository.
+Total findings in a time window, segmented by skill and repository. Use the
+Sentry time picker for the window. Query `skill.run` spans so the count uses
+the final post-processed findings, not per-hunk candidates.
 
 ```text
-dataset=metrics query='metric:warden.findings gen_ai.agent.name:"<skill_name>" vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
-fields=timestamp,metric,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,warden.finding.severity,value
-aggregate=sum(value) by gen_ai.agent.name,vcs.owner.name,vcs.repository.name
+dataset=spans query='span.op:skill.run warden.finding.count:>0'
+fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,warden.trigger.name,warden.finding.count
+aggregate=sum(warden.finding.count) by gen_ai.agent.name,vcs.owner.name,vcs.repository.name
+sort=-timestamp
+```
+
+Add `gen_ai.agent.name:"<skill_name>"`, `vcs.owner.name:"<owner>"`, or
+`vcs.repository.name:"<repo>"` to narrow the same query.
+
+Fix evaluation verdict breakdown for a skill. Use the Sentry time picker for
+the window.
+
+```text
+dataset=spans query='span.op:fix_eval.evaluate gen_ai.agent.name:"<skill_name>"'
+fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict,warden.fix_eval.used_fallback
+aggregate=count() by warden.fix_eval.verdict,gen_ai.agent.name,vcs.owner.name,vcs.repository.name
+sort=-timestamp
+```
+
+Finding lifecycle from analysis to fix evaluation. First find the evaluation
+span by finding ID, then open the trace or query the trace ID with the path and
+skill from that span.
+
+```text
+dataset=spans query='span.op:fix_eval.evaluate warden.fix_eval.finding_id:"<finding_id>"'
+fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict
+sort=-timestamp
+```
+
+```text
+dataset=spans query='trace:"<trace_id>" (span.op:skill.run OR span.op:skill.analyze_hunk OR span.op:fix_eval.evaluate) gen_ai.agent.name:"<skill_name>"'
+fields=timestamp,span.op,span_id,span.duration,code.file.path,warden.hunk.line_range,warden.finding.count,warden.fix_eval.finding_id,warden.fix_eval.verdict,error.type
+sort=timestamp
 ```
 
 ## Domains
@@ -146,7 +190,8 @@ Spans: `workflow.run`, `workflow.init`, `config.load`
 Attributes: `trace_id`, `vcs.owner.name`, `vcs.repository.name`,
 `vcs.repository.url.full`, `warden.source`, `github.event.name`,
 `cicd.pipeline.name`, `cicd.pipeline.run.id`,
-`cicd.pipeline.run.url.full`, `warden.trigger.count`
+`cicd.pipeline.run.url.full`, `warden.trigger.count`,
+`warden.finding.count`
 
 ### Trigger And GitHub Review
 

--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -157,7 +157,7 @@ Created from `SDKAssistantMessage` events streamed by `query()`. Each span repre
 |-----------|--------|-------|
 | `gen_ai.operation.name` | `'chat'` | OTel operation name |
 | `gen_ai.provider.name` | `'anthropic'` | OTel provider |
-| `gen_ai.agent.name` | Skill name | Links turn to skill |
+| `gen_ai.agent.name` | Skill name when available | Links turn to skill |
 | `gen_ai.response.model` | `message.message.model` | Actual model used for this turn |
 | `gen_ai.usage.input_tokens` | `input + cache_read + cache_write` | Total input tokens (same accounting as parent) |
 | `gen_ai.usage.output_tokens` | `message.message.usage.output_tokens` | Output tokens for this turn |
@@ -172,22 +172,60 @@ Created from `tool_use` content blocks in `SDKAssistantMessage`, enriched with t
 
 | Attribute | Source | Notes |
 |-----------|--------|-------|
+| `gen_ai.operation.name` | `'execute_tool'` | OTel operation name |
+| `gen_ai.agent.name` | Skill name when available | Links tool use to skill |
 | `gen_ai.tool.name` | `tool_use.name` | Tool name (e.g. `Read`, `Grep`) |
 | `tool.elapsed_seconds` | `SDKToolProgressMessage.elapsed_time_seconds` | Execution duration; only set when progress message received |
 
+### Structured `gen_ai.chat` attributes
+
+Direct structured model calls (`runAuxiliary` / `runSynthesis`) create manual
+`gen_ai.chat` spans so the bundled action has coverage even when loader-based
+auto-instrumentation is unavailable.
+
+| Attribute | Source | Notes |
+|-----------|--------|-------|
+| `gen_ai.operation.name` | `'chat'` | OTel operation name |
+| `gen_ai.provider.name` | `'anthropic'` | OTel provider |
+| `gen_ai.agent.name` | Request `agentName` when available | Links the call to the originating skill or builder agent |
+| `warden.ai.task` | Request `task` | Warden task name (`extraction`, `deduplication`, `fix_quality`, `fix_evaluation`, `consolidation`, or `skill_build`) |
+| `gen_ai.request.model` | Requested model | Model sent to Anthropic |
+
+Structured tool-loop calls also create `gen_ai.execute_tool` child spans with
+`gen_ai.operation.name`, `gen_ai.agent.name`, `warden.ai.task`, and
+`gen_ai.tool.name`.
+
 ### Why manual instrumentation for the SDK
 
-The Claude Code SDK runs as a subprocess via `query()`. It is not an `@anthropic-ai/sdk` client call, so `anthropicAIIntegration` cannot auto-instrument it. The SDK streams rich message types (`SDKAssistantMessage`, `SDKToolProgressMessage`) that provide per-turn token usage and tool execution data. We process these to create `gen_ai.chat` and `gen_ai.execute_tool` child spans. The aggregate result message provides session-level totals for the parent `gen_ai.invoke_agent` span. Direct Anthropic API calls (haiku extraction, fix evaluation judge) *are* auto-instrumented by the integration.
+The Claude Code SDK runs as a subprocess via `query()`. It is not an `@anthropic-ai/sdk` client call, so `anthropicAIIntegration` cannot auto-instrument it. The SDK streams rich message types (`SDKAssistantMessage`, `SDKToolProgressMessage`) that provide per-turn token usage and tool execution data. We process these to create `gen_ai.chat` and `gen_ai.execute_tool` child spans. The aggregate result message provides session-level totals for the parent `gen_ai.invoke_agent` span. Direct structured Anthropic calls are also wrapped manually because the bundled GitHub Action cannot rely on loader-based auto-instrumentation.
 
 ---
 
 ## Internal Span Attributes
 
+### `workflow.run`
+
+| Attribute | Type | When set |
+|-----------|------|----------|
+| `warden.trigger.count` | number | After trigger matching |
+| `warden.finding.count` | number | After result |
+
+### `skill.run`
+
+| Attribute | Type | When set |
+|-----------|------|----------|
+| `gen_ai.agent.name` | string | Creation and after skill resolution |
+| `warden.trigger.name` | string | Creation for trigger-backed runs |
+| `warden.file.count` | number | Creation |
+| `warden.finding.count` | number | After result |
+
 ### `skill.analyze_file`
 
 The parent `skill.run` span carries `gen_ai.agent.name` for every run and
 `warden.trigger.name` only when the skill was selected by an actual trigger.
-Direct CLI skill runs omit trigger metadata.
+Direct CLI skill runs omit trigger metadata. Child file and hunk spans also
+carry `gen_ai.agent.name` so skill-scoped span queries do not depend on parent
+span context propagation.
 
 | Attribute | Type | When set |
 |-----------|------|----------|
@@ -224,8 +262,8 @@ Retries add a breadcrumb (`category: 'retry'`) with attempt number, error messag
 |-----------|------|----------|
 | `code.file.path` | string | Creation |
 | `code.line.number` | number | Creation |
-| `warden.fix_eval.finding_id` | string | Creation |
-| `gen_ai.agent.name` | string | Creation (when available) |
+| `warden.fix_eval.finding_id` | string | Creation from Warden comment metadata |
+| `gen_ai.agent.name` | string | Creation from Warden comment metadata |
 | `warden.fix_eval.verdict` | string | After result |
 | `warden.fix_eval.used_fallback` | boolean | After result |
 
@@ -275,6 +313,9 @@ All metrics inherit `warden.source`, repository attributes, and GitHub Actions a
 Called once per analysis workflow execution (CLI run or GitHub Action workflow).
 
 ### Skill-level (`emitSkillMetrics`)
+
+Called once per completed skill report from both CLI/PR task execution and
+scheduled workflow execution.
 
 | Metric | Type | Per-metric attributes |
 |--------|------|-----------------------|

--- a/src/action/fix-evaluation/fix-evaluation.test.ts
+++ b/src/action/fix-evaluation/fix-evaluation.test.ts
@@ -318,6 +318,29 @@ describe('evaluateFixAttempts', () => {
     expect(result.evaluations[0]?.findingId).toBe('WRZ-XPL');
   });
 
+  it('uses Warden comment attribution for fix-eval skill and finding ID', async () => {
+    const comment = createComment({
+      title: 'baseSha is set to branch name',
+      body: `**baseSha is set to branch name**
+
+The base SHA points at the branch.
+
+<sub>Identified by Warden security-review · WRZ-XPL</sub>`,
+    });
+    mockEvaluateFix.mockResolvedValue({
+      verdict: { status: 'resolved', reasoning: 'Fixed' },
+      usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.001 },
+      usedFallback: false,
+    });
+
+    const result = await evaluateFixAttempts(mockOctokit, [comment], defaultContext, [], 'api-key');
+
+    expect(result.evaluations[0]).toMatchObject({
+      findingId: 'WRZ-XPL',
+      skill: 'security-review',
+    });
+  });
+
   it('counts skipped when pre-fix code fetch fails', async () => {
     const comment = createComment();
     mockFetchFileContent.mockRejectedValueOnce(new Error('API rate limit'));

--- a/src/action/fix-evaluation/index.ts
+++ b/src/action/fix-evaluation/index.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 import type { ExistingComment } from '../../output/dedup.js';
+import { parseWardenFindingId, parseWardenSkills } from '../../output/dedup.js';
 import type { Finding, UsageStats } from '../../types/index.js';
 import { aggregateUsage, emptyUsage } from '../../sdk/usage.js';
 import { findingMatchesComment } from '../../output/stale.js';
@@ -17,8 +18,16 @@ const MAX_EVALUATIONS = 20;
 
 /** Extract finding ID (e.g. "WRZ-XPL") from a comment title like "[WRZ-XPL] Some title" */
 function extractFindingId(title: string): string | undefined {
-  const match = title.match(/^\[([A-Z0-9]{3}-[A-Z0-9]{3})\]\s*/);
+  const match = title.match(/^\[([^\]]+)\]\s*/);
   return match?.[1];
+}
+
+function getCommentFindingId(comment: ExistingComment): string | undefined {
+  return comment.findingId ?? extractFindingId(comment.title) ?? (comment.body ? parseWardenFindingId(comment.body) : undefined);
+}
+
+function getCommentSkill(comment: ExistingComment): string | undefined {
+  return comment.skills?.[0] ?? (comment.body ? parseWardenSkills(comment.body)[0] : undefined);
 }
 
 /** Number of lines of context around the finding location */
@@ -158,8 +167,8 @@ export async function evaluateFixAttempts(
       const uniqueResolvedThreadIds = new Set<string>();
 
       for (const comment of commentsToEvaluate) {
-        const findingId = extractFindingId(comment.title);
-        const skill = comment.skills?.[0];
+        const findingId = getCommentFindingId(comment);
+        const skill = getCommentSkill(comment);
 
         // Fetch code at the issue location before the fix
         let codeBeforeFix: string;
@@ -210,7 +219,7 @@ export async function evaluateFixAttempts(
           async (evalSpan) => {
             const startTime = performance.now();
             const evalResult = await evaluateFix(
-              { comment, changedFiles, codeBeforeFix, codeAfterFix, commitMessages },
+              { comment, skillName: skill, changedFiles, codeBeforeFix, codeAfterFix, commitMessages },
               toolContext,
               apiKey,
               runtimeOptions

--- a/src/action/fix-evaluation/judge.ts
+++ b/src/action/fix-evaluation/judge.ts
@@ -15,6 +15,7 @@ import { fetchFileContent, fetchFileLines } from './github.js';
 
 export interface FixJudgeInput {
   comment: ExistingComment;
+  skillName?: string;
   changedFiles: string[];
   codeBeforeFix: string;
   codeAfterFix?: string;
@@ -224,6 +225,7 @@ export async function evaluateFix(
 
   const result = await getRuntime(runtimeOptions.runtime).runAuxiliary({
     task: 'fix_evaluation',
+    agentName: input.skillName,
     apiKey,
     prompt,
     schema: FixJudgeVerdictSchema,

--- a/src/action/review/poster.test.ts
+++ b/src/action/review/poster.test.ts
@@ -468,7 +468,7 @@ describe('postTriggerReview', () => {
     // Consolidation should have been called with both findings
     expect(consolidateBatchFindings).toHaveBeenCalledWith(
       [finding1, finding2],
-      { apiKey: 'test-key', hashOnly: false }
+      expect.objectContaining({ apiKey: 'test-key', hashOnly: false })
     );
 
     expect(postResult.posted).toBe(true);

--- a/src/action/review/poster.ts
+++ b/src/action/review/poster.ts
@@ -191,6 +191,7 @@ export async function postTriggerReview(
         model: ctx.model,
         hashOnly: !apiKey,
         maxRetries: ctx.maxRetries,
+        agentName: result.report.skill,
       });
       findingsToPost = consolidateResult.findings;
 

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -774,6 +774,7 @@ export async function runPRWorkflow(
       }
 
       const { context, runnerConcurrency, auxiliaryOptions, matchedTriggers } = initResult;
+      span.setAttribute('warden.trigger.count', matchedTriggers.length);
 
       // Set Sentry context after building event context
       if (context.pullRequest) {
@@ -819,7 +820,11 @@ export async function runPRWorkflow(
       );
 
       const results = await Sentry.startSpan(
-        { op: 'workflow.execute', name: 'execute triggers' },
+        {
+          op: 'workflow.execute',
+          name: 'execute triggers',
+          attributes: { 'warden.trigger.count': matchedTriggers.length },
+        },
         () => executeAllTriggers(matchedTriggers, octokit, context, runnerConcurrency, inputs),
       );
 
@@ -833,6 +838,7 @@ export async function runPRWorkflow(
 
       const canResolveStale = shouldResolveStaleComments(results);
       const allFindings = reviewPhase.reports.flatMap((r) => r.findings);
+      span.setAttribute('warden.finding.count', allFindings.length);
 
       await Sentry.startSpan(
         { op: 'workflow.resolve', name: 'resolve stale comments' },

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -20,7 +20,7 @@ import { shouldFail, countFindingsAtOrAbove, countSeverity } from '../../trigger
 import { resolveSkillAsync } from '../../skills/loader.js';
 import { filterFindings } from '../../types/index.js';
 import type { SkillReport } from '../../types/index.js';
-import { setRepositoryScope } from '../../sentry.js';
+import { Sentry, logger, setRepositoryScope, emitRunMetric } from '../../sentry.js';
 import type { ActionInputs } from '../inputs.js';
 import {
   setOutput,
@@ -39,10 +39,27 @@ import {
 // Main Schedule Workflow
 // -----------------------------------------------------------------------------
 
+interface WorkflowSpan {
+  setAttribute(key: string, value: string | number | boolean): void;
+  spanContext?: () => { traceId: string };
+}
+
 export async function runScheduleWorkflow(
   octokit: Octokit,
   inputs: ActionInputs,
   repoPath: string
+): Promise<void> {
+  return Sentry.startSpan(
+    { op: 'workflow.run', name: 'review schedule' },
+    (span) => runScheduleWorkflowInner(octokit, inputs, repoPath, span),
+  );
+}
+
+async function runScheduleWorkflowInner(
+  octokit: Octokit,
+  inputs: ActionInputs,
+  repoPath: string,
+  workflowSpan: WorkflowSpan
 ): Promise<void> {
   const githubRepository = process.env['GITHUB_REPOSITORY'];
   setRepositoryScope(githubRepository);
@@ -81,6 +98,8 @@ export async function runScheduleWorkflow(
       try {
         const fullName = process.env['GITHUB_REPOSITORY'] ?? '';
         const [o = '', n = ''] = fullName.split('/');
+        workflowSpan.setAttribute('warden.trigger.count', 0);
+        workflowSpan.setAttribute('warden.finding.count', 0);
         writeFindingsOutput([], {
           eventType: 'schedule',
           action: 'scheduled',
@@ -93,11 +112,20 @@ export async function runScheduleWorkflow(
     throw error;
   }
 
+  workflowSpan.setAttribute('warden.trigger.count', scheduleTriggers.length);
+  emitRunMetric();
+  const traceId = workflowSpan.spanContext?.().traceId;
+  logger.info('Workflow initialized', {
+    'warden.trigger.count': scheduleTriggers.length,
+    ...(traceId ? { 'trace.id': traceId } : {}),
+  });
+
   if (scheduleTriggers.length === 0) {
     console.log('No schedule triggers configured');
     setOutput('findings-count', 0);
     setOutput('high-count', 0);
     setOutput('summary', 'No schedule triggers configured');
+    workflowSpan.setAttribute('warden.finding.count', 0);
     try {
       const fullName = process.env['GITHUB_REPOSITORY'] ?? '';
       const [o = '', n = ''] = fullName.split('/');
@@ -188,6 +216,7 @@ export async function runScheduleWorkflow(
         maxContextFiles: resolved.maxContextFiles,
         auxiliaryMaxRetries: resolved.auxiliaryMaxRetries,
         verifyFindings: resolved.verifyFindings,
+        telemetryTriggerName: resolved.name,
         pathToClaudeCodeExecutable: claudePath,
       });
       console.log(`Found ${report.findings.length} findings`);
@@ -250,6 +279,7 @@ export async function runScheduleWorkflow(
 
   // Set outputs
   const highCount = countSeverity(allReports, 'high');
+  workflowSpan.setAttribute('warden.finding.count', totalFindings);
 
   setOutput('findings-count', totalFindings);
   setOutput('high-count', highCount);

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -286,6 +286,7 @@ export async function runSkillTask(
             model: runnerOptions?.model,
             skippedFiles: skippedFiles.length > 0 ? skippedFiles : undefined,
           };
+          span.setAttribute('warden.finding.count', 0);
           callbacks.onSkillSkipped(name);
           // Also fire onSkillComplete so the incremental JSONL writer records the skipped skill.
           callbacks.onSkillComplete(name, skippedReport);
@@ -556,6 +557,7 @@ export async function runSkillTask(
           if (totalFailedExtractions > 0) errorReport.failedExtractions = totalFailedExtractions;
           if (skippedFiles.length > 0) errorReport.skippedFiles = skippedFiles;
           if (auxUsage) errorReport.auxiliaryUsage = auxUsage;
+          span.setAttribute('warden.finding.count', 0);
           callbacks.onSkillError(name, error.message);
           // Mirror the success path: emit a final completion event with the
           // (errored) report so terminal renderers print the per-skill
@@ -630,6 +632,7 @@ export async function runSkillTask(
         if (auxUsage) {
           report.auxiliaryUsage = auxUsage;
         }
+        span.setAttribute('warden.finding.count', report.findings.length);
 
         // Emit metrics and log completion
         emitSkillMetrics(report);
@@ -664,6 +667,7 @@ export async function runSkillTask(
           model: runnerOptions?.model,
           error: { code, message, timestamp: new Date().toISOString() },
         };
+        span.setAttribute('warden.finding.count', 0);
         // Mirror the success / all-hunks-fail paths: emit a final completion
         // event so non-TTY (log-mode) renderers print a per-skill summary
         // line for the failure. Without this, log mode shows only the

--- a/src/output/dedup.test.ts
+++ b/src/output/dedup.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Octokit } from '@octokit/rest';
 import {
   generateContentHash,
   generateMarker,
   parseMarker,
   parseWardenComment,
+  parseWardenFindingId,
   isWardenComment,
   deduplicateFindings,
   findingToExistingComment,
+  fetchExistingComments,
   parseWardenSkills,
   updateWardenCommentBody,
   consolidateBatchFindings,
@@ -140,6 +143,34 @@ The function checks the wrong signal.
   });
 });
 
+describe('parseWardenFindingId', () => {
+  it('parses finding ID from current muted attribution', () => {
+    const body = `**Issue**
+
+Description
+
+<sub>Identified by Warden security-review · WRZ-XPL</sub>`;
+
+    expect(parseWardenFindingId(body)).toBe('WRZ-XPL');
+  });
+
+  it('parses finding ID from legacy title prefix', () => {
+    const body = `**:warning: [2K5-29B] Legacy issue title**
+
+Description
+
+---
+<sub>warden: security-review</sub>`;
+
+    expect(parseWardenFindingId(body)).toBe('2K5-29B');
+  });
+
+  it('does not treat legacy severity attribution as a finding ID', () => {
+    const body = `<sub>Identified by Warden via \`security-review\` · high</sub>`;
+    expect(parseWardenFindingId(body)).toBeUndefined();
+  });
+});
+
 describe('isWardenComment', () => {
   it('returns true for comment with attribution', () => {
     const body = `**:warning: Issue**\n\nDescription\n\n---\n<sub>warden: skill</sub>`;
@@ -174,6 +205,61 @@ describe('isWardenComment', () => {
   it('returns false for regular comment', () => {
     const body = 'This is a regular comment.';
     expect(isWardenComment(body)).toBe(false);
+  });
+});
+
+describe('fetchExistingComments', () => {
+  it('preserves parsed Warden skill and finding ID from review comments', async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: 'thread-1',
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    {
+                      id: 'comment-node-1',
+                      databaseId: 123,
+                      body: `**SQL injection**
+
+User input reaches a query.
+
+<sub>Identified by Warden security-review · WRZ-XPL</sub>
+<!-- warden:v1:src/db.ts:42:abc12345 -->`,
+                      path: 'src/db.ts',
+                      line: 42,
+                      originalLine: 40,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const comments = await fetchExistingComments(
+      { graphql } as unknown as Octokit,
+      'getsentry',
+      'warden',
+      123
+    );
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toMatchObject({
+      id: 123,
+      path: 'src/db.ts',
+      line: 42,
+      findingId: 'WRZ-XPL',
+      isWarden: true,
+      skills: ['security-review'],
+      threadId: 'thread-1',
+    });
   });
 });
 
@@ -598,6 +684,7 @@ describe('findingToExistingComment', () => {
       line: 45,
       title: 'SQL Injection',
       description: 'User input passed to query',
+      findingId: 'f1',
       contentHash: generateContentHash('SQL Injection', 'User input passed to query'),
       isWarden: true,
       skills: [],

--- a/src/output/dedup.ts
+++ b/src/output/dedup.ts
@@ -30,6 +30,8 @@ export interface ExistingComment {
   line: number;
   title: string;
   description: string;
+  /** Stable Warden finding ID from the attribution footer or legacy title prefix */
+  findingId?: string;
   contentHash: string;
   /** GraphQL node ID for the review thread (used to resolve stale comments) */
   threadId?: string;
@@ -140,6 +142,21 @@ export function parseWardenComment(body: string): { title: string; description: 
   const description = body.slice(titleEnd, descEnd).trim();
 
   return { title, description };
+}
+
+/**
+ * Parse the finding ID from a Warden comment's attribution or legacy title.
+ */
+export function parseWardenFindingId(body: string): string | undefined {
+  const attributionMatch = body.match(/(?:<sub>)?Identified by Warden (?!via\s)([^<\n\r]*)(?:<\/sub>|$)/m);
+  if (attributionMatch?.[1]) {
+    const idMatch = attributionMatch[1].match(/·\s*(?:`([^`]+)`|([^`\n\r]+))/);
+    const id = (idMatch?.[1] ?? idMatch?.[2])?.trim();
+    if (id) return id;
+  }
+
+  const titleMatch = body.match(/\*\*(?::[a-z_]+:\s*)?\[([^\]]+)\]\s*.+?\*\*/);
+  return titleMatch?.[1]?.trim() || undefined;
 }
 
 /**
@@ -417,6 +434,7 @@ export async function fetchExistingComments(
         line: marker?.line ?? firstComment.line ?? firstComment.originalLine ?? 0,
         title,
         description,
+        findingId: isWarden ? parseWardenFindingId(firstComment.body) : undefined,
         contentHash: marker?.contentHash ?? generateContentHash(title, description),
         threadId: thread.id,
         isResolved: thread.isResolved,
@@ -471,7 +489,7 @@ async function findSemanticDuplicates(
   findings: Finding[],
   existingComments: ExistingComment[],
   apiKey: string,
-  options: Pick<DeduplicateOptions, 'runtime' | 'model' | 'maxRetries'> = {}
+  options: Pick<DeduplicateOptions, 'runtime' | 'model' | 'maxRetries' | 'currentSkill'> = {}
 ): Promise<SemanticDuplicateResult> {
   if (findings.length === 0 || existingComments.length === 0) {
     return { matches: new Map() };
@@ -505,6 +523,7 @@ Return [] if none are duplicates.`),
 
   const result = await getRuntime(options.runtime).runAuxiliary({
     task: 'deduplication',
+    agentName: options.currentSkill,
     apiKey,
     prompt,
     schema: DuplicateMatchesSchema,
@@ -653,6 +672,7 @@ export function findingToExistingComment(finding: Finding, skill?: string): Exis
     line: finding.location.endLine ?? finding.location.startLine,
     title: finding.title,
     description: finding.description,
+    findingId: finding.id,
     contentHash: generateContentHash(finding.title, finding.description),
     isWarden: true,
     skills: skill ? [skill] : [],
@@ -799,6 +819,7 @@ Singletons (findings with no duplicates) should not appear in any group.
 
   const result = await getRuntime(options.runtime).runAuxiliary({
     task: 'deduplication',
+    agentName: options.agentName,
     apiKey: options.apiKey,
     prompt,
     schema: ConsolidationGroupsSchema,

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -1,7 +1,7 @@
 import type { SkillDefinition } from '../config/schema.js';
 import type { ErrorCode, Finding, RetryConfig } from '../types/index.js';
 import { getHunkLineRange, type HunkWithContext } from '../diff/index.js';
-import { Sentry, emitExtractionMetrics, emitRetryMetric } from '../sentry.js';
+import { Sentry, emitExtractionMetrics, emitRetryMetric, emitSkillMetrics } from '../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, isRetryableError, isAuthenticationError, isAuthenticationErrorMessage, isSubprocessError, classifyError, mapExtractionErrorCode, sanitizeErrorMessage } from './errors.js';
 import type { CircuitBreakerReason } from './circuit-breaker.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
@@ -98,6 +98,7 @@ function recordCircuitFailure(
 async function parseHunkOutput(
   result: SkillRunResult,
   filename: string,
+  skillName: string,
   options: SkillRunnerOptions
 ): Promise<ParseHunkOutputResult> {
   if (result.status !== 'success') {
@@ -118,6 +119,7 @@ async function parseHunkOutput(
     runtime: options.runtime,
     model: options.auxiliaryModel,
     maxRetries: options.auxiliaryMaxRetries,
+    agentName: skillName,
   });
 
   if (fallback.success) {
@@ -180,6 +182,7 @@ async function analyzeHunk(
       op: 'skill.analyze_hunk',
       name: `analyze hunk ${hunkCtx.filename}:${lineRange}`,
       attributes: {
+        'gen_ai.agent.name': skill.name,
         'code.file.path': hunkCtx.filename,
         'warden.hunk.line_range': lineRange,
       },
@@ -318,7 +321,7 @@ async function analyzeHunk(
           }
 
           options.circuitBreaker?.recordSuccess();
-          const parseResult = await parseHunkOutput(resultMessage, hunkCtx.filename, options);
+          const parseResult = await parseHunkOutput(resultMessage, hunkCtx.filename, skill.name, options);
 
           // Filter findings outside hunk line range (defense-in-depth)
           const hunkRange = getHunkLineRange(hunkCtx.hunk);
@@ -534,6 +537,7 @@ export async function analyzeFile(
       op: 'skill.analyze_file',
       name: `analyze file ${file.filename}`,
       attributes: {
+        'gen_ai.agent.name': skill.name,
         'code.file.path': file.filename,
         'warden.hunk.count': file.hunks.length,
       },
@@ -666,6 +670,35 @@ export function generateSummary(skillName: string, findings: Finding[]): string 
  * Run a skill on a PR, analyzing each hunk separately.
  */
 export async function runSkill(
+  skill: SkillDefinition,
+  context: EventContext,
+  options: SkillRunnerOptions = {}
+): Promise<SkillReport> {
+  return Sentry.startSpan(
+    {
+      op: 'skill.run',
+      name: `run ${skill.name}`,
+      attributes: {
+        'gen_ai.agent.name': skill.name,
+        ...(options.telemetryTriggerName ? { 'warden.trigger.name': options.telemetryTriggerName } : {}),
+        'warden.file.count': context.pullRequest?.files.length ?? 0,
+      },
+    },
+    async (span) => {
+      try {
+        const report = await runSkillAnalysis(skill, context, options);
+        span.setAttribute('warden.finding.count', report.findings.length);
+        emitSkillMetrics(report);
+        return report;
+      } catch (error) {
+        span.setAttribute('warden.finding.count', 0);
+        throw error;
+      }
+    },
+  );
+}
+
+async function runSkillAnalysis(
   skill: SkillDefinition,
   context: EventContext,
   options: SkillRunnerOptions = {}

--- a/src/sdk/extract.ts
+++ b/src/sdk/extract.ts
@@ -29,6 +29,7 @@ export interface AuxiliaryCallOptions {
   runtime?: RuntimeName;
   model?: string;
   maxRetries?: number;
+  agentName?: string;
 }
 
 /**
@@ -219,6 +220,7 @@ If no findings exist, return: {"findings": []}`),
 
   const result = await getRuntime(runtime).runAuxiliary({
     task: 'extraction',
+    agentName: options.agentName,
     apiKey,
     prompt: userContent,
     schema: z.object({ findings: z.array(z.unknown()) }),
@@ -530,6 +532,7 @@ Singletons should not appear. Return [] if no findings describe the same issue.`
 
   const result = await getRuntime(options?.runtime).runSynthesis({
     task: 'consolidation',
+    agentName: options?.agentName,
     apiKey,
     prompt,
     schema: MergeGroupsSchema,

--- a/src/sdk/fix-quality.ts
+++ b/src/sdk/fix-quality.ts
@@ -29,6 +29,7 @@ interface SanitizeSuggestedFixesOptions {
   runtime?: RuntimeName;
   model?: string;
   maxRetries?: number;
+  agentName?: string;
   onFindingProcessing?: (event: FindingProcessingEvent) => void;
 }
 
@@ -161,6 +162,7 @@ Pass only if the diff clearly addresses the stated issue without obvious regress
 
   const result = await getRuntime(runtime).runAuxiliary({
     task: 'fix_quality',
+    agentName: options.agentName,
     apiKey,
     prompt,
     schema: SemanticFixVerdictSchema,

--- a/src/sdk/haiku.ts
+++ b/src/sdk/haiku.ts
@@ -152,6 +152,8 @@ export interface CallHaikuOptions<T> {
   apiKey: string;
   prompt: string;
   schema: z.ZodType<T>;
+  agentName?: string;
+  task?: string;
   model?: string;
   maxTokens?: number;
   timeout?: number;
@@ -174,7 +176,7 @@ function inferPrefill(schema: z.ZodType): string | undefined {
  * Auto-prefills based on Zod schema type, extracts JSON, validates with Zod.
  */
 export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuResult<T>> {
-  const { apiKey, prompt, schema, model = HAIKU_MODEL, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES } = options;
+  const { apiKey, prompt, schema, agentName, task, model = HAIKU_MODEL, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES } = options;
 
   return Sentry.startSpan(
     {
@@ -183,6 +185,8 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
       attributes: {
         'gen_ai.operation.name': 'chat',
         'gen_ai.provider.name': 'anthropic',
+        ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
+        ...(task ? { 'warden.ai.task': task } : {}),
         'gen_ai.request.model': model,
         'gen_ai.request.max_tokens': maxTokens,
       },
@@ -250,6 +254,8 @@ export interface CallHaikuWithToolsOptions<T> {
   schema: z.ZodType<T>;
   tools: Anthropic.Tool[];
   executeTool: (name: string, input: Record<string, unknown>) => Promise<string>;
+  agentName?: string;
+  task?: string;
   model?: string;
   maxTokens?: number;
   maxIterations?: number;
@@ -269,6 +275,8 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
     schema,
     tools,
     executeTool,
+    agentName,
+    task,
     model = HAIKU_MODEL,
     maxTokens = DEFAULT_MAX_TOKENS,
     maxIterations = 5,
@@ -283,6 +291,8 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
       attributes: {
         'gen_ai.operation.name': 'chat',
         'gen_ai.provider.name': 'anthropic',
+        ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
+        ...(task ? { 'warden.ai.task': task } : {}),
         'gen_ai.request.model': model,
         'gen_ai.request.max_tokens': maxTokens,
       },
@@ -362,6 +372,8 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
                 name: `execute_tool ${block.name}`,
                 attributes: {
                   'gen_ai.operation.name': 'execute_tool',
+                  ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
+                  ...(task ? { 'warden.ai.task': task } : {}),
                   'gen_ai.tool.name': block.name,
                 },
               },

--- a/src/sdk/json-output.ts
+++ b/src/sdk/json-output.ts
@@ -14,6 +14,7 @@ export type ParseJsonFromOutputResult<T> =
 
 export interface JsonOutputRepairOptions {
   apiKey?: string;
+  agentName?: string;
   runtime?: Runtime;
   runtimeName?: RuntimeName;
   model?: string;
@@ -77,6 +78,7 @@ async function repairJsonOutput<T>(
   const runtime = repair.runtime ?? getRuntime(repair.runtimeName);
   const result = await runtime.runAuxiliary({
     task: 'extraction',
+    agentName: repair.agentName,
     apiKey: repair.apiKey,
     model: repair.model,
     maxRetries: repair.maxRetries,

--- a/src/sdk/post-process.ts
+++ b/src/sdk/post-process.ts
@@ -66,6 +66,7 @@ export async function postProcessFindings(
     runtime: options.runtime,
     model: options.synthesisModel,
     maxRetries: options.auxiliaryMaxRetries,
+    agentName: options.skill.name,
     onFindingProcessing: options.onFindingProcessing,
   });
   currentFindings = mergeResult.findings;
@@ -79,6 +80,7 @@ export async function postProcessFindings(
     runtime: options.runtime,
     model: options.auxiliaryModel,
     maxRetries: options.auxiliaryMaxRetries,
+    agentName: options.skill.name,
     onFindingProcessing: options.onFindingProcessing,
   });
   currentFindings = sanitized.findings;

--- a/src/sdk/runtimes/claude.ts
+++ b/src/sdk/runtimes/claude.ts
@@ -25,8 +25,10 @@ import { aggregateUsage, emptyUsage, estimateTokens, extractUsage } from '../usa
 import type {
   AuxiliaryRunRequest,
   AuxiliaryRunResult,
+  AuxiliaryTask,
   AuxiliaryTool,
   Runtime,
+  SynthesisTask,
   SynthesisRunRequest,
   SkillRunRequest,
   SkillRunResponse,
@@ -102,6 +104,8 @@ function resolveClaudeSkillTools(
 async function runStructured<T>(
   request: {
     kind: 'auxiliary' | 'synthesis';
+    task?: AuxiliaryTask | SynthesisTask;
+    agentName?: string;
     apiKey?: string;
     prompt: string;
     schema: SynthesisRunRequest<T>['schema'];
@@ -125,6 +129,8 @@ async function runStructured<T>(
       schema: request.schema,
       tools: request.tools.map(toAnthropicTool),
       executeTool: request.executeTool ?? (async () => ''),
+      agentName: request.agentName,
+      task: request.task,
       model: request.model,
       maxTokens: request.maxTokens,
       maxIterations: request.maxIterations,
@@ -137,6 +143,8 @@ async function runStructured<T>(
     apiKey: request.apiKey,
     prompt: request.prompt,
     schema: request.schema,
+    agentName: request.agentName,
+    task: request.task,
     model: request.model,
     maxTokens: request.maxTokens,
     timeout: request.timeout,
@@ -373,6 +381,8 @@ export const claudeRuntime: Runtime = {
                       op: 'gen_ai.execute_tool',
                       name: toolUse.name,
                       attributes: {
+                        'gen_ai.operation.name': 'execute_tool',
+                        'gen_ai.agent.name': skillName,
                         'gen_ai.tool.name': toolUse.name,
                         ...(elapsed !== undefined && { 'tool.elapsed_seconds': elapsed }),
                       },

--- a/src/sdk/runtimes/types.ts
+++ b/src/sdk/runtimes/types.ts
@@ -93,6 +93,8 @@ export type AuxiliaryRunResult<T> =
 
 interface AuxiliaryRunRequestBase<T> {
   task: AuxiliaryTask;
+  /** Skill or agent name that owns this auxiliary call, when available. */
+  agentName?: string;
   apiKey?: string;
   prompt: string;
   schema: z.ZodType<T>;
@@ -118,6 +120,8 @@ export type AuxiliaryRunRequest<T> = AuxiliaryRunRequestWithoutTools<T> | Auxili
 
 export interface SynthesisRunRequest<T> {
   task: SynthesisTask;
+  /** Skill or agent name that owns this synthesis call, when available. */
+  agentName?: string;
   apiKey?: string;
   prompt: string;
   schema: z.ZodType<T>;

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -128,6 +128,8 @@ export interface SkillRunnerOptions {
   auxiliaryMaxRetries?: number;
   /** Verify candidate findings in a second read-only pass. Defaults to true. */
   verifyFindings?: boolean;
+  /** Trigger name to attach to skill-level telemetry when the caller has one. */
+  telemetryTriggerName?: string;
 }
 
 /**

--- a/src/skill-builder/agentic.ts
+++ b/src/skill-builder/agentic.ts
@@ -270,6 +270,7 @@ export async function runStructuredSkillBuilderAgent<T>(args: {
         schema: args.schema,
         repair: {
           runtime,
+          agentName: args.skillName,
           apiKey: args.repair.apiKey,
           model: args.repair.model,
           maxRetries: args.repair.maxRetries,

--- a/src/skill-builder/outline.ts
+++ b/src/skill-builder/outline.ts
@@ -400,6 +400,7 @@ export async function buildSkillOutline(
 
   const result = await runtime.runSynthesis({
     task: 'skill_build',
+    agentName: `${skill.name}:skill-outline`,
     apiKey,
     prompt: buildOutlinePrompt(skill, source, options.previousOutline),
     schema: SkillBuildOutlineSchema,


### PR DESCRIPTION
Preserve Warden finding IDs and skill attribution when parsing existing review comments so fix evaluation spans can segment verdicts by originating skill and finding.

Add workflow and skill-level span counts for trigger totals and final findings, including scheduled runs. Structured auxiliary model spans now carry the owning skill or builder agent and Warden task when that context exists, so analytics can rely on span attributes instead of brittle log parsing or empty finding metrics.

Update TELEMETRY.md with span-based recipes for total findings, fix evaluation verdict breakdowns, and tracing a finding from analysis through fix evaluation.

Fixes #309