### PR TITLE
ref(evals): Centralize fixture provenance

### DIFF
--- a/evals/INTERNAL.md
+++ b/evals/INTERNAL.md
@@ -29,7 +29,9 @@ summary for per-case test reporting, and gates the workflow on the aggregate
 - `evals/code-review/*.json`: one full-pipeline code-review scenario per file.
 - `evals/security-review/*.json`: one full-pipeline security-review scenario per file.
 - `evals/verification/*.json`: one candidate finding sent directly to `verifyFindings`.
-- `evals/fixtures/*`: checked-in fixture source code. Eval runs copy these files into temporary git repos under the OS temp directory.
+- `evals/fixtures/*`: checked-in fixture source code. Eval runs copy these files
+  into temporary git repos under the OS temp directory, preserving paths under
+  `evals/fixtures/`.
 - `src/evals/e2e.eval.ts`: generic YAML full-pipeline suites.
 - `src/evals/code-review.eval.ts`: code-review correctness benchmark scenarios.
 - `src/evals/security-review.eval.ts`: security-review benchmark scenarios.
@@ -43,6 +45,10 @@ real skill under test.
 
 1. Add or scaffold a scenario JSON file under `evals/<category>/`.
 2. Add focused, checked-in fixture files under `evals/fixtures/<scenario>/`.
+   GitHub scaffolds use
+   `evals/fixtures/<scenario>/github/<owner>/<repo>/<repo-relative-path>` to
+   preserve source context while eval output uses `<scenario>/<repo-relative-path>`.
+   Scaffolded source repositories are still passed to prompts as repository context.
 3. Write a specific `should_find` assertion and useful `should_not_find` guards.
 4. Run the narrow case first with `pnpm evals -t <scenario>`.
 5. Run the suite with `pnpm evals -t <category>`.

--- a/evals/README.md
+++ b/evals/README.md
@@ -251,6 +251,17 @@ The scaffold writes a `TODO` `should_find` assertion. That stub is expected to
 fail until you replace it with the exact expected finding, and it should not be
 committed as-is.
 
+Scaffolded GitHub fixtures include source context in their paths:
+`evals/fixtures/<scenario>/github/<owner>/<repo>/<repo-relative-path>`.
+Eval runs copy them into the temp repo as `<scenario>/<repo-relative-path>` so
+test output stays focused on the case and original source file. The source
+repository is still included in prompt context and `notes.repository`.
+Hand-written fixtures can stay shorter when the source repository path is not
+useful.
+
+When a scaffold skips files, it records them in `notes.skipped_files` and prints
+them in CLI output. Review that list before committing the eval.
+
 ### Guidelines
 
 - **One bug per eval.** Each scenario tests one specific behavior.
@@ -266,8 +277,9 @@ committed as-is.
 
 1. **Discovery**: Scan `evals/` for YAML suites and JSON scenario directories
 2. **Loading**: Parse YAML/JSON, validate with Zod, resolve paths
-3. **Git repo**: Copy checked-in fixtures into a temp repo and commit them on
-   an `eval` branch (empty `main` as base), so the agent has a real repo to explore
+3. **Git repo**: Copy checked-in fixtures into a temp repo, preserving paths
+   under `evals/fixtures/`, and commit them on an `eval` branch (empty `main`
+   as base), so the agent has a real repo to explore
 4. **Context**: Build `EventContext` from real `git diff main...eval`
 5. **Execution**: Run the skill via `runSkill()` with the real SDK pipeline;
    the agent operates in the temp repo with Read/Grep tools

--- a/scripts/scaffold-eval.ts
+++ b/scripts/scaffold-eval.ts
@@ -85,5 +85,11 @@ console.log('Fixtures:');
 for (const file of result.files) {
   console.log(`  ${file.fixturePath} <- ${file.sourcePath}@${file.ref}`);
 }
+if (result.skippedFiles.length > 0) {
+  console.log('Skipped:');
+  for (const file of result.skippedFiles) {
+    console.log(`  ${file.sourcePath} (${file.reason})`);
+  }
+}
 console.log('');
 console.log('Next: replace the TODO should_find entry with the exact expected finding.');

