### PR TITLE
fix(action): Validate Pi model selectors before execution

### DIFF
--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -328,6 +328,7 @@
         "max_turns",
         "aborted",
         "all_hunks_failed",
+        "invalid_model_selector",
         "skill_resolution_failed",
         "extraction_invalid_json",
         "extraction_unbalanced_json",

--- a/specs/reporters.md
+++ b/specs/reporters.md
@@ -554,7 +554,7 @@ New run logs are homogeneous: every line is a chunk result. Each line is self-co
 
 **HunkFailure**: `{ type: "analysis" | "extraction", filename: string, lineRange: string, code: ErrorCode, message: string, preview?: string, attempts?: int }`
 
-**ErrorCode**: one of `"auth_failed"`, `"provider_unavailable"`, `"sdk_error"`, `"subprocess_failure"`, `"max_turns"`, `"aborted"`, `"all_hunks_failed"`, `"skill_resolution_failed"`, `"extraction_invalid_json"`, `"extraction_unbalanced_json"`, `"extraction_no_findings_json"`, `"extraction_missing_findings_key"`, `"extraction_findings_not_array"`, `"extraction_llm_failed"`, `"extraction_llm_timeout"`, `"extraction_no_api_key"`, `"unknown"`. Stable public contract.
+**ErrorCode**: one of `"auth_failed"`, `"provider_unavailable"`, `"sdk_error"`, `"subprocess_failure"`, `"max_turns"`, `"aborted"`, `"all_hunks_failed"`, `"invalid_model_selector"`, `"skill_resolution_failed"`, `"extraction_invalid_json"`, `"extraction_unbalanced_json"`, `"extraction_no_findings_json"`, `"extraction_missing_findings_key"`, `"extraction_findings_not_array"`, `"extraction_llm_failed"`, `"extraction_llm_timeout"`, `"extraction_no_api_key"`, `"unknown"`. Stable public contract.
 
 **BySeverity**: `{ high: int, medium: int, low: int }`. Legacy 5-level keys (`critical`, `info`) are still accepted on read for backward compatibility with older logs and normalized to `high`/`low`; new output is strictly 3-level.
 

--- a/src/action/error-reporting.ts
+++ b/src/action/error-reporting.ts
@@ -1,0 +1,32 @@
+import { Sentry } from '../sentry.js';
+import { classifyError } from '../sdk/errors.js';
+import type { ErrorCode } from '../types/index.js';
+
+interface TriggerErrorContext {
+  triggerName: string;
+  skillName: string;
+}
+
+function shouldFingerprintTriggerError(code: ErrorCode): boolean {
+  return (
+    code === 'provider_unavailable'
+    || code === 'all_hunks_failed'
+    || code === 'invalid_model_selector'
+  );
+}
+
+/**
+ * Capture trigger failures with stable tags and grouped fingerprints.
+ */
+export function captureActionTriggerError(error: unknown, context: TriggerErrorContext): ErrorCode {
+  const { code } = classifyError(error);
+  Sentry.captureException(error, {
+    tags: {
+      'warden.trigger.name': context.triggerName,
+      'gen_ai.agent.name': context.skillName,
+      'warden.error.code': code,
+    },
+    ...(shouldFingerprintTriggerError(code) ? { fingerprint: ['warden', code] } : {}),
+  });
+  return code;
+}

--- a/src/action/triggers/executor.test.ts
+++ b/src/action/triggers/executor.test.ts
@@ -5,6 +5,26 @@ import type { ResolvedTrigger } from '../../config/loader.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import type { RenderResult } from '../../output/types.js';
 
