### PR TITLE
fix(code-review): Calibrate config severity

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -100,7 +100,7 @@ evals/
 | `model` | No | Model override for this scenario |
 | `should_find` | Yes | What the pipeline should detect (at least one) |
 | `should_find[].finding` | Yes | Natural language description for the LLM judge |
-| `should_find[].severity` | No | Expected severity (hint, not strict) |
+| `should_find[].severity` | No | Expected severity. When provided, the matched finding must use this exact normalized severity. |
 | `should_find[].required` | No | If true (default), eval fails when not found |
 | `should_not_find` | No | Things the pipeline should NOT report (precision) |
 

--- a/evals/config-severity.yaml
+++ b/evals/config-severity.yaml
@@ -1,0 +1,12 @@
+skill: ../src/builtin-skills/code-review/SKILL.md
+
+evals:
+  - name: robots-prefix-blocks-public-metadata
+    given: a robots.txt golden test disallows a prefix that also blocks a documented public metadata endpoint
+    files:
+      - fixtures/robots-prefix-blocks-public-metadata/__static_test.ts
+    should_find:
+      - finding: robots.txt Disallow /mcp is a prefix rule that blocks the public /mcp.json metadata endpoint from crawlers
+        severity: high
+    should_not_find:
+      - the test file being test-only makes the finding low severity

--- a/evals/fixtures/robots-prefix-blocks-public-metadata/__static_test.ts
+++ b/evals/fixtures/robots-prefix-blocks-public-metadata/__static_test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../server.js";
+
+describe("static routes", () => {
+  it("serves the public MCP discovery manifest", async () => {
+    const response = await app.request("/mcp.json");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      name: "Example MCP",
+      transport: "streamable-http",
+    });
+  });
+
+  it("serves robots.txt", async () => {
+    const response = await app.request("/robots.txt");
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe([
+      "User-agent: *",
+      "Disallow: /admin",
+      "Disallow: /mcp",
+      "",
+    ].join("\n"));
+  });
+});

--- a/src/builtin-skills/code-review/SKILL.md
+++ b/src/builtin-skills/code-review/SKILL.md
@@ -51,6 +51,7 @@ No proof, no finding. Suspicion is not a result.
 | Boundaries and edge cases | Empty, first, last, duplicate, pagination, sorting, timezone, locale, precision, overflow, migration, or compatibility cases produce wrong behavior. |
 | Persistence and migrations | Writes are non-atomic, migrations lose data, backfills skip rows, query filters update the wrong records, or rollback paths leave inconsistent state. |
 | API and dependency behavior | Published interfaces, CLI flags, config options, webhooks, service calls, or third-party dependency changes break documented or existing caller behavior. |
+| Public metadata and routing config | Robots rules, sitemaps, manifests, redirects, cache headers, or route config make documented public entry points unreachable, stale, or undiscoverable. |
 | UI correctness | The UI displays stale, wrong, duplicate, missing, or unsaved data because of the changed code, not because of style or preference. |
 | Build, test, and workflow breakage | Changed code, packaging, imports, exports, generated artifacts, CI, or release workflows fail deterministically or report false success. |
 
@@ -58,11 +59,12 @@ No proof, no finding. Suspicion is not a result.
 
 | Level | Use For |
 |-------|---------|
-| high | Data loss or corruption, critical-path crashes, broken production deploy or release, incorrect billing or permissions state, published interface breakage for normal callers, deadlock or hang in core flow, or false success after a failed destructive operation. |
+| high | Data loss or corruption, critical-path crashes, broken production deploy or release, incorrect billing or permissions state, published interface breakage for normal callers, public metadata/config that blocks normal discovery or reachability of shipped endpoints, deadlock or hang in core flow, or false success after a failed destructive operation. |
 | medium | Reproducible wrong results, recoverable crashes, duplicate or missed side effects, broken non-critical workflow, meaningful edge case in a shipped path, or compatibility break with a clear affected caller. |
-| low | Narrow but real bug with limited blast radius, confusing state that can cause user-visible mistakes, or a test/tooling bug that masks the intended behavior. |
+| low | Narrow but real bug with limited blast radius, confusing state that can cause user-visible mistakes, or a test/tooling bug that masks only a narrow non-shipped behavior. |
 
 - Use the lower severity when impact depends on unproven preconditions.
+- Score test and golden-file findings by the shipped behavior they authorize or hide, not by the file type. A test that locks in a high-impact production breakage is high severity.
 - Do not inflate severity for cleverness. The bug earns its level through impact.
 
 ## What Not To Report