--- a/src/evals/fixtures.test.ts
+++ b/src/evals/fixtures.test.ts
@@ -1,0 +1,50 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildGitHubEvalFixturePath,
+  evalFixtureRepoPath,
+  evalFixtureSourceRepository,
+  safeEvalFixturePathSegment,
+  singleEvalFixtureSourceRepository,
+} from './fixtures.js';
+
+describe('eval fixture paths', () => {
+  it('builds GitHub storage paths and clean temp repo paths', () => {
+    const storagePath = join(
+      '/tmp/work',
+      'evals',
+      'fixtures',
+      'source-context',
+      buildGitHubEvalFixturePath({
+        owner: 'getsentry',
+        repo: 'sentry',
+        sourcePath: 'src/sentry/api/endpoint.py',
+      }),
+    );
+
+    expect(storagePath).toContain('source-context/github/getsentry/sentry/src/sentry/api/endpoint.py');
+    expect(evalFixtureRepoPath(storagePath)).toBe('source-context/src/sentry/api/endpoint.py');
+    expect(evalFixtureSourceRepository(storagePath)).toBe('getsentry/sentry');
+  });
+
+  it('leaves hand-written fixture paths unchanged', () => {
+    const fixturePath = join('/tmp/work', 'evals', 'fixtures', 'scenario', 'handler.ts');
+
+    expect(evalFixtureRepoPath(fixturePath)).toBe('scenario/handler.ts');
+    expect(evalFixtureSourceRepository(fixturePath)).toBeUndefined();
+  });
+
+  it('returns one source repository only when all encoded fixtures agree', () => {
+    const first = join('/tmp/work', 'evals', 'fixtures', 'case', 'github', 'getsentry', 'sentry', 'a.py');
+    const second = join('/tmp/work', 'evals', 'fixtures', 'case', 'github', 'getsentry', 'sentry', 'b.py');
+    const third = join('/tmp/work', 'evals', 'fixtures', 'case', 'github', 'getsentry', 'warden', 'c.ts');
+
+    expect(singleEvalFixtureSourceRepository([first, second])).toBe('getsentry/sentry');
+    expect(singleEvalFixtureSourceRepository([first, third])).toBeUndefined();
+  });
+
+  it('sanitizes unsafe path segments', () => {
+    expect(safeEvalFixturePathSegment('sentry app')).toBe('sentry_app');
+    expect(safeEvalFixturePathSegment('..')).toBe('path');
+  });
+});

--- a/src/evals/fixtures.ts
+++ b/src/evals/fixtures.ts
@@ -1,0 +1,97 @@
+import { basename, dirname, posix } from 'node:path';
+
+const GITHUB_FIXTURE_SOURCE = 'github';
+const UNSAFE_FIXTURE_PATH_CHARS = /[^a-zA-Z0-9._-]+/g;
+
+interface GitHubFixturePathOptions {
+  owner: string;
+  repo: string;
+  sourcePath: string;
+}
+
+function fixtureStorageSegments(srcPath: string): string[] | undefined {
+  const segments = srcPath.replaceAll('\\', '/').split('/').filter(Boolean);
+
+  for (let index = 0; index < segments.length - 1; index++) {
+    if (segments[index] === 'evals' && segments[index + 1] === 'fixtures') {
+      return segments.slice(index + 2);
+    }
+  }
+
+  const fixturesIndex = segments.indexOf('fixtures');
+  if (fixturesIndex !== -1 && fixturesIndex < segments.length - 1) {
+    return segments.slice(fixturesIndex + 1);
+  }
+
+  return undefined;
+}
+
+function fixtureRepoPathSegments(srcPath: string): string[] {
+  const fixtureSegments = fixtureStorageSegments(srcPath);
+  if (!fixtureSegments) {
+    return [basename(dirname(srcPath)), basename(srcPath)].filter(Boolean);
+  }
+
+  const [scenario, source, owner, repo, ...sourcePath] = fixtureSegments;
+  if (scenario && source === GITHUB_FIXTURE_SOURCE && owner && repo && sourcePath.length > 0) {
+    return [scenario, ...sourcePath];
+  }
+  return fixtureSegments;
+}
+
+/** Convert an arbitrary source path segment into a stable eval fixture segment. */
+export function safeEvalFixturePathSegment(value: string): string {
+  const candidate = value
+    .replace(UNSAFE_FIXTURE_PATH_CHARS, '_')
+    .replace(/^_+|_+$/g, '');
+
+  if (!candidate || candidate === '.' || candidate === '..') {
+    return 'path';
+  }
+  return candidate;
+}
+
+/** Build the checked-in fixture path suffix for a GitHub source file. */
+export function buildGitHubEvalFixturePath(options: GitHubFixturePathOptions): string {
+  const sourceSegments = options.sourcePath
+    .split('/')
+    .filter(Boolean)
+    .map(safeEvalFixturePathSegment);
+
+  return posix.join(
+    GITHUB_FIXTURE_SOURCE,
+    safeEvalFixturePathSegment(options.owner),
+    safeEvalFixturePathSegment(options.repo),
+    ...sourceSegments,
+  );
+}
+
+/** Return the source repository encoded in a scaffolded eval fixture path, when present. */
+export function evalFixtureSourceRepository(srcPath: string): string | undefined {
+  const fixtureSegments = fixtureStorageSegments(srcPath);
+  if (!fixtureSegments) {
+    return undefined;
+  }
+
+  const [, source, owner, repo, ...sourcePath] = fixtureSegments;
+  if (source === GITHUB_FIXTURE_SOURCE && owner && repo && sourcePath.length > 0) {
+    return `${owner}/${repo}`;
+  }
+
+  return undefined;
+}
+
+/** Return the repo-relative path used when copying an eval fixture into a temp repo. */
+export function evalFixtureRepoPath(srcPath: string): string {
+  return fixtureRepoPathSegments(srcPath).join('/');
+}
+
+/** Return a single encoded source repository when all fixture paths agree. */
+export function singleEvalFixtureSourceRepository(filePaths: string[]): string | undefined {
+  const repositories = new Set(
+    filePaths
+      .map(evalFixtureSourceRepository)
+      .filter((repo): repo is string => Boolean(repo))
+  );
+  return repositories.size === 1 ? [...repositories][0] : undefined;
+}

