### PR TITLE
fix(action): Correct fix evaluation verdict handling

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -124,7 +124,7 @@ Finding fix evaluation and stale comment resolution.
 
 ```text
 dataset=spans query='span.op:fix_eval.evaluate warden.fix_eval.finding_id:"<finding_id>"'
-fields=timestamp,trace,span_id,span.duration,code.file.path,code.line.number,gen_ai.agent.name,warden.fix_eval.verdict,warden.fix_eval.used_fallback,error.type
+fields=timestamp,trace,span_id,span.duration,code.file.path,code.line.number,gen_ai.agent.name,warden.fix_eval.verdict,warden.fix_eval.raw_verdict,warden.fix_eval.used_fallback,error.type
 sort=-timestamp
 ```
 
@@ -155,8 +155,8 @@ the window.
 
 ```text
 dataset=spans query='span.op:fix_eval.evaluate gen_ai.agent.name:"<skill_name>"'
-fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict,warden.fix_eval.used_fallback
-aggregate=count() by warden.fix_eval.verdict,gen_ai.agent.name,vcs.owner.name,vcs.repository.name
+fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict,warden.fix_eval.raw_verdict,warden.fix_eval.used_fallback
+aggregate=count() by warden.fix_eval.verdict,warden.fix_eval.used_fallback,gen_ai.agent.name,vcs.owner.name,vcs.repository.name
 sort=-timestamp
 ```
 
@@ -166,13 +166,13 @@ skill from that span.
 
 ```text
 dataset=spans query='span.op:fix_eval.evaluate warden.fix_eval.finding_id:"<finding_id>"'
-fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict
+fields=timestamp,trace,span_id,span.duration,vcs.owner.name,vcs.repository.name,gen_ai.agent.name,code.file.path,code.line.number,warden.fix_eval.finding_id,warden.fix_eval.verdict,warden.fix_eval.raw_verdict
 sort=-timestamp
 ```
 
 ```text
 dataset=spans query='trace:"<trace_id>" (span.op:skill.run OR span.op:skill.analyze_hunk OR span.op:fix_eval.evaluate) gen_ai.agent.name:"<skill_name>"'
-fields=timestamp,span.op,span_id,span.duration,code.file.path,warden.hunk.line_range,warden.finding.count,warden.fix_eval.finding_id,warden.fix_eval.verdict,error.type
+fields=timestamp,span.op,span_id,span.duration,code.file.path,warden.hunk.line_range,warden.finding.count,warden.fix_eval.finding_id,warden.fix_eval.verdict,warden.fix_eval.raw_verdict,error.type
 sort=timestamp
 ```
 
@@ -258,12 +258,13 @@ Existing Warden comments were not resolved, were judged incorrectly, or fix
 evaluation failed.
 
 Events: operation tags `fetch_fix_context`, `evaluate_fix_attempts`,
-`resolve_stale_comments`
+`evaluate_fix_attempt`, `resolve_stale_comments`
 
 Spans: `workflow.resolve`, `fix_eval.run`, `fix_eval.evaluate`
 
 Attributes: `warden.fix_eval.comment_count`, `warden.fix_eval.finding_id`,
 `gen_ai.agent.name`, `warden.fix_eval.verdict`,
+`warden.fix_eval.raw_verdict`,
 `warden.fix_eval.used_fallback`, `code.file.path`, `code.line.number`
 
 ### Local Run Logs

--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -669,6 +669,10 @@
             {
               "type": "string",
               "const": "re_detected"
+            },
+            {
+              "type": "string",
+              "const": "eval_error"
             }
           ]
         },
@@ -681,6 +685,9 @@
         },
         "usage": {
           "$ref": "#/$defs/UsageStats"
+        },
+        "usedFallback": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/specs/reporters.md
+++ b/specs/reporters.md
@@ -558,7 +558,7 @@ New run logs are homogeneous: every line is a chunk result. Each line is self-co
 
 **BySeverity**: `{ high: int, medium: int, low: int }`. Legacy 5-level keys (`critical`, `info`) are still accepted on read for backward compatibility with older logs and normalized to `high`/`low`; new output is strictly 3-level.
 