+const sentryMocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  startSpan: vi.fn((_ctx: unknown, callback: (span: { setAttribute: (key: string, value: unknown) => void }) => unknown) =>
+    callback({ setAttribute: vi.fn() })
+  ),
+}));
+
+vi.mock('../../sentry.js', async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  const actualSentry = actual['Sentry'] as Record<string, unknown>;
+  return {
+    ...actual,
+    Sentry: {
+      ...actualSentry,
+      captureException: sentryMocks.captureException,
+      startSpan: sentryMocks.startSpan,
+    },
+  };
+});
+
 // Mock dependencies
 vi.mock('../../skills/loader.js', () => ({
   resolveSkillAsync: vi.fn(),
@@ -32,6 +52,7 @@ import { runSkillTask } from '../../cli/output/tasks.js';
 import { createSkillCheck, updateSkillCheck, failSkillCheck } from '../../output/github-checks.js';
 import { renderSkillReport } from '../../output/renderer.js';
 import { resolveSkillAsync } from '../../skills/loader.js';
+import { InvalidPiModelSelectorError } from '../../sdk/runtimes/model-selectors.js';
 
 describe('executeTrigger', () => {
   // Suppress console output during tests
@@ -243,6 +264,40 @@ const mockContext: EventContext = {
     expect(failSkillCheck).toHaveBeenCalledWith(
       mockOctokit, 123, expect.objectContaining({ message: 'API error' }),
       { owner: 'test-owner', repo: 'test-repo', headSha: 'abc123' }
+    );
+  });
+
+  it('reports invalid Pi model selectors before running the skill', async () => {
+    vi.mocked(createSkillCheck).mockResolvedValue({ checkRunId: 123, url: 'https://github.com/check/123' });
+    vi.mocked(failSkillCheck).mockResolvedValue(undefined);
+
+    const result = await executeTrigger({
+      ...mockTrigger,
+      runtime: 'pi',
+      model: 'claude-sonnet-4-5',
+    }, mockDeps);
+
+    expect(runSkillTask).not.toHaveBeenCalled();
+    expect(result.triggerName).toBe('test-trigger');
+    expect(result.error).toBeInstanceOf(InvalidPiModelSelectorError);
+    expect((result.error as Error).message).toBe(
+      'Pi runtime model for test-trigger must use provider/model format: claude-sonnet-4-5'
+    );
+    expect(failSkillCheck).toHaveBeenCalledWith(
+      mockOctokit, 123, expect.objectContaining({
+        message: 'Pi runtime model for test-trigger must use provider/model format: claude-sonnet-4-5',
+      }),
+      { owner: 'test-owner', repo: 'test-repo', headSha: 'abc123' }
+    );
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(
+      expect.any(InvalidPiModelSelectorError),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          'warden.error.code': 'invalid_model_selector',
+          'warden.trigger.name': 'test-trigger',
+        }),
+        fingerprint: ['warden', 'invalid_model_selector'],
+      })
     );
   });
 

--- a/src/action/triggers/executor.ts
+++ b/src/action/triggers/executor.ts
@@ -24,10 +24,12 @@ import {
 } from '../../output/github-checks.js';
 import { logGroup, logGroupEnd } from '../workflow/base.js';
 import { DEFAULT_FILE_CONCURRENCY } from '../../sdk/types.js';
-import { SkillRunnerError, classifyError } from '../../sdk/errors.js';
+import { SkillRunnerError } from '../../sdk/errors.js';
 import type { Semaphore } from '../../utils/index.js';
 import { Verbosity } from '../../cli/output/verbosity.js';
 import type { ProviderFailureCircuitBreaker } from '../../sdk/circuit-breaker.js';
+import { assertValidPiModelSelectors } from '../../sdk/runtimes/model-selectors.js';
+import { captureActionTriggerError } from '../error-reporting.js';
 
 /** Log-mode output for CI: no TTY, no color. */
 const CI_OUTPUT_MODE: OutputMode = { isTTY: false, supportsColor: false, columns: 120 };