--- a/src/builtin-skills/code-review/SOURCES.md
+++ b/src/builtin-skills/code-review/SOURCES.md
@@ -8,6 +8,7 @@
 | Local `architecture-review` and `code-simplifier` skills | Local prior art | Medium | Use boundaries to avoid overlap with style and architecture feedback. | Make exclusions explicit so code review reports only bugs. |
 | Common production correctness review failure modes | Engineering practice | Medium | Keep examples generic, transformed, and evidence-gated. | Cover logic, state, async, error handling, contracts, persistence, UI, build, and workflow bugs. |
 | Warden package skill loader and packaging tests | Repository behavior | High | Use for validation scope only. | Add tests that the new built-in skill resolves and is included in the npm package. |
+| GitHub issue #317 severity feedback | Maintainer issue feedback | High | Use only the generalized severity lesson; do not encode repo-specific private context. | Score tests, golden files, and config bugs by production blast radius when they hide or authorize shipped breakage. |
 
 ## Coverage Matrix
 
@@ -16,7 +17,7 @@
 | Bug class definitions and prerequisites | Complete | `SKILL.md` defines reportable categories and requires a concrete trigger, violated contract, and impact. |
 | Reachability and reproducibility evidence | Complete | Findings must prove the changed path is reachable and the failure is triggered by a specific input, state, ordering, or configuration. |
 | False-positive controls | Complete | Exclusions block style, architecture, maintainability, security, performance-only, test-coverage-only, and pattern-only findings. |
-| Severity and confidence calibration | Complete | Severity is tied to user-visible or operational impact, with lower severity for unproven preconditions. |
+| Severity and confidence calibration | Complete | Severity is tied to user-visible or operational impact, including high-impact public discovery/config breakage, with lower severity for unproven preconditions. |
 | Remediation expectations | Complete | Findings may include `suggestedFix` only when the fix is complete for the analyzed path. |
 | Language and workflow caveats | Complete for initial scope | References cover JS/TS, Python, and GitHub Actions workflow correctness. Other languages use the core contract until repeated examples justify references. |
 
@@ -34,6 +35,9 @@
 4. Build and workflow breakage are correctness bugs.
    - Reason: Warden reviews code changes that can break published packages, CI, and releases.
    - Decision: include deterministic build, packaging, test, and workflow failures when the changed code proves the failure.
+5. Tests and golden files inherit severity from the shipped behavior they protect.
+   - Reason: a changed test can lock in broken output for a public route or config surface while looking like a low-impact test-only edit.
+   - Decision: do not automatically classify test/tooling findings as low when they mask or authorize high-impact production breakage.
 
 ## Open Gaps
 

--- a/src/builtin-skills/code-review/SPEC.md
+++ b/src/builtin-skills/code-review/SPEC.md
@@ -10,7 +10,7 @@ It should catch real regressions and production defects while preferring no find
 
 In scope:
 
-- Logic, state, async, data contract, persistence, edge-case, API, UI, build, test, and workflow correctness bugs.
+- Logic, state, async, data contract, persistence, edge-case, API, public metadata/config, UI, build, test, and workflow correctness bugs.
 - Changed production code, user entry points, public APIs, shipped workflows, and tests that can mask shipped regressions.
 - General bug-finding guidance that applies across application code.
 - Focused notes for JavaScript/TypeScript, Python, and GitHub Actions workflow correctness.
@@ -89,6 +89,7 @@ Data that must not be stored:
 - Holdout examples:
   - A style-only diff with no behavior change should produce no finding.
   - A security-only diff should be routed to `security-review`, not reported by `code-review`.
+  - A test or golden fixture that locks in broken shipped behavior should be scored by the shipped behavior's blast radius, not by the file type.
   - A type-safe or schema-validated path should not be reported as a runtime bug.
 - Acceptance gates:
   - Findings require trigger, expected behavior, actual behavior, and impact.

