### PR TITLE
fix(reviews): Compact inline finding comments

### DIFF
--- a/specs/github-comments.md
+++ b/specs/github-comments.md
@@ -9,7 +9,13 @@ How Warden formats and manages PR comments: format conventions, deduplication, a
 ```
 **Title stating what is broken or wrong**
 
-2-4 sentence description. Root cause first, user-visible consequence last.
+One short sentence stating what breaks and why it matters.
+
+<details><summary>Verification</summary>
+
+Evidence checked before reporting the finding.
+
+</details>
 
 <details><summary>Also found at N additional locations</summary>
 
@@ -23,6 +29,7 @@ Identified by Warden `skill-name` · `FINDING-ID`
 ```
 
 - Title: bold, no emoji, no ID, no confidence, no severity
+- Verification details render in a collapsible block when present
 - Severity is communicated via GitHub check annotation level (failure/warning/notice)
 - Footer: skill name and finding ID in backticks
 - Additional locations in collapsible details block

--- a/src/builtin-skills/code-review/SKILL.md
+++ b/src/builtin-skills/code-review/SKILL.md
@@ -80,6 +80,6 @@ No proof, no finding. Suspicion is not a result.
 ## Finding Format
 
 - Title: name the exact bug and trigger.
-- Description: include the changed behavior, trigger conditions, expected behavior, actual behavior, and concrete impact.
-- `verification`: list checked files, functions, callers, guards, tests, schemas, or framework guarantees.
+- Description: one short public comment stating the broken behavior and impact. Use a second sentence only if needed for the fix.
+- `verification`: include trigger conditions, expected behavior, actual behavior, checked callers, guards, tests, schemas, or framework guarantees.
 - `suggestedFix`: include only when the fix is complete for the analyzed path.

--- a/src/builtin-skills/security-review/SKILL.md
+++ b/src/builtin-skills/security-review/SKILL.md
@@ -76,6 +76,6 @@ Load only matching references:
 ## Finding Format
 
 - Title: name the vulnerability and impact.
-- Description: include source, sink or missing guard, boundary crossed, and attacker-visible consequence.
-- `verification`: list checked files, functions, guards, or sibling paths.
+- Description: one short public comment stating the exploitable path and impact. Use a second sentence only if needed for the fix.
+- `verification`: include source, sink or missing guard, boundary crossed, mitigations checked, and attacker-visible consequence.
 - `suggestedFix`: include only when the fix is complete for the analyzed file.

--- a/src/output/renderer.test.ts
+++ b/src/output/renderer.test.ts
@@ -104,6 +104,35 @@ describe('renderSkillReport', () => {
     expect(result.review!.comments[0]!.body).not.toContain('confidence');
   });
 