--- a/src/evals/runner.test.ts
+++ b/src/evals/runner.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { setupEvalRepo } from './runner.js';
 import type { EvalMeta } from './types.js';
@@ -48,6 +49,61 @@ describe('setupEvalRepo', () => {
       expect(existsSync(join(repoDir, '.warden', 'skills', 'security-review', 'SKILL.md'))).toBe(true);
     } finally {
       rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves nested fixture paths from evals/fixtures', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'warden-eval-runner-'));
+    const fixturePath = join(
+      tempRoot,
+      'evals',
+      'fixtures',
+      'source-context',
+      'github',
+      'getsentry',
+      'sentry',
+      'src',
+      'sentry',
+      'api',
+      'endpoint.py',
+    );
+    mkdirSync(dirname(fixturePath), { recursive: true });
+    writeFileSync(fixturePath, 'def endpoint():\n    pass\n');
+
+    const meta: EvalMeta = {
+      name: 'source-context',
+      category: 'security-review',
+      skillName: 'security-review',
+      given: 'fixture source path carries repository context',
+      skillPath: join(repoRoot, 'src', 'builtin-skills', 'security-review', 'SKILL.md'),
+      filePaths: [fixturePath],
+      model: 'anthropic/claude-sonnet-4-6',
+      runtime: 'pi',
+      should_find: [{ finding: 'source path context', required: true }],
+      should_not_find: [],
+    };
+
+    let repoDir: string | undefined;
+    const logs: string[] = [];
+    try {
+      repoDir = setupEvalRepo(meta, (message) => {
+        logs.push(message);
+      });
+      const changedFiles = git(repoDir, ['diff', '--name-only', 'main...eval'])
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+
+      expect(changedFiles).toEqual(['source-context/src/sentry/api/endpoint.py']);
+      expect(git(repoDir, ['config', '--get', 'remote.origin.url']).trim())
+        .toBe('https://github.com/getsentry/sentry.git');
+      expect(existsSync(join(repoDir, 'source-context', 'src', 'sentry', 'api', 'endpoint.py')))
+        .toBe(true);
+    } finally {
+      if (repoDir) {
+        rmSync(repoDir, { recursive: true, force: true });
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/evals/runner.ts
+++ b/src/evals/runner.ts
@@ -5,6 +5,7 @@ import { execGitNonInteractive } from '../utils/exec.js';
 import { buildLocalEventContext } from '../cli/context.js';
 import { resolveSkillAsync } from '../skills/loader.js';
 import { runSkill } from '../sdk/runner.js';
+import { evalFixtureRepoPath, singleEvalFixtureSourceRepository } from './fixtures.js';
 import { formatEvalId } from './names.js';
 import type { EvalMeta } from './types.js';
 import type { Finding, SkillReport } from '../types/index.js';
@@ -52,6 +53,10 @@ export function setupEvalRepo(meta: EvalMeta, log: (msg: string) => void): strin
     git(['init', '--initial-branch=main']);
     git(['config', 'user.email', 'eval@warden.dev']);
     git(['config', 'user.name', 'Warden Eval']);
+    const sourceRepository = singleEvalFixtureSourceRepository(meta.filePaths);
+    if (sourceRepository) {
+      git(['remote', 'add', 'origin', `https://github.com/${sourceRepository}.git`]);
+    }
 
     // Copy skill into repo. If it lives in a directory (skill-name/SKILL.md),
     // copy the whole directory to preserve resource subdirs (scripts/, references/).
@@ -74,11 +79,11 @@ export function setupEvalRepo(meta: EvalMeta, log: (msg: string) => void): strin
     git(['commit', '-m', 'install eval skill']);
     git(['checkout', '-b', 'eval']);
 
-    // Copy fixture files, preserving their parent directory name
+    // Copy fixture files, preserving their path under evals/fixtures.
     for (const srcPath of meta.filePaths) {
-      const destDir = join(tmpDir, basename(dirname(srcPath)));
-      mkdirSync(destDir, { recursive: true });
-      copyFileSync(srcPath, join(destDir, basename(srcPath)));
+      const destPath = join(tmpDir, ...evalFixtureRepoPath(srcPath).split('/'));
+      mkdirSync(dirname(destPath), { recursive: true });
+      copyFileSync(srcPath, destPath);
     }
 
     git(['add', '.']);

--- a/src/evals/scaffold.test.ts
+++ b/src/evals/scaffold.test.ts
@@ -98,14 +98,18 @@ describe('scaffoldEvalFromGitHubPullRequest', () => {
       'src/api.py',
       'src/previous.py',
     ]);
+    expect(result.skippedFiles).toEqual([{
+      sourcePath: 'src/new.py',
+      reason: 'added file has no base-side content',
+    }]);
     expect(result.files.map((file) => file.fixturePath)).toEqual([
-      'fixtures/fix-project-access-bypass/api.py',
-      'fixtures/fix-project-access-bypass/previous.py',
+      'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/api.py',
+      'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/previous.py',
     ]);
 
-    expect(readFileSync(join(tempDir, 'fixtures/fix-project-access-bypass/api.py'), 'utf-8'))
+    expect(readFileSync(join(tempDir, 'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/api.py'), 'utf-8'))
       .toBe('src/api.py@base-sha\n');
-    expect(readFileSync(join(tempDir, 'fixtures/fix-project-access-bypass/previous.py'), 'utf-8'))
+    expect(readFileSync(join(tempDir, 'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/previous.py'), 'utf-8'))
       .toBe('src/previous.py@base-sha\n');
 
     const scenario = JSON.parse(
@@ -114,15 +118,20 @@ describe('scaffoldEvalFromGitHubPullRequest', () => {
     expect(scenario).toMatchObject({
       given: 'Fix project access bypass',
       files: [
-        'fixtures/fix-project-access-bypass/api.py',
-        'fixtures/fix-project-access-bypass/previous.py',
+        'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/api.py',
+        'fixtures/fix-project-access-bypass/github/getsentry/sentry/src/previous.py',
       ],
       should_find: [{
         finding: 'TODO: describe the vulnerability fixed by https://github.com/getsentry/sentry/pull/12345',
       }],
       notes: {
         source: 'https://github.com/getsentry/sentry/pull/12345',
+        repository: 'getsentry/sentry',
         side: 'base',
+        skipped_files: [{
+          sourcePath: 'src/new.py',
+          reason: 'added file has no base-side content',
+        }],
       },
     });
 
@@ -131,6 +140,10 @@ describe('scaffoldEvalFromGitHubPullRequest', () => {
     );
     expect(validatedScenario.notes?.source).toBe('https://github.com/getsentry/sentry/pull/12345');
     expect(validatedScenario.notes?.side).toBe('base');
+    expect(validatedScenario.notes?.skipped_files).toEqual([{
+      sourcePath: 'src/new.py',
+      reason: 'added file has no base-side content',
+    }]);
   });
 
   it('rejects unsafe category and scenario names', async () => {

--- a/src/evals/scaffold.ts
+++ b/src/evals/scaffold.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, posix } from 'node:path';
 import { Octokit } from '@octokit/rest';
+import { buildGitHubEvalFixturePath } from './fixtures.js';
 
 type PullRequestSide = 'base' | 'head';
 
@@ -25,10 +26,16 @@ export interface ScaffoldedEvalFile {
   ref: string;
 }
 
+export interface SkippedScaffoldFile {
+  sourcePath: string;
+  reason: string;
+}
+
 export interface ScaffoldedEval {
   name: string;
   scenarioPath: string;
   files: ScaffoldedEvalFile[];
+  skippedFiles: SkippedScaffoldFile[];
 }
 
 interface GitHubFileContent {
@@ -42,7 +49,6 @@ interface PullFile {
   previous_filename?: string;
 }
 
-const UNSAFE_FILENAME_CHARS = /[^a-zA-Z0-9._-]+/g;
 const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
 
 function requireSafePathSegment(value: string, label: string): string {
@@ -105,26 +111,29 @@ function getGitHubToken(): string | undefined {
   return process.env['GITHUB_TOKEN'] ?? process.env['GH_TOKEN'];
 }
 
-function fixtureFilename(path: string, seen: Set<string>): string {
-  const base = path.split('/').pop() || 'fixture';
-  let candidate = base.replace(UNSAFE_FILENAME_CHARS, '_');
+function fixturePathForSource(
+  pull: GitHubPullRequestRef,
+  sourcePath: string,
+  seen: Set<string>
+): string {
+  const candidate = buildGitHubEvalFixturePath({
+    owner: pull.owner,
+    repo: pull.repo,
+    sourcePath,
+  });
+
   if (!seen.has(candidate)) {
     seen.add(candidate);
     return candidate;
   }
 
-  const prefix = path
-    .split('/')
-    .slice(0, -1)
-    .join('_')
-    .replace(UNSAFE_FILENAME_CHARS, '_')
-    .slice(-40)
-    .replace(/^_+|_+$/g, '');
-  candidate = prefix ? `${prefix}_${candidate}` : candidate;
+  const dir = posix.dirname(candidate);
+  const base = posix.basename(candidate);
   let deduped = candidate;
   let suffix = 2;
   while (seen.has(deduped)) {
-    deduped = `${candidate}.${suffix}`;
+    const filename = `${base}.${suffix}`;
+    deduped = dir === '.' ? filename : posix.join(dir, filename);
     suffix++;
   }
   seen.add(deduped);
@@ -143,6 +152,16 @@ function filePathForSide(file: PullFile, side: PullRequestSide): string | undefi
     return undefined;
   }
   return file.filename;
+}
+
+function skippedSideReason(file: PullFile, side: PullRequestSide): string | undefined {
+  if (side === 'base' && file.status === 'added') {
+    return 'added file has no base-side content';
+  }
+  if (side === 'head' && file.status === 'removed') {
+    return 'removed file has no head-side content';
+  }
+  return undefined;
 }
 
 async function fetchFileContent(
@@ -186,7 +205,9 @@ function scenarioJson(args: {
   body?: string | null;
   files: string[];
   url: string;
+  repository: string;
   side: PullRequestSide;
+  skippedFiles: SkippedScaffoldFile[];
 }): string {
   return `${JSON.stringify({
     given: args.title,
@@ -197,7 +218,9 @@ function scenarioJson(args: {
     should_not_find: [],
     notes: {
       source: args.url,
+      repository: args.repository,
       side: args.side,
+      skipped_files: args.skippedFiles.length > 0 ? args.skippedFiles : undefined,
       body: args.body || undefined,
     },
   }, null, 2)}\n`;
@@ -229,8 +252,9 @@ export async function scaffoldEvalFromGitHubPullRequest(
   const name = requestedName ?? slugifyEvalName(pr.title);
   const fixtureDir = fromEvalsPath(options.evalsDir, posix.join('fixtures', name));
   const scenarioPath = join(options.evalsDir, category, `${name}.json`);
-  const seenFilenames = new Set<string>();
+  const seenFixturePaths = new Set<string>();
   const copiedFiles: ScaffoldedEvalFile[] = [];
+  const skippedFiles: SkippedScaffoldFile[] = [];
   const contents: (ScaffoldedEvalFile & { content: string })[] = [];
 
   if (!options.force && existsSync(scenarioPath)) {
@@ -240,16 +264,27 @@ export async function scaffoldEvalFromGitHubPullRequest(
   for (const file of files) {
     const sourcePath = filePathForSide(file, side);
     if (!sourcePath) {
+      skippedFiles.push({
+        sourcePath: file.previous_filename ?? file.filename,
+        reason: skippedSideReason(file, side) ?? `file has no ${side}-side content`,
+      });
       continue;
     }
 
     const content = await fetchFileContent(octokit, pull, sourcePath, ref);
     if (!content) {
+      skippedFiles.push({
+        sourcePath,
+        reason: `content was not available at ${side} ref ${ref}`,
+      });
       continue;
     }
 
-    const filename = fixtureFilename(sourcePath, seenFilenames);
-    const fixturePath = posix.join('fixtures', name, filename);
+    const fixturePath = posix.join(
+      'fixtures',
+      name,
+      fixturePathForSource(pull, sourcePath, seenFixturePaths),
+    );
     const fullFixturePath = fromEvalsPath(options.evalsDir, fixturePath);
     if (!options.force && existsSync(fullFixturePath)) {
       throw new Error(`Eval fixture already exists: ${fullFixturePath}`);
@@ -282,7 +317,9 @@ export async function scaffoldEvalFromGitHubPullRequest(
       body: pr.body,
       files: copiedFiles.map((file) => file.fixturePath),
       url: options.url,
+      repository: `${pull.owner}/${pull.repo}`,
       side,
+      skippedFiles,
     }),
     { flag: options.force ? 'w' : 'wx' },
   );
@@ -291,5 +328,6 @@ export async function scaffoldEvalFromGitHubPullRequest(
     name,
     scenarioPath,
     files: copiedFiles,
+    skippedFiles,
   };
 }

--- a/src/evals/types.ts
+++ b/src/evals/types.ts
@@ -29,8 +29,15 @@ export type ShouldFind = z.infer<typeof ShouldFindSchema>;
 export const EvalScenarioNotesSchema = z.object({
   /** Original PR, issue, benchmark, or other source URL. */
   source: z.string().optional(),
+  /** Source repository for scaffolded fixtures, for example "getsentry/sentry". */
+  repository: z.string().optional(),
   /** Which source side was captured when scaffolded from a PR. */
   side: z.string().optional(),
+  /** Files intentionally skipped while scaffolding, with maintainer-facing reasons. */
+  skipped_files: z.array(z.object({
+    sourcePath: z.string(),
+    reason: z.string(),
+  })).optional(),
   /** Optional copied source notes, such as a PR body. */
   body: z.string().optional(),
 }).passthrough();

--- a/src/evals/verify.ts
+++ b/src/evals/verify.ts
@@ -14,6 +14,7 @@ import { verifyFindings } from '../sdk/verify.js';
 import { FindingSchema, type Finding, type UsageStats } from '../types/index.js';
 import { RuntimeNameSchema, type RuntimeName } from '../sdk/runtimes/types.js';
 import { discoverEvalScenarioFiles, resolveEvalSkillName } from './index.js';
+import { evalFixtureRepoPath, singleEvalFixtureSourceRepository } from './fixtures.js';
 import { formatEvalId } from './names.js';
 import { setupEvalRepo } from './runner.js';
 import type { EvalMeta } from './types.js';
@@ -109,10 +110,6 @@ function loadVerificationScenario(filePath: string) {
   return validated.data;
 }
 
-function copiedFixturePath(srcPath: string): string {
-  return `${basename(dirname(srcPath))}/${basename(srcPath)}`;
-}
-
 export function resolveVerificationEvalMeta(
   scenarioPath: string,
   options: VerificationScenarioSetOptions
@@ -184,6 +181,7 @@ export async function runVerificationEval(
   let repoDir: string | undefined;
   try {
     repoDir = setupEvalRepo(repoMeta, log);
+    const sourceRepository = singleEvalFixtureSourceRepository(meta.filePaths);
     const skillSrcDir = dirname(meta.skillPath);
     const skillPath = existsSync(join(skillSrcDir, 'SKILL.md'))
       ? join(repoDir, '.warden', 'skills', basename(skillSrcDir))
@@ -200,8 +198,9 @@ export async function runVerificationEval(
       runtime,
       model,
       prContext: {
+        repository: sourceRepository,
         title: meta.given,
-        changedFiles: meta.filePaths.map(copiedFixturePath),
+        changedFiles: meta.filePaths.map(evalFixtureRepoPath),
       },
     });
 

--- a/src/sdk/analyze.ts
+++ b/src/sdk/analyze.ts
@@ -758,6 +758,7 @@ async function runSkillAnalysis(
   // bloating every hunk prompt with thousands of filenames.
   const isPullRequest = context.pullRequest.number !== 0;
   const prContext: PRPromptContext = {
+    repository: context.repository.fullName,
     changedFiles: isPullRequest ? context.pullRequest.files.map((f) => f.filename) : [],
     title: context.pullRequest.title,
     body: context.pullRequest.body,

--- a/src/sdk/prompt-sections.test.ts
+++ b/src/sdk/prompt-sections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildFileListSection,
   buildJsonOutputSection,
+  buildPullRequestContextSection,
   buildTaggedSection,
   formatIndexedFindingsForPrompt,
   joinPromptSections,
@@ -48,6 +49,18 @@ describe('prompt section helpers', () => {
     expect(section).not.toContain('src/a.ts');
     expect(section).toContain('- src/b.ts');
     expect(section).toContain('... and 1 more');
+  });
+
+  it('includes repository in pull request context without changing file paths', () => {
+    const section = buildPullRequestContextSection({
+      repository: 'getsentry/sentry',
+      title: 'Fix project access bypass',
+      body: 'Project access was missing.',
+      changedFiles: ['src/api.py'],
+    });
+
+    expect(section).toContain('<repository>getsentry/sentry</repository>');
+    expect(section).toContain('<title>Fix project access bypass</title>');
   });
 
   it('formats indexed findings consistently for auxiliary prompts', () => {

--- a/src/sdk/prompt-sections.ts
+++ b/src/sdk/prompt-sections.ts
@@ -1,6 +1,8 @@
 import { findingLine, type Finding } from '../types/index.js';
 
 export interface PromptPRContext {
+  /** Repository full name, e.g. "getsentry/sentry" */
+  repository?: string;
   /** All files being changed in the PR */
   changedFiles: string[];
   /** PR title - explains what the change does */
@@ -52,9 +54,15 @@ ${lines.join('\n')}
  * Build tagged pull request context shared by Warden agents.
  */
 export function buildPullRequestContextSection(prContext?: PromptPRContext): string | undefined {
-  if (!prContext?.title) return undefined;
+  if (!prContext?.title && !prContext?.repository) return undefined;
 
-  const lines = [`<title>${prContext.title}</title>`];
+  const lines: string[] = [];
+  if (prContext.repository) {
+    lines.push(`<repository>${prContext.repository}</repository>`);
+  }
+  if (prContext.title) {
+    lines.push(`<title>${prContext.title}</title>`);
+  }
 
   if (prContext.body) {
     const body = prContext.body.length > MAX_BODY_LENGTH

--- a/src/sdk/verify.test.ts
+++ b/src/sdk/verify.test.ts
@@ -90,6 +90,7 @@ describe('verifyFindings', () => {
       skill: makeSkill(),
       model: 'claude-haiku-4-5',
       prContext: {
+        repository: 'getsentry/sentry',
         title: 'Fix guarded path',
         body: 'Adds a guard before the call.',
         changedFiles: ['src/app.ts', 'src/guard.ts'],
@@ -113,6 +114,9 @@ describe('verifyFindings', () => {
     }));
     expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
       userPrompt: expect.stringContaining('<candidate_finding>'),
+    }));
+    expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: expect.stringContaining('<repository>getsentry/sentry</repository>'),
     }));
     expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
       userPrompt: expect.stringContaining('- src/guard.ts'),


### PR DESCRIPTION
Keep scaffolded eval fixture provenance explicit without leaking it into eval output. GitHub-sourced fixtures now encode owner/repo under the checked-in fixture path, while runners and verifier map them back to repo-relative paths and prompt repository metadata.

**Fixture Interface**

Add a shared `src/evals/fixtures.ts` helper for building fixture storage paths, deriving repo-relative paths, and detecting a single source repository. This keeps scaffold, runner, and verifier on one layout contract.

**Scaffold Visibility**

Record skipped files and source repository in scenario notes, and print skipped files from `pnpm evals:scaffold` so base/head-only gaps are visible when a fixture is generated.