### PR TITLE
feat(cli): Add @file target lists

### DIFF
--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -79,15 +79,16 @@ Get an API key from https://console.anthropic.com/. `ANTHROPIC_API_KEY` is also 
 ### warden
 
 ```
-warden [target] [options]
+warden [targets...] [options]
 ```
 
-Run code analysis on the specified target. If no target is given, analyzes uncommitted changes.
+Run code analysis on the specified targets. If no target is given, analyzes uncommitted changes.
 
 ```bash
 warden                     # Analyze uncommitted changes (default)
 warden src/auth.ts         # Analyze specific file
 warden src/api/            # Analyze a directory
+warden @targets.txt        # Analyze targets listed in a file
 warden HEAD~3..HEAD        # Analyze changes in a git range
 warden main..HEAD          # Analyze all commits not on main
 ```

--- a/packages/docs/src/pages/cli.astro
+++ b/packages/docs/src/pages/cli.astro
@@ -26,16 +26,17 @@ const tocItems = [
 
   <div class="command-card">
     <h3 id="warden">warden</h3>
-    <div class="synopsis">warden [target] [options]</div>
-    <p>Run code analysis on the specified target. If no target is given, Warden reviews the current branch against the default branch.</p>
+    <div class="synopsis">warden [targets...] [options]</div>
+    <p>Run code analysis on the specified targets. If no target is given, Warden reviews the current branch against the default branch.</p>
     <ul>
-      <li><code>target</code> - Files, directories, or git refs to analyze (optional)</li>
+      <li><code>targets</code> - Files, directories, globs, git refs, or <code>@files</code> containing target lists (optional)</li>
     </ul>
     <Terminal>
       <Code
         code={`warden                     # Review current branch changes
 warden src/auth.ts         # Analyze specific file
 warden src/api/            # Analyze a directory
+warden @targets.txt        # Analyze targets listed in a file
 warden --staged            # Analyze staged changes
 warden HEAD~3..HEAD        # Analyze changes in a git range`}
         lang="bash"

--- a/packages/docs/src/pages/guide.astro
+++ b/packages/docs/src/pages/guide.astro
@@ -158,12 +158,13 @@ warden --skill code-review`}
 
     <h3>Analyze Specific Files</h3>
 
-    <p>Target specific files or directories:</p>
+    <p>Target specific files, directories, or a file containing one target per line:</p>
 
     <Terminal showCopy={true}>
       <Code
         code={`warden src/auth.ts
-warden src/api/`}
+warden src/api/
+warden @targets.txt`}
         lang="bash"
         theme="vitesse-black"
       />

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,6 +1,14 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { parseCliArgs, CLIOptionsSchema, detectTargetType, classifyTargets } from './args.js';
+import {
+  parseCliArgs,
+  CLIOptionsSchema,
+  detectTargetType,
+  classifyTargets,
+  expandTargetFileReferences,
+} from './args.js';
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual('node:fs');
@@ -726,5 +734,47 @@ describe('classifyTargets', () => {
     const { gitRefs, filePatterns } = classifyTargets(['feature'], { forceGit: true });
     expect(gitRefs).toEqual(['feature']);
     expect(filePatterns).toEqual([]);
+  });
+});
+
+describe('expandTargetFileReferences', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `warden-targets-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('expands @file target lists', () => {
+    writeFileSync(
+      join(tempDir, 'targets.txt'),
+      [
+        '# selected files',
+        'src/auth.ts',
+        '',
+        'internal/api/admin.go',
+        'src/**/*.ts',
+      ].join('\n')
+    );
+
+    expect(expandTargetFileReferences(['README.md', '@targets.txt'], tempDir)).toEqual([
+      'README.md',
+      'src/auth.ts',
+      'internal/api/admin.go',
+      'src/**/*.ts',
+    ]);
+  });
+
+  it('throws when an @file target list cannot be read', () => {
+    expect(() => expandTargetFileReferences(['@missing.txt'], tempDir)).toThrow(
+      /Failed to read target list missing\.txt/
+    );
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,4 +1,5 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { z } from 'zod';
 import { SeverityThresholdSchema, ConfidenceThresholdSchema } from '../types/index.js';
@@ -232,6 +233,43 @@ export function classifyTargets(targets: string[], options: DetectTargetTypeOpti
   }
 
   return { gitRefs, filePatterns };
+}
+
+/**
+ * Expand @file target references into newline-delimited target lists.
+ */
+export function expandTargetFileReferences(
+  targets: string[],
+  cwd = process.cwd()
+): string[] {
+  const expanded: string[] = [];
+
+  for (const target of targets) {
+    if (!target.startsWith('@')) {
+      expanded.push(target);
+      continue;
+    }
+
+    const listPath = target.slice(1);
+    if (!listPath) {
+      throw new Error('Target list path is empty: @');
+    }
+
+    try {
+      const content = readFileSync(resolve(cwd, listPath), 'utf-8');
+      for (const line of content.split(/\r?\n/)) {
+        const value = line.trim();
+        if (value && !value.startsWith('#')) {
+          expanded.push(value);
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to read target list ${listPath}: ${message}`, { cause: error });
+    }
+  }
+
+  return expanded;
 }
 
 /**

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -229,7 +229,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
       'warden run [targets...] [options]',
     ],
     arguments: [
-      { label: 'targets...', description: 'Files, globs, or git refs to analyze' },
+      { label: 'targets...', description: 'Files, globs, git refs, or @files containing target lists' },
     ],
     options: [
       'cwd',
@@ -251,6 +251,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
     ],
     examples: [
       'warden src/auth.ts',
+      'warden @targets.txt --skill security-review',
       'warden "src/**/*.ts" --skill security-review',
       'warden HEAD~3',
       'warden --staged --fix',

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -13,7 +13,7 @@ import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, F
 import { filterFindings } from '../types/index.js';
 import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
 import { isRepoRelativePath, normalizePath } from '../utils/path.js';