+  it('renders verification details in a collapsible section', () => {
+    const report: SkillReport = {
+      ...baseReport,
+      skill: 'code-review',
+      findings: [
+        {
+          id: 'f1',
+          severity: 'medium',
+          title: 'Vitest runs in watch mode in CI',
+          description:
+            'The test script can hang CI because Vitest watches by default. Use `vitest run` so the job exits after one pass.',
+          verification: 'Checked package.json scripts and Vitest default behavior.',
+          location: {
+            path: 'package.json',
+            startLine: 10,
+          },
+        },
+      ],
+    };
+
+    const result = renderSkillReport(report);
+    const body = result.review!.comments[0]!.body;
+
+    expect(body).toContain('Vitest runs in watch mode in CI');
+    expect(body).toContain('The test script can hang CI');
+    expect(body).toContain('<details><summary>Verification</summary>');
+    expect(body).toContain('Checked package.json scripts');
+  });
+
   it('includes deduplication marker in comments', () => {
     const report: SkillReport = {
       ...baseReport,
@@ -1283,6 +1312,25 @@ describe('renderFindingsBody', () => {
     expect(body).toContain('(`src/db.ts:42`)');
     expect(body).toContain('User input in query');
     expect(body).toContain('<sub>Identified by Warden security-review</sub>');
+  });
+
+  it('renders verification details in body findings', () => {
+    const findings = [
+      {
+        id: 'f1',
+        severity: 'medium' as const,
+        title: 'Fallback Finding',
+        description: 'Short visible comment',
+        verification: 'Checked the fallback review body path.',
+        location: { path: 'src/app.ts', startLine: 12 },
+      },
+    ];
+
+    const body = renderFindingsBody(findings, 'code-review');
+
+    expect(body).toContain('Short visible comment');
+    expect(body).toContain('<details><summary>Verification</summary>');
+    expect(body).toContain('Checked the fallback review body path.');
   });
 
   it('renders findings without location', () => {

--- a/src/output/renderer.ts
+++ b/src/output/renderer.ts
@@ -71,7 +71,7 @@ function renderReview(
     let body = `**${escapeHtml(finding.title)}**\n\n${escapeHtml(finding.description)}`;
 
     if (finding.verification) {
-      body += `\n\n<details><summary>Verification</summary>\n\n${escapeHtml(finding.verification)}\n\n</details>`;
+      body += `\n\n${renderVerification(finding.verification)}`;
     }
 
     if (includeSuggestions && finding.suggestedFix) {
@@ -163,6 +163,10 @@ function renderSuggestion(description: string, diff: string): string {
   }
 
   return `**Suggested fix:** ${escapeHtml(description)}\n\n\`\`\`suggestion\n${suggestionLines.join('\n')}\n\`\`\``;
+}
+
+function renderVerification(verification: string): string {
+  return `<details><summary>Verification</summary>\n\n${escapeHtml(verification)}\n\n</details>`;
 }
 
 function renderHiddenFindingsLink(hiddenCount: number, checkRunUrl: string): string {
@@ -275,6 +279,10 @@ export function renderFindingsBody(findings: Finding[], skill: string): string {
     lines.push('');
     lines.push(escapeHtml(finding.description));
     lines.push('');
+    if (finding.verification) {
+      lines.push(renderVerification(finding.verification));
+      lines.push('');
+    }
   }
   lines.push(renderAttributionFooter(skill));
   return lines.join('\n');

--- a/src/sdk/prompt.test.ts
+++ b/src/sdk/prompt.test.ts
@@ -36,7 +36,6 @@ describe('buildHunkSystemPrompt', () => {
   it('includes verification field in output schema', () => {
     const result = buildHunkSystemPrompt(skill);
     expect(result).toContain('"verification"');
-    expect(result).toContain('Required. What you checked before reporting');
   });
 
   it('includes skill prompt in instructions', () => {

--- a/src/sdk/prompt.ts
+++ b/src/sdk/prompt.ts
@@ -51,14 +51,14 @@ Full schema:
       "id": "unique-identifier",
       "severity": "high|medium|low",
       "confidence": "high|medium|low",
-      "title": "Assertive, impact-focused title stating what is broken or wrong (e.g. 'wasFailFastAborted never detects fail-fast abort')",
-      "description": "2-4 concise sentences. Start with the root cause, end with the user-visible consequence.",
+      "title": "Short, specific title naming the broken behavior or risk (e.g. 'wasFailFastAborted never detects fail-fast abort')",
+      "description": "Visible inline PR comment. Use one short, direct sentence whenever possible; two only if needed for the fix or impact.",
       "location": {
         "path": "path/to/file.ts",
         "startLine": 10,
         "endLine": 15
       },
-      "verification": "Required. What you checked before reporting: files read, code paths traced, assumptions validated. Reference specific files/functions.",
+      "verification": "Required. Detailed evidence for the collapsible verification block: files/functions checked, trigger conditions, expected vs actual behavior, and why mitigations do not apply.",
       "suggestedFix": {
         "description": "How to fix this issue",
         "diff": "unified diff format"
@@ -75,8 +75,10 @@ Requirements:
 - "confidence" reflects how certain you are this is a real issue given the codebase context
 - "suggestedFix" is optional - only include when you can provide a complete, correct fix **to the file being analyzed**. Omit suggestedFix if:
   - The fix would be incomplete or you're uncertain about the correct solution
-  - The fix requires changes to a different file or a new file (describe the fix in the description field instead)
-- Keep descriptions concise (2-4 sentences). Start with the root cause, end with the user-visible consequence.
+  - The fix requires changes to a different file or a new file (briefly name the fix in the description field instead)
+- "description" is rendered directly in GitHub inline comments. Keep it brief and actionable, usually one sentence.
+- Put proof, trace notes, checked files, and expected/actual breakdowns in "verification", not "description".
+- Do not include severity, confidence, finding ID, skill name, or generic review framing in "description".
 - Focus your analysis on the code changes in the hunk. Surrounding context and tool results are for understanding only -- all findings must reference lines within the hunk range.
 `),
   ];


### PR DESCRIPTION
Compact Warden review comments by treating `description` as the short public comment text and keeping detailed proof in `verification`.

The platform prompt and built-in review skills now separate reviewer-facing copy from verification evidence. Inline comments and review-body fallbacks still render verification in a collapsible block, but the normal visible comment is guided toward one short, direct sentence.

This keeps the review surface more legible without removing the detailed evidence reviewers can expand when needed.

Refs GH-312