@@ -131,6 +133,8 @@ export async function executeTrigger(
       const skillRoot = trigger.useBuiltinSkill ? undefined : (trigger.skillRoot ?? context.repoPath);
 
       try {
+        assertValidPiModelSelectors([trigger]);
+
         const taskOptions: SkillTaskOptions = {
           name: trigger.name,
           displayName: trigger.skill,
@@ -226,12 +230,9 @@ export async function executeTrigger(
         };
       } catch (error) {
         if (error instanceof ActionFailedError) throw error;
-        const { code } = classifyError(error);
-        Sentry.captureException(error, {
-          tags: { 'warden.trigger.name': trigger.name, 'gen_ai.agent.name': trigger.skill },
-          ...(code === 'provider_unavailable' || code === 'all_hunks_failed'
-            ? { fingerprint: ['warden', code] }
-            : {}),
+        captureActionTriggerError(error, {
+          triggerName: trigger.name,
+          skillName: trigger.skill,
         });
 
         // Mark skill check as failed

--- a/src/action/workflow/__fixtures__/layered-auxiliary-model/.warden-org/warden.toml
+++ b/src/action/workflow/__fixtures__/layered-auxiliary-model/.warden-org/warden.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [defaults.auxiliary]
-model = "org-aux-model"
+model = "anthropic/org-aux-model"
 maxRetries = 7
 
 [[skills]]

--- a/src/action/workflow/__fixtures__/layered-auxiliary-model/warden.toml
+++ b/src/action/workflow/__fixtures__/layered-auxiliary-model/warden.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [defaults.auxiliary]
-model = "repo-aux-model"
+model = "anthropic/repo-aux-model"
 maxRetries = 2
 
 [[skills]]

--- a/src/action/workflow/__fixtures__/schedule/.warden-org/warden.toml
+++ b/src/action/workflow/__fixtures__/schedule/.warden-org/warden.toml
@@ -4,7 +4,7 @@ version = 1
 auxiliaryMaxRetries = 7
 
 [defaults.synthesis]
-model = "org-synth-model"
+model = "anthropic/org-synth-model"
 
 [[skills]]
 name = "org-skill"

--- a/src/action/workflow/__fixtures__/schedule/warden.toml
+++ b/src/action/workflow/__fixtures__/schedule/warden.toml
@@ -4,7 +4,7 @@ version = 1
 auxiliaryMaxRetries = 3
 
 [defaults.synthesis]
-model = "repo-synth-model"
+model = "anthropic/repo-synth-model"
 
 [[skills]]
 name = "test-skill"

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -846,7 +846,7 @@ describe('runPRWorkflow', () => {
         'test-api-key',
         expect.objectContaining({
           runtime: 'pi',
-          model: 'org-aux-model',
+          model: 'anthropic/org-aux-model',
           maxRetries: 7,
         })
       );

--- a/src/action/workflow/schedule.test.ts
+++ b/src/action/workflow/schedule.test.ts
@@ -325,12 +325,12 @@ describe('runScheduleWorkflow', () => {
       expect(mockRunSkill).toHaveBeenNthCalledWith(1,
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ synthesisModel: 'org-synth-model' })
+        expect.objectContaining({ synthesisModel: 'anthropic/org-synth-model' })
       );
       expect(mockRunSkill).toHaveBeenNthCalledWith(2,
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ synthesisModel: 'repo-synth-model' })
+        expect.objectContaining({ synthesisModel: 'anthropic/repo-synth-model' })
       );
     });
 

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -15,6 +15,7 @@ import type { LayeredSkillRootsByName, ResolvedTrigger } from '../../config/load
 import type { ScheduleConfig } from '../../config/schema.js';
 import { buildScheduleEventContext } from '../../event/schedule-context.js';
 import { runSkill } from '../../sdk/runner.js';
+import { assertValidPiModelSelectors } from '../../sdk/runtimes/model-selectors.js';
 import { createOrUpdateIssue, createFixPR } from '../../output/github-issues.js';
 import { shouldFail, countFindingsAtOrAbove, countSeverity } from '../../triggers/matcher.js';
 import { resolveSkillAsync } from '../../skills/loader.js';
@@ -34,6 +35,7 @@ import {
   getDefaultBranchFromAPI,
   writeFindingsOutput,
 } from './base.js';
+import { captureActionTriggerError } from '../error-reporting.js';
 
 // -----------------------------------------------------------------------------
 // Main Schedule Workflow
@@ -172,6 +174,8 @@ async function runScheduleWorkflowInner(
     logGroup(`Running trigger: ${resolved.name} (skill: ${resolved.skill})`);
 
     try {
+      assertValidPiModelSelectors([resolved]);
+
       // Build context from paths filter
       const patterns = resolved.filters?.paths ?? ['**/*'];
       const ignorePatterns = resolved.filters?.ignorePaths;
@@ -268,6 +272,10 @@ async function runScheduleWorkflowInner(
       logGroupEnd();
     } catch (error) {
       if (error instanceof ActionFailedError) throw error;
+      captureActionTriggerError(error, {
+        triggerName: resolved.name,
+        skillName: resolved.skill,
+      });
       const errorMessage = error instanceof Error ? error.message : String(error);
       triggerErrors.push(`${resolved.name}: ${errorMessage}`);
       console.error(`::warning::Trigger ${resolved.name} failed: ${error}`);

--- a/src/cli/auth-flow.test.ts
+++ b/src/cli/auth-flow.test.ts
@@ -108,7 +108,7 @@ describe('runSkills auth flow', () => {
     expect(exitCode).toBe(1);
     expect(stdoutSpy).toHaveBeenCalled();
     expect(summary.error).toMatchObject({
-      code: 'unknown',
+      code: 'invalid_model_selector',
       message: 'Pi runtime model for security-review must use provider/model format: claude-sonnet-4-5',
     });
     expect(verifyAuthMock).not.toHaveBeenCalled();

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -30,7 +30,11 @@ import {
   buildGeneratedSkill,
 } from '../../skill-builder/skill.js';
 import { getRuntime } from '../../sdk/runtimes/index.js';
-import { isPiModelSelector } from '../../sdk/runtimes/model-selectors.js';
+import {
+  findInvalidPiModelSelector,
+  invalidPiModelSelectorMessage,
+  type InvalidPiModelSelector,
+} from '../../sdk/runtimes/model-selectors.js';
 
 function renderHeader(args: {
   reporter: Reporter;
@@ -166,8 +170,8 @@ function resolveSynthesisModel(
 
 type GeneratedSkillCommandMode = 'build' | 'improve';
 
-function reportInvalidPiModelSelector(reporter: Reporter, label: string, model: string): void {
-  reporter.error(`Pi runtime ${label} must use provider/model format: ${model}`);
+function reportInvalidPiModelSelector(reporter: Reporter, invalid: InvalidPiModelSelector): void {
+  reporter.error(invalidPiModelSelectorMessage(invalid));
   reporter.tip('Set a Pi model selector such as anthropic/claude-sonnet-4-6.');
 }
 
@@ -329,15 +333,14 @@ async function runGeneratedSkillCommand(
     const model = resolveSynthesisModel(config, options);
     const repairModel = emptyToUndefined(config?.defaults?.auxiliary?.model);
     const maxRetries = config?.defaults?.auxiliary?.maxRetries ?? config?.defaults?.auxiliaryMaxRetries;
-    if (runtimeName === 'pi') {
-      if (model && !isPiModelSelector(model)) {
-        reportInvalidPiModelSelector(reporter, 'model', model);
-        return 1;
-      }
-      if (repairModel && !isPiModelSelector(repairModel)) {
-        reportInvalidPiModelSelector(reporter, 'repair model', repairModel);
-        return 1;
-      }
+    const invalidModelSelector = findInvalidPiModelSelector([{
+      runtime: runtimeName,
+      model,
+      auxiliaryModel: repairModel,
+    }]);
+    if (invalidModelSelector) {
+      reportInvalidPiModelSelector(reporter, invalidModelSelector);
+      return 1;
     }
     const runtime = getRuntime(runtimeName);
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,7 +5,11 @@ import { Sentry, flushSentry, setRepositoryScope, emitRunMetric, getTraceId } fr
 import { emptyToUndefined, loadWardenConfig, resolveSkillConfigs } from '../config/loader.js';
 import type { SkillDefinition, WardenConfig } from '../config/schema.js';
 import { verifyAuth, type WardenAuthenticationError, type SkillRunnerOptions, type ChunkAnalysisResult } from '../sdk/runner.js';
-import { isPiModelSelector } from '../sdk/runtimes/model-selectors.js';
+import {
+  findInvalidPiModelSelector as findInvalidPiModelSelectorTarget,
+  invalidPiModelSelectorMessage,
+  type InvalidPiModelSelector,
+} from '../sdk/runtimes/model-selectors.js';
 import { mapExtractionErrorCode } from '../sdk/errors.js';
 import { mergeAuxiliaryUsage } from '../sdk/usage.js';
 import { resolveSkillAsync, SkillLoaderError } from '../skills/loader.js';
@@ -583,42 +587,23 @@ function needsClaudeAuth(items: { runtime?: SkillRunnerOptions['runtime'] }[]): 
   return items.some((item) => (item.runtime ?? 'pi') === 'claude');
 }
 
-interface InvalidPiModelSelector {
-  specName: string;
-  option: 'model' | 'auxiliaryModel' | 'synthesisModel';
-  model: string;
-}
-
 /**
  * Find the first Pi runner option using a model ID that is not provider/model.
  */
 export function findInvalidPiModelSelector(
   specs: Pick<RunSkillSpec, 'name' | 'runnerOptions'>[]
 ): InvalidPiModelSelector | undefined {
-  for (const spec of specs) {
-    const runtimeName = spec.runnerOptions.runtime ?? 'pi';
-    if (runtimeName !== 'pi') {
-      continue;
-    }
-
-    for (const option of ['model', 'auxiliaryModel', 'synthesisModel'] as const) {
-      const model = spec.runnerOptions[option];
-      if (model && !isPiModelSelector(model)) {
-        return { specName: spec.name, option, model };
-      }
-    }
-  }
-
-  return undefined;
+  return findInvalidPiModelSelectorTarget(
+    specs.map((spec) => ({
+      name: spec.name,
+      ...spec.runnerOptions,
+    }))
+  );
 }
 
 function reportInvalidPiModelSelector(reporter: Reporter, invalid: InvalidPiModelSelector): void {
   reporter.error(invalidPiModelSelectorMessage(invalid));
   reporter.tip('Set a Pi model selector such as anthropic/claude-sonnet-4-6.');
-}
-
-function invalidPiModelSelectorMessage(invalid: InvalidPiModelSelector): string {
-  return `Pi runtime ${invalid.option} for ${invalid.specName} must use provider/model format: ${invalid.model}`;
 }
 
 function emitInvalidPiModelSelectorRunLog(
@@ -627,7 +612,7 @@ function emitInvalidPiModelSelectorRunLog(
   invalid: InvalidPiModelSelector
 ): void {
   emitEmptyRunLog(repoPath, options, {
-    code: 'unknown',
+    code: 'invalid_model_selector',
     message: invalidPiModelSelectorMessage(invalid),
     timestamp: new Date().toISOString(),
   });

--- a/src/cli/output/tasks.test.ts
+++ b/src/cli/output/tasks.test.ts
@@ -953,6 +953,52 @@ describe('runSkillTask all-hunks-fail synthesis', () => {
     expect((result.error as SkillRunnerError).code).toBe('provider_unavailable');
   });
 
+  it('preserves invalid_model_selector when every hunk fails from Pi model validation', async () => {
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+    const hunkFailures: HunkFailure[] = [
+      {
+        type: 'analysis',
+        filename: 'a.ts',
+        lineRange: '1-10',
+        code: 'invalid_model_selector',
+        message: 'Pi runtime model must use provider/model format: claude-sonnet-4-5',
+      },
+    ];
+
+    vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [],
+      usage: { inputTokens: 0, outputTokens: 0, costUSD: 0 },
+      failedHunks: 1,
+      failedExtractions: 0,
+      hunkFailures,
+    });
+
+    const options: SkillTaskOptions = {
+      name: 'invalid-model-skill',
+      resolveSkill: async () =>
+        ({ name: 'invalid-model-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+    };
+
+    const result = await runSkillTask(options, 1, noopCallbacks());
+
+    expect(result.report!.error?.code).toBe('invalid_model_selector');
+    expect(result.report!.error?.message).toContain('provider/model format');
+    expect((result.error as SkillRunnerError).code).toBe('invalid_model_selector');
+  });
+
   it('ignores unrelated circuit state when this skill completed without failures', async () => {
     const fakeHunk = {
       hunk: { newStart: 1, newCount: 10 },

--- a/src/cli/output/tasks.ts
+++ b/src/cli/output/tasks.ts
@@ -59,6 +59,10 @@ function allAnalysisFailuresHaveCode(
   );
 }
 
+function firstAnalysisFailureMessage(hunkFailures: HunkFailure[], code: ErrorCode): string | undefined {
+  return hunkFailures.find((failure) => failure.type === 'analysis' && failure.code === code)?.message;
+}
+
 function summarizeRunFailure(args: {
   totalHunks: number;
   hunkFailures: HunkFailure[];
@@ -73,6 +77,12 @@ function summarizeRunFailure(args: {
     return {
       code: 'auth_failed',
       message: 'Authentication failed. Warden stopped early.',
+    };
+  }
+  if (allAnalysisFailuresHaveCode(hunkFailures, 'invalid_model_selector')) {
+    return {
+      code: 'invalid_model_selector',
+      message: firstAnalysisFailureMessage(hunkFailures, 'invalid_model_selector') ?? 'Invalid Pi model selector.',
     };
   }
   if (allAnalysisFailuresHaveCode(hunkFailures, 'provider_unavailable')) {

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -60,7 +60,7 @@ function isAbortRequested(error: unknown, abortController?: AbortController): bo
 }
 
 function isCircuitBreakerCode(code: ErrorCode | undefined): code is CircuitBreakerReason['code'] {
-  return code === 'auth_failed' || code === 'provider_unavailable';
+  return code === 'auth_failed' || code === 'provider_unavailable' || code === 'invalid_model_selector';
 }
 
 function hunkFailureFromCircuit(
@@ -889,6 +889,15 @@ async function runSkillAnalysis(
   }
   if (totalAttemptFailures > 0 && totalAttemptFailures === totalHunks && allFindings.length === 0) {
     const analysisFailures = allHunkFailures.filter((failure) => failure.type === 'analysis');
+    if (
+      analysisFailures.length > 0
+      && analysisFailures.every((failure) => failure.code === 'invalid_model_selector')
+    ) {
+      throw new SkillRunnerError(
+        analysisFailures[0]?.message ?? 'Invalid Pi model selector.',
+        { code: 'invalid_model_selector' },
+      );
+    }
     if (
       analysisFailures.length > 0
       && analysisFailures.every((failure) => failure.code === 'provider_unavailable')

--- a/src/sdk/circuit-breaker.test.ts
+++ b/src/sdk/circuit-breaker.test.ts
@@ -12,6 +12,16 @@ describe('ProviderFailureCircuitBreaker', () => {
     expect(controller.signal.aborted).toBe(true);
   });
 
+  it('opens immediately on invalid model selectors', () => {
+    const controller = new AbortController();
+    const breaker = new ProviderFailureCircuitBreaker({ abortController: controller });
+
+    breaker.recordFailure('invalid_model_selector', 'bad model');
+
+    expect(breaker.reason).toEqual({ code: 'invalid_model_selector', message: 'bad model' });
+    expect(controller.signal.aborted).toBe(true);
+  });
+
   it('opens after consecutive provider failures and resets on success', () => {
     const controller = new AbortController();
     const breaker = new ProviderFailureCircuitBreaker({

--- a/src/sdk/circuit-breaker.ts
+++ b/src/sdk/circuit-breaker.ts
@@ -3,7 +3,7 @@ import { sanitizeErrorMessage } from './errors.js';
 
 const DEFAULT_MAX_CONSECUTIVE_PROVIDER_FAILURES = 5;
 
-type CircuitBreakerCode = Extract<ErrorCode, 'auth_failed' | 'provider_unavailable'>;
+type CircuitBreakerCode = Extract<ErrorCode, 'auth_failed' | 'provider_unavailable' | 'invalid_model_selector'>;
 
 export interface CircuitBreakerReason {
   code: CircuitBreakerCode;
@@ -48,7 +48,7 @@ export class ProviderFailureCircuitBreaker {
   recordFailure(code: ErrorCode, message: string): void {
     if (this.openReason) return;
 
-    if (code === 'auth_failed') {
+    if (code === 'auth_failed' || code === 'invalid_model_selector') {
       this.open({ code, message });
       return;
     }

--- a/src/sdk/errors.test.ts
+++ b/src/sdk/errors.test.ts
@@ -8,6 +8,7 @@ import {
   SkillRunnerError,
   WardenAuthenticationError,
 } from './errors.js';
+import { InvalidPiModelSelectorError } from './runtimes/model-selectors.js';
 
 describe('isSubprocessError', () => {
   it('detects EPIPE errors', () => {
@@ -82,6 +83,14 @@ describe('classifyError', () => {
   it('respects SkillRunnerError.code when set', () => {
     const err = new SkillRunnerError('all chunks failed', { code: 'all_hunks_failed' });
     expect(classifyError(err)).toEqual({ code: 'all_hunks_failed', message: 'all chunks failed' });
+  });
+
+  it('maps invalid Pi model selectors to invalid_model_selector', () => {
+    const err = new InvalidPiModelSelectorError({ option: 'model', model: 'claude-sonnet-4-5' });
+    expect(classifyError(err)).toEqual({
+      code: 'invalid_model_selector',
+      message: 'Pi runtime model must use provider/model format: claude-sonnet-4-5',
+    });
   });
 
   it('tags subprocess errors as subprocess_failure', () => {

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -6,6 +6,7 @@ import {
   APIConnectionTimeoutError,
 } from '@anthropic-ai/sdk';
 import type { ErrorCode } from '../types/index.js';
+import { InvalidPiModelSelectorError } from './runtimes/model-selectors.js';
 
 export class SkillRunnerError extends Error {
   /** Optional classification so callers skip message-sniffing. */
@@ -151,6 +152,9 @@ export function classifyError(error: unknown): { code: ErrorCode; message: strin
   }
   if (error instanceof SkillRunnerError && error.code) {
     return { code: error.code, message };
+  }
+  if (error instanceof InvalidPiModelSelectorError) {
+    return { code: 'invalid_model_selector', message };
   }
   if (isSubprocessError(error)) {
     return { code: 'subprocess_failure', message };

--- a/src/sdk/runtimes/model-selectors.ts
+++ b/src/sdk/runtimes/model-selectors.ts
@@ -9,3 +9,73 @@ export function isPiModelSelector(model: string): boolean {
     model.indexOf('/', slashIndex + 1) === -1
   );
 }
+
+export type PiModelSelectorOption = 'model' | 'auxiliaryModel' | 'synthesisModel';
+
+export interface PiModelSelectorTarget {
+  name?: string;
+  runtime?: string;
+  model?: string;
+  auxiliaryModel?: string;
+  synthesisModel?: string;
+}
+
+export interface InvalidPiModelSelector {
+  specName?: string;
+  option: PiModelSelectorOption;
+  model: string;
+}
+
+/**
+ * Format the user-facing error for an invalid Pi model selector.
+ */
+export function invalidPiModelSelectorMessage(invalid: InvalidPiModelSelector): string {
+  const target = invalid.specName ? ` for ${invalid.specName}` : '';
+  return `Pi runtime ${invalid.option}${target} must use provider/model format: ${invalid.model}`;
+}
+
+/**
+ * Preserve invalid Pi selector details through shared error classification.
+ */
+export class InvalidPiModelSelectorError extends Error {
+  invalid: InvalidPiModelSelector;
+
+  constructor(invalid: InvalidPiModelSelector) {
+    super(invalidPiModelSelectorMessage(invalid));
+    this.name = 'InvalidPiModelSelectorError';
+    this.invalid = invalid;
+  }
+}
+
+/**
+ * Find the first Pi runner option using a model ID that is not provider/model.
+ */
+export function findInvalidPiModelSelector(
+  targets: PiModelSelectorTarget[]
+): InvalidPiModelSelector | undefined {
+  for (const target of targets) {
+    const runtimeName = target.runtime ?? 'pi';
+    if (runtimeName !== 'pi') {
+      continue;
+    }
+
+    for (const option of ['model', 'auxiliaryModel', 'synthesisModel'] as const) {
+      const model = target[option];
+      if (model && !isPiModelSelector(model)) {
+        return { specName: target.name, option, model };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Throw when any Pi runner option is not a provider/model selector.
+ */
+export function assertValidPiModelSelectors(targets: PiModelSelectorTarget[]): void {
+  const invalid = findInvalidPiModelSelector(targets);
+  if (invalid) {
+    throw new InvalidPiModelSelectorError(invalid);
+  }
+}

--- a/src/sdk/runtimes/pi.test.ts
+++ b/src/sdk/runtimes/pi.test.ts
@@ -312,7 +312,7 @@ describe('piRuntime.runSkill', () => {
       options: {
         model: 'gpt-test',
       },
-    })).rejects.toThrow('Pi model selector must be provider/model');
+    })).rejects.toThrow('Pi runtime model must use provider/model format');
 
     expect(piMocks.registry.find).not.toHaveBeenCalled();
   });

--- a/src/sdk/runtimes/pi.ts
+++ b/src/sdk/runtimes/pi.ts
@@ -43,7 +43,7 @@ import {
   setGenAiUsageAttrs,
 } from '../otel.js';
 import { aggregateUsage, emptyUsage } from '../usage.js';
-import { isPiModelSelector } from './model-selectors.js';
+import { InvalidPiModelSelectorError, isPiModelSelector } from './model-selectors.js';
 import type {
   AuxiliaryRunRequest,
   AuxiliaryRunResult,
@@ -106,9 +106,7 @@ function errorMessage(error: unknown): string {
 
 function parseModelSelector(model: string): PiModelSelector {
   if (!isPiModelSelector(model)) {
-    throw new Error(
-      `Pi model selector must be provider/model: ${model}. For example openai/gpt-5.5.`
-    );
+    throw new InvalidPiModelSelectorError({ option: 'model', model });
   }
   const slashIndex = model.indexOf('/');
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -207,6 +207,7 @@ export const ErrorCodeSchema = z.enum([
   'max_turns',
   'aborted',
   'all_hunks_failed',
+  'invalid_model_selector',
   'skill_resolution_failed',
   'extraction_invalid_json',
   'extraction_unbalanced_json',


### PR DESCRIPTION
Share Pi model selector validation between the CLI and GitHub Action paths.

The Action path could previously let an invalid Pi model selector, such as a bare WARDEN_MODEL value, reach runtime execution. That collapsed the failure into a generic all-hunks-failed path and made the captured Sentry event less useful. This moves selector validation into a shared helper and runs it before Action skill execution.

Action trigger failures now use a shared capture helper so PR and schedule workflows tag and fingerprint Sentry events consistently. Invalid selectors preserve a dedicated invalid_model_selector error code in runtime classification, JSONL output, and Action telemetry.

The schema and reporter spec were updated to document the new public error code. The fixture model names in Action tests now use provider/model selectors so they reflect the Pi runtime contract.