-**FixEvalDetail**: `{ path: string, line: int, findingId?: string, verdict: "not_attempted" | "attempted_failed" | "resolved" | "re_detected", reasoning?: string, durationMs: number, usage: UsageStats }`
+**FixEvalDetail**: `{ path: string, line: int, findingId?: string, verdict: "not_attempted" | "attempted_failed" | "resolved" | "re_detected" | "eval_error", reasoning?: string, durationMs: number, usage: UsageStats, usedFallback?: boolean }`
 
 ### Output Location
 

--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -264,7 +264,8 @@ Retries add a breadcrumb (`category: 'retry'`) with attempt number, error messag
 | `code.line.number` | number | Creation |
 | `warden.fix_eval.finding_id` | string | Creation from Warden comment metadata |
 | `gen_ai.agent.name` | string | Creation from Warden comment metadata |
-| `warden.fix_eval.verdict` | string | After result |
+| `warden.fix_eval.raw_verdict` | string | Judge result before Warden overrides |
+| `warden.fix_eval.verdict` | string | Final outcome after re-detection and fallback handling |
 | `warden.fix_eval.used_fallback` | boolean | After result |
 
 ---
@@ -289,6 +290,7 @@ All `captureException` calls include an `operation` tag for filtering in Sentry 
 | `fetch_existing_comments` | `postReviewsAndTrackFailures` | Fetching PR comments for dedup |
 | `post_thread_reply` | `evaluateFixesAndResolveStale` | Posting fix evaluation reply |
 | `evaluate_fix_attempts` | `evaluateFixesAndResolveStale` | Fix evaluation batch |
+| `evaluate_fix_attempt` | `evaluateFixAttempts` | Per-comment fix evaluation |
 | `resolve_stale_comments` | `evaluateFixesAndResolveStale` | Stale comment resolution |
 | `dismiss_review` | `finalizeWorkflow` | Dismissing CHANGES_REQUESTED review |
 | `update_core_check` | `finalizeWorkflow` | Updating check run with summary |
@@ -377,9 +379,9 @@ Called from `evaluateFixAttempts` after all evaluations complete.
 | `warden.fix_eval.unique_findings.evaluated` | count | -- |
 | `warden.fix_eval.unique_findings.code_changed` | count | -- |
 | `warden.fix_eval.unique_findings.resolved` | count | -- |
-| `warden.fix_eval.verdict` | count | `warden.fix_eval.verdict`, `gen_ai.agent.name` |
+| `warden.fix_eval.verdict` | count | `warden.fix_eval.verdict`, `warden.fix_eval.used_fallback`, `gen_ai.agent.name` |
 
-The aggregate metrics above are emitted once per run. The per-verdict metric is emitted after each individual evaluation with the verdict (`resolved`, `attempted_failed`, `not_attempted`, `re_detected`) and the originating skill name.
+The aggregate metrics above are emitted once per run. The per-verdict metric is emitted after each individual evaluation with the final verdict (`resolved`, `attempted_failed`, `not_attempted`, `re_detected`, `eval_error`), whether fallback was used, and the originating skill name.
 
 ### Stale resolution (`emitStaleResolutionMetric`)
 

--- a/src/action/fix-evaluation/fix-evaluation.test.ts
+++ b/src/action/fix-evaluation/fix-evaluation.test.ts
@@ -241,6 +241,64 @@ describe('evaluateFixAttempts', () => {
     expect(result.uniqueFindingsResolved).toBe(0);
   });
 
