### PR TITLE
fix(action): Preload Pi node-only providers

### DIFF
--- a/src/action/pi-ncc-compat.test.ts
+++ b/src/action/pi-ncc-compat.test.ts
@@ -12,11 +12,33 @@ describe('preloadPiRuntimeForActionBundle', () => {
   it('ignores ncc dynamic-import failures for Pi Node built-ins', async () => {
     const unhandledRejections = new EventEmitter();
 
-    await expect(preloadPiRuntimeForActionBundle(async () => {
-      unhandledRejections.emit('unhandledRejection', nccBuiltinError('node:os'));
-    }, unhandledRejections)).resolves.toBeUndefined();
+    await expect(preloadPiRuntimeForActionBundle(
+      async () => {
+        unhandledRejections.emit('unhandledRejection', nccBuiltinError('node:os'));
+      },
+      unhandledRejections,
+      async () => {
+        unhandledRejections.emit('unhandledRejection', nccBuiltinError('node:os'));
+      }
+    )).resolves.toBeUndefined();
 
     expect(unhandledRejections.listenerCount('unhandledRejection')).toBe(0);
+  });
+
+  it('preloads ncc-sensitive providers after preloading Pi', async () => {
+    const calls: string[] = [];
+
+    await preloadPiRuntimeForActionBundle(
+      async () => {
+        calls.push('runtime');
+      },
+      new EventEmitter(),
+      async () => {
+        calls.push('providers');
+      }
+    );
+
+    expect(calls).toEqual(['runtime', 'providers']);
   });
 
   it('keeps unexpected unhandled rejections fatal', async () => {
@@ -24,7 +46,7 @@ describe('preloadPiRuntimeForActionBundle', () => {
 
     await expect(preloadPiRuntimeForActionBundle(async () => {
       unhandledRejections.emit('unhandledRejection', new Error('real failure'));
-    }, unhandledRejections)).rejects.toThrow('real failure');
+    }, unhandledRejections, async () => undefined)).rejects.toThrow('real failure');
 
     expect(unhandledRejections.listenerCount('unhandledRejection')).toBe(0);
   });

--- a/src/action/pi-ncc-compat.ts
+++ b/src/action/pi-ncc-compat.ts
@@ -1,6 +1,8 @@
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 
 type UnhandledRejectionListener = (reason: unknown) => void;
+type PiRuntimeImporter = () => Promise<unknown>;
+type PiProviderPreloader = () => Promise<void>;
 
 interface UnhandledRejectionTarget {
   prependListener(eventName: 'unhandledRejection', listener: UnhandledRejectionListener): unknown;
@@ -22,13 +24,24 @@ function isNccPiBuiltinImportFailure(reason: unknown): boolean {
   );
 }
 
+async function preloadPiProviderModulesForActionBundle(): Promise<void> {
+  const [{ setBedrockProviderModule }, { bedrockProviderModule }] = await Promise.all([
+    import('@earendil-works/pi-ai'),
+    import('@earendil-works/pi-ai/bedrock-provider'),
+    import('@earendil-works/pi-ai/openai-codex-responses'),
+  ]);
+
+  setBedrockProviderModule(bedrockProviderModule);
+}
+
 /**
  * Preload Pi before action initialization so ncc's dynamic-import rewrite for
- * Pi's env-key helper cannot terminate the bundled GitHub Action.
+ * Pi's env-key helper and node-only providers cannot terminate the bundled GitHub Action.
  */
 export async function preloadPiRuntimeForActionBundle(
-  importPiRuntime: () => Promise<unknown> = () => import('../sdk/runtimes/pi.js'),
+  importPiRuntime: PiRuntimeImporter = () => import('../sdk/runtimes/pi.js'),
   unhandledRejections: UnhandledRejectionTarget = process,
+  preloadProviders: PiProviderPreloader = preloadPiProviderModulesForActionBundle,
 ): Promise<void> {
   let unexpectedRejection: unknown;
   const onUnhandledRejection = (reason: unknown) => {
@@ -41,6 +54,7 @@ export async function preloadPiRuntimeForActionBundle(
   unhandledRejections.prependListener('unhandledRejection', onUnhandledRejection);
   try {
     await importPiRuntime();
+    await preloadProviders();
     // ncc emits the synthetic missing-builtin rejections after Pi module
     // evaluation, so drain two turns before removing the temporary listener.
     await waitForImmediate();


### PR DESCRIPTION
Preload Pi provider modules during GitHub Action startup so ncc-bundled action runs do not hit Pi non-literal node-only import paths during analysis.

**Action Bundle Compatibility**

The action now registers Pi Bedrock through the exported provider module and loads the Codex provider while the temporary ncc missing-builtin rejection guard is active. This mirrors Pi's own bundled entrypoint pattern and keeps lazy provider setup out of the later analysis path.

**Validation**

Local validation passed for lint, typecheck, the focused compatibility test, package build, action bundle build, and a preload smoke test. A full local pnpm test run still fails in src/cli/files.test.ts because fast-glob hits EACCES while scanning /tmp/snap-private-tmp, unrelated to this action change.

Fixes #322