--- a/src/evals/judge.ts
+++ b/src/evals/judge.ts
@@ -28,7 +28,7 @@ function buildJudgePrompt(meta: EvalMeta, findings: Finding[]): string {
     : '  (no findings reported)';
 
   const shouldFindBlock = meta.should_find.map((e, i) => {
-    const sev = e.severity ? ` [expected severity: ${e.severity}]` : '';
+    const sev = e.severity ? ` [required severity: ${e.severity}]` : '';
     const req = e.required ? ' (REQUIRED)' : ' (optional)';
     return `  [${i}] ${e.finding}${sev}${req}`;
   }).join('\n');
@@ -56,8 +56,8 @@ ${shouldNotFindBlock}
 
 For each "should find" assertion, determine if ANY of the agent's findings satisfy it.
 A finding satisfies an assertion if it describes the same issue, even if worded differently.
-The severity hint is guidance, not a strict requirement: if the finding describes the
-right issue at a close severity level, it still counts as met.
+When an assertion includes a required severity, the matching finding must use that exact
+normalized severity.
 
 For each "should not find" assertion, determine if ANY of the agent's findings violate it.
 A violation means the agent reported something it should not have.

--- a/src/evals/runner.ts
+++ b/src/evals/runner.ts
@@ -161,7 +161,7 @@ export async function runEval(
     log('Running judge...');
     const judgeResult = await runJudge(meta, report.findings, options.apiKey);
 
-    const passed = evalPassed(meta, judgeResult.response);
+    const passed = evalPassed(meta, judgeResult.response, report.findings);
     log(`Result: ${passed ? 'PASS' : 'FAIL'}`);
 
     return {

--- a/src/evals/types.test.ts
+++ b/src/evals/types.test.ts
@@ -51,6 +51,30 @@ describe('evalPassed', () => {
     expect(evalPassed(meta, response)).toBe(false);
   });
 
+  it('fails when a required severity does not match the matched finding', () => {
+    const meta = makeMeta({
+      should_find: [{ finding: 'public endpoint discovery breakage', severity: 'high', required: true }],
+    });
+    const response = makeJudgeResponse({
+      expectations: [{ met: true, matchedFindingIndex: 0, reasoning: 'same issue' }],
+    });
+    const findings = [{ id: 'f1', severity: 'low' as const, title: 'Robots blocks endpoint', description: 'desc' }];
+
+    expect(evalPassed(meta, response, findings)).toBe(false);
+  });
+
+  it('passes when a required severity matches the matched finding', () => {
+    const meta = makeMeta({
+      should_find: [{ finding: 'public endpoint discovery breakage', severity: 'high', required: true }],
+    });
+    const response = makeJudgeResponse({
+      expectations: [{ met: true, matchedFindingIndex: 0, reasoning: 'same issue' }],
+    });
+    const findings = [{ id: 'f1', severity: 'high' as const, title: 'Robots blocks endpoint', description: 'desc' }];
+
+    expect(evalPassed(meta, response, findings)).toBe(true);
+  });
+
   it('passes when optional should_find assertion is not met', () => {
     const meta = makeMeta({
       should_find: [

--- a/src/evals/types.ts
+++ b/src/evals/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { SeveritySchema } from '../types/index.js';
-import type { SkillReport, UsageStats } from '../types/index.js';
+import type { Finding, SkillReport, UsageStats } from '../types/index.js';
 
 /** Default model for eval skill execution and judging. */
 export const DEFAULT_EVAL_MODEL = 'claude-sonnet-4-6';
@@ -11,7 +11,7 @@ export const DEFAULT_EVAL_MODEL = 'claude-sonnet-4-6';
 export const ShouldFindSchema = z.object({
   /** Natural language description of the expected finding for the LLM judge */
   finding: z.string(),
-  /** Expected severity level (hint for the judge, not a strict match) */
+  /** Expected severity level. When provided, evals require an exact normalized match. */
   severity: SeveritySchema.optional(),
   /** If true (default), eval fails when this is not found */
   required: z.boolean().default(true),
@@ -146,13 +146,26 @@ export interface EvalResult {
 /**
  * Determine if an eval passed based on judge response and eval metadata.
  */
-export function evalPassed(meta: EvalMeta, judgeResponse: JudgeResponse): boolean {
+export function evalPassed(
+  meta: EvalMeta,
+  judgeResponse: JudgeResponse,
+  findings?: Finding[]
+): boolean {
   // Check required should_find assertions are met
   for (let i = 0; i < meta.should_find.length; i++) {
     const assertion = meta.should_find[i];
     const verdict = judgeResponse.expectations[i];
     if (assertion?.required && !verdict?.met) {
       return false;
+    }
+
+    if (assertion?.required && assertion.severity && verdict?.met && findings) {
+      const matchedFinding = verdict.matchedFindingIndex === null
+        ? undefined
+        : findings[verdict.matchedFindingIndex];
+      if (matchedFinding?.severity !== assertion.severity) {
+        return false;
+      }
     }
   }
 
@@ -185,6 +198,12 @@ export function formatEvalResult(result: EvalResult): string {
     lines.push(`  [${mark}] should find: ${assertion?.finding ?? 'unknown'}${req}`);
     if (verdict?.reasoning) {
       lines.push(`    -> ${verdict.reasoning}`);
+    }
+    if (assertion?.severity && verdict?.met && verdict.matchedFindingIndex !== null) {
+      const matchedSeverity = result.report.findings[verdict.matchedFindingIndex]?.severity ?? 'missing';
+      if (matchedSeverity !== assertion.severity) {
+        lines.push(`    -> severity mismatch: expected ${assertion.severity}, got ${matchedSeverity}`);
+      }
     }
   }
 


### PR DESCRIPTION
Calibrate the bundled `code-review` skill so high-impact public metadata and routing config breakages are treated by blast radius, even when the evidence appears in tests or golden fixtures.

This also makes eval severity expectations strict when a severity is specified, then adds a regression eval for the robots.txt prefix case from issue #317. A finding that catches `/mcp` blocking `/mcp.json` now has to land as high severity to pass.

Fixes #317