+  it('overrides not_attempted verdict when issue is re-detected', async () => {
+    const comment = createComment();
+    const finding = createFinding();
+
+    mockEvaluateFix.mockResolvedValue({
+      verdict: { status: 'not_attempted', reasoning: 'Unrelated changes' },
+      usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.001 },
+      usedFallback: false,
+    });
+
+    const result = await evaluateFixAttempts(
+      mockOctokit,
+      [comment],
+      defaultContext,
+      [finding],
+      'api-key'
+    );
+
+    expect(result.toResolve).toHaveLength(0);
+    expect(result.toReply).toHaveLength(1);
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]).toMatchObject({
+      verdict: 're_detected',
+      usedFallback: false,
+    });
+    expect(result.uniqueFindingsEvaluated).toBe(1);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(0);
+  });
+
+  it('overrides fallback verdict when issue is re-detected', async () => {
+    const comment = createComment();
+    const finding = createFinding();
+
+    mockEvaluateFix.mockResolvedValue({
+      verdict: { status: 'not_attempted', reasoning: 'Evaluation failed' },
+      usage: { inputTokens: 50, outputTokens: 0, costUSD: 0.0001 },
+      usedFallback: true,
+    });
+
+    const result = await evaluateFixAttempts(
+      mockOctokit,
+      [comment],
+      defaultContext,
+      [finding],
+      'api-key'
+    );
+
+    expect(result.failedEvaluations).toBe(1);
+    expect(result.toResolve).toHaveLength(0);
+    expect(result.toReply).toHaveLength(1);
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]).toMatchObject({
+      verdict: 're_detected',
+      usedFallback: true,
+    });
+  });
+
   it('limits evaluation to MAX_EVALUATIONS (20)', async () => {
     const comments = Array.from({ length: 25 }, (_, i) =>
       createComment({ id: i + 1, threadId: `thread-${i}` })
@@ -275,8 +333,43 @@ describe('evaluateFixAttempts', () => {
     expect(result.toReply).toHaveLength(0);
     expect(result.evaluations).toHaveLength(1);
     expect(result.evaluations[0]).toMatchObject({
+      verdict: 'eval_error',
       usedFallback: true,
     });
+  });
+
+  it('continues evaluating remaining comments when one evaluation throws', async () => {
+    const comments = [
+      createComment({ id: 1, threadId: 'thread-1', path: 'src/a.ts' }),
+      createComment({ id: 2, threadId: 'thread-2', path: 'src/b.ts' }),
+    ];
+
+    mockEvaluateFix
+      .mockRejectedValueOnce(new Error('provider crashed'))
+      .mockResolvedValueOnce({
+        verdict: { status: 'resolved', reasoning: 'Fixed' },
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.001 },
+        usedFallback: false,
+      });
+
+    const result = await evaluateFixAttempts(mockOctokit, comments, defaultContext, [], 'api-key');
+
+    expect(result.evaluated).toBe(2);
+    expect(result.failedEvaluations).toBe(1);
+    expect(result.toResolve).toHaveLength(1);
+    expect(result.toResolve[0]).toBe(comments[1]);
+    expect(result.evaluations).toHaveLength(2);
+    expect(result.evaluations[0]).toMatchObject({
+      verdict: 'eval_error',
+      usedFallback: true,
+    });
+    expect(result.evaluations[1]).toMatchObject({
+      verdict: 'resolved',
+      usedFallback: false,
+    });
+    expect(result.uniqueFindingsEvaluated).toBe(2);
+    expect(result.uniqueFindingsCodeChanged).toBe(1);
+    expect(result.uniqueFindingsResolved).toBe(1);
   });
 
   it('aggregates usage across multiple evaluations', async () => {

--- a/src/action/fix-evaluation/index.ts
+++ b/src/action/fix-evaluation/index.ts
@@ -5,7 +5,7 @@ import type { Finding, UsageStats } from '../../types/index.js';
 import { aggregateUsage, emptyUsage } from '../../sdk/usage.js';
 import { findingMatchesComment } from '../../output/stale.js';
 import { Sentry, emitFixEvalMetrics, emitFixEvalVerdictMetric } from '../../sentry.js';
-import type { EvaluateFixAttemptsContext, EvaluateFixAttemptsResult, FixEvaluation } from './types.js';
+import type { EvaluateFixAttemptsContext, EvaluateFixAttemptsResult, FixEvaluation, FixJudgeResult } from './types.js';
 import { evaluateFix } from './judge.js';
 import type { FixJudgeContext, FixJudgeRuntimeOptions } from './judge.js';
 import { fetchFollowUpChanges, fetchFileContent, formatFailedFixReply } from './github.js';
@@ -15,6 +15,9 @@ export type { EvaluateFixAttemptsResult, FixEvaluation } from './types.js';
 
 /** Maximum comments to evaluate per run */
 const MAX_EVALUATIONS = 20;
+const EVALUATION_FAILED_REASONING = 'Evaluation failed';
+const RE_DETECTED_REASONING =
+  'The fix attempt was made, but the same issue was detected again in the updated code.';
 
 /** Extract finding ID (e.g. "WRZ-XPL") from a comment title like "[WRZ-XPL] Some title" */
 function extractFindingId(title: string): string | undefined {
@@ -76,6 +79,100 @@ async function fetchCodeAtLocation(
  */
 function wasReDetected(comment: ExistingComment, currentFindings: Finding[]): boolean {
   return currentFindings.some((finding) => findingMatchesComment(finding, comment));
+}
+
+function createFallbackEvaluation(): FixJudgeResult {
+  return {
+    verdict: { status: 'not_attempted', reasoning: EVALUATION_FAILED_REASONING },
+    usage: emptyUsage(),
+    usedFallback: true,
+  };
+}
+
+/**
+ * Apply Warden's final verdict precedence and record the side effects for it.
+ */
+function recordEvaluationOutcome(args: {
+  result: EvaluateFixAttemptsResult;
+  comment: ExistingComment;
+  findingId?: string;
+  skill?: string;
+  context: EvaluateFixAttemptsContext;
+  evalResult: FixJudgeResult;
+  durationMs: number;
+  reDetected: boolean;
+  uniqueCodeChangedThreadIds: Set<string>;
+  uniqueResolvedThreadIds: Set<string>;
+}): FixEvaluation['verdict'] {
+  const {
+    result,
+    comment,
+    findingId,
+    skill,
+    context,
+    evalResult,
+    durationMs,
+    reDetected,
+    uniqueCodeChangedThreadIds,
+    uniqueResolvedThreadIds,
+  } = args;
+
+  if (evalResult.usedFallback) {
+    result.failedEvaluations++;
+  }
+
+  let finalVerdict: FixEvaluation['verdict'];
+  let reasoning = evalResult.verdict.reasoning;
+
+  if (reDetected) {
+    finalVerdict = 're_detected';
+    reasoning = RE_DETECTED_REASONING;
+    if (comment.threadId) {
+      uniqueCodeChangedThreadIds.add(comment.threadId);
+    }
+    result.toReply.push({
+      comment,
+      replyBody: formatFailedFixReply(context.headSha, RE_DETECTED_REASONING),
+      commitSha: context.headSha,
+    });
+  } else if (evalResult.usedFallback) {
+    finalVerdict = 'eval_error';
+  } else if (evalResult.verdict.status === 'not_attempted') {
+    finalVerdict = 'not_attempted';
+  } else if (evalResult.verdict.status === 'resolved') {
+    finalVerdict = 'resolved';
+    if (comment.threadId) {
+      uniqueCodeChangedThreadIds.add(comment.threadId);
+      uniqueResolvedThreadIds.add(comment.threadId);
+    }
+    result.toResolve.push(comment);
+  } else {
+    finalVerdict = 'attempted_failed';
+    if (comment.threadId) {
+      uniqueCodeChangedThreadIds.add(comment.threadId);
+    }
+    result.toReply.push({
+      comment,
+      replyBody: formatFailedFixReply(context.headSha, evalResult.verdict.reasoning),
+      commitSha: context.headSha,
+    });
+  }
+
+  result.evaluations.push({
+    findingId,
+    skill,
+    path: comment.path,
+    line: comment.line,
+    title: comment.title,
+    verdict: finalVerdict,
+    reasoning,
+    durationMs,
+    usage: evalResult.usage,
+    usedFallback: evalResult.usedFallback,
+  });
+  emitFixEvalVerdictMetric(finalVerdict, skill, { usedFallback: evalResult.usedFallback });
+
+  return finalVerdict;
 }
 
 /**
@@ -205,7 +302,9 @@ export async function evaluateFixAttempts(
           // Non-fatal: judge can still use tools to investigate
         }
 
-        const evalResultData = await Sentry.startSpan(
+        const reDetected = wasReDetected(comment, currentFindings);
+
+        await Sentry.startSpan(
           {
             op: 'fix_eval.evaluate',
             name: `evaluate fix ${comment.path}:${comment.line}`,
@@ -218,106 +317,39 @@ export async function evaluateFixAttempts(
           },
           async (evalSpan) => {
             const startTime = performance.now();
-            const evalResult = await evaluateFix(
-              { comment, skillName: skill, changedFiles, codeBeforeFix, codeAfterFix, commitMessages },
-              toolContext,
-              apiKey,
-              runtimeOptions
-            );
+            let evalResult: FixJudgeResult;
+            try {
+              evalResult = await evaluateFix(
+                { comment, skillName: skill, changedFiles, codeBeforeFix, codeAfterFix, commitMessages },
+                toolContext,
+                apiKey,
+                runtimeOptions
+              );
+            } catch (error) {
+              Sentry.captureException(error, { tags: { operation: 'evaluate_fix_attempt' } });
+              evalResult = createFallbackEvaluation();
+            }
             const durationMs = performance.now() - startTime;
 
-            evalSpan.setAttribute('warden.fix_eval.verdict', evalResult.verdict.status);
+            evalSpan.setAttribute('warden.fix_eval.raw_verdict', evalResult.verdict.status);
             evalSpan.setAttribute('warden.fix_eval.used_fallback', evalResult.usedFallback);
 
-            return { evalResult, durationMs };
+            usages.push(evalResult.usage);
+            const finalVerdict = recordEvaluationOutcome({
+              result,
+              comment,
+              findingId,
+              skill,
+              context,
+              evalResult,
+              durationMs,
+              reDetected,
+              uniqueCodeChangedThreadIds,
+              uniqueResolvedThreadIds,
+            });
+            evalSpan.setAttribute('warden.fix_eval.verdict', finalVerdict);
           },
         );
-
-        const { evalResult, durationMs } = evalResultData;
-        usages.push(evalResult.usage);
-
-        if (evalResult.usedFallback) {
-          result.failedEvaluations++;
-          result.evaluations.push({
-            findingId,
-            skill,
-            path: comment.path,
-            line: comment.line,
-            title: comment.title,
-            verdict: evalResult.verdict.status,
-            reasoning: evalResult.verdict.reasoning,
-            durationMs,
-            usage: evalResult.usage,
-            usedFallback: true,
-          });
-          emitFixEvalVerdictMetric(evalResult.verdict.status, skill);
-          continue;
-        }
-
-        if (evalResult.verdict.status === 'not_attempted') {
-          result.evaluations.push({
-            findingId,
-            skill,
-            path: comment.path,
-            line: comment.line,
-            title: comment.title,
-            verdict: 'not_attempted',
-            reasoning: evalResult.verdict.reasoning,
-            durationMs,
-            usage: evalResult.usage,
-            usedFallback: false,
-          });
-          emitFixEvalVerdictMetric('not_attempted', skill);
-          continue;
-        }
-
-        // Check if the issue was re-detected (overrides LLM judgment)
-        const reDetected = wasReDetected(comment, currentFindings);
-        let finalVerdict: FixEvaluation['verdict'] = evalResult.verdict.status;
-
-        if (reDetected) {
-          finalVerdict = 're_detected';
-          if (comment.threadId) {
-            uniqueCodeChangedThreadIds.add(comment.threadId);
-          }
-          result.toReply.push({
-            comment,
-            replyBody: formatFailedFixReply(
-              context.headSha,
-              'The fix attempt was made, but the same issue was detected again in the updated code.'
-            ),
-            commitSha: context.headSha,
-          });
-        } else if (evalResult.verdict.status === 'resolved') {
-          if (comment.threadId) {
-            uniqueCodeChangedThreadIds.add(comment.threadId);
-            uniqueResolvedThreadIds.add(comment.threadId);
-          }
-          result.toResolve.push(comment);
-        } else {
-          if (evalResult.verdict.status === 'attempted_failed' && comment.threadId) {
-            uniqueCodeChangedThreadIds.add(comment.threadId);
-          }
-          result.toReply.push({
-            comment,
-            replyBody: formatFailedFixReply(context.headSha, evalResult.verdict.reasoning),
-            commitSha: context.headSha,
-          });
-        }
-
-        result.evaluations.push({
-          findingId,
-          skill,
-          path: comment.path,
-          line: comment.line,
-          title: comment.title,
-          verdict: finalVerdict,
-          reasoning: evalResult.verdict.reasoning,
-          durationMs,
-          usage: evalResult.usage,
-          usedFallback: false,
-        });
-        emitFixEvalVerdictMetric(finalVerdict, skill);
       }
 
       result.usage = usages.length > 0 ? aggregateUsage(usages) : emptyUsage();

--- a/src/action/fix-evaluation/types.ts
+++ b/src/action/fix-evaluation/types.ts
@@ -25,7 +25,7 @@ export interface FixEvaluation {
   path: string;
   line: number;
   title: string;
-  verdict: FixStatus | 're_detected';
+  verdict: FixStatus | 're_detected' | 'eval_error';
   reasoning?: string;
   durationMs: number;
   usage: UsageStats;

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -120,7 +120,7 @@ function logFixEvaluation(ev: FixEvaluation, index: number, total: number): void
   const totalTokens = ev.usage.inputTokens + ev.usage.outputTokens;
   const costStr = ev.usage.costUSD > 0 ? `, ${formatCost(ev.usage.costUSD)}` : '';
   const idPrefix = ev.findingId ? `${ev.findingId} ` : '';
-  const verdict = ev.usedFallback ? 'eval_error' : ev.verdict;
+  const verdict = ev.verdict;
 
   const line = `  [${index + 1}/${total}] ${idPrefix}${ev.path}:${ev.line} → ${verdict} (${formatDuration(ev.durationMs)}, ${formatTokens(totalTokens)} tok${costStr})`;
 

--- a/src/cli/output/jsonl.ts
+++ b/src/cli/output/jsonl.ts
@@ -168,10 +168,11 @@ export const JsonlFixEvalDetailSchema = z.object({
   path: z.string(),
   line: z.number().int().positive(),
   findingId: z.string().optional(),
-  verdict: z.union([FixStatusSchema, z.literal('re_detected')]),
+  verdict: z.union([FixStatusSchema, z.literal('re_detected'), z.literal('eval_error')]),
   reasoning: z.string().optional(),
   durationMs: z.number().nonnegative(),
   usage: UsageStatsSchema,
+  usedFallback: z.boolean().optional(),
 });
 export type JsonlFixEvalDetail = z.infer<typeof JsonlFixEvalDetailSchema>;
 

--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -100,4 +100,18 @@ describe('sentry telemetry scope', () => {
       })
     );
   });
+
+  it('emits fix evaluation verdict metrics with fallback attribution', async () => {
+    const sentry = await loadInitializedSentry();
+
+    sentry.emitFixEvalVerdictMetric('eval_error', 'security-review', { usedFallback: true });
+
+    expect(sentryMocks.metrics.count).toHaveBeenCalledWith('warden.fix_eval.verdict', 1, {
+      attributes: {
+        'warden.fix_eval.verdict': 'eval_error',
+        'warden.fix_eval.used_fallback': true,
+        'gen_ai.agent.name': 'security-review',
+      },
+    });
+  });
 });

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -259,9 +259,19 @@ export function emitDedupMetrics(skill: string, total: number, unique: number): 
   });
 }
 
-export function emitFixEvalVerdictMetric(verdict: string, skill?: string): void {
+/**
+ * Emit the final fix-evaluation outcome for one comment.
+ */
+export function emitFixEvalVerdictMetric(
+  verdict: string,
+  skill?: string,
+  options: { usedFallback?: boolean } = {}
+): void {
   safeEmit(() => {
     const attrs: TelemetryAttributes = { 'warden.fix_eval.verdict': verdict };
+    if (options.usedFallback !== undefined) {
+      attrs['warden.fix_eval.used_fallback'] = options.usedFallback;
+    }
     if (skill) {
       Object.assign(attrs, agentMetricAttributes(skill));
     }


### PR DESCRIPTION
Fix fix-evaluation outcome handling so current-run re-detection is applied before fallback or not_attempted paths can short-circuit. Per-comment judge failures are now isolated as eval_error outcomes instead of aborting the batch.

This also aligns telemetry, logs, and structured schemas around final fix-evaluation outcomes. Spans retain the raw judge verdict for debugging while metrics and logs report the final Warden outcome, with fallback attribution preserved.

Fixes #310