-import { parseCliArgs, showVersion, classifyTargets, type CLIOptions } from './args.js';
+import { parseCliArgs, showVersion, classifyTargets, expandTargetFileReferences, type CLIOptions } from './args.js';
 import { showHelp } from './help.js';
 import { buildLocalEventContext, buildFileEventContext } from './context.js';
 import { getRepoRoot, getHeadSha, refExists, getDefaultBranch } from './git.js';
@@ -1445,21 +1445,32 @@ async function runDirectSkillMode(options: CLIOptions, reporter: Reporter): Prom
 }
 
 async function runCommand(options: CLIOptions, reporter: Reporter): Promise<number> {
-  const targets = options.targets ?? [];
+  const rawTargets = options.targets ?? [];
+  let targets = rawTargets;
+
+  try {
+    targets = expandTargetFileReferences(targets);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    reporter.error(message);
+    return 1;
+  }
 
   // --staged is only meaningful without explicit targets
-  if (options.staged && targets.length > 0) {
+  if (options.staged && rawTargets.length > 0) {
     reporter.warning('--staged is ignored when targets are specified');
   }
 
   // No targets with --skill → run skill directly on current branch changes
-  if (targets.length === 0 && options.skill) {
-    return runDirectSkillMode(options, reporter);
+  if (rawTargets.length === 0) {
+    if (options.skill) {
+      return runDirectSkillMode(options, reporter);
+    }
+    return runConfigMode(options, reporter);
   }
 
-  // No targets → config mode (use triggers)
   if (targets.length === 0) {
-    return runConfigMode(options, reporter);
+    return runFileMode([], options, reporter);
   }
 
   // Classify targets


### PR DESCRIPTION
Add @file target list expansion to the CLI.

This lets users pass a newline-delimited file of scattered targets, like @targets.txt, instead of shelling through xargs or adding another flag. Blank lines and # comment lines are ignored, then the expanded targets use the existing file, glob, and git-ref classification path.

Fixes #281