### PR TITLE
test(evals): Add vitest-evals reporter bug fixtures

### DIFF
--- a/evals/INTERNAL.md
+++ b/evals/INTERNAL.md
@@ -23,6 +23,13 @@ still records the JSON and JUnit reports, publishes JUnit annotations and a job
 summary for per-case test reporting, and gates the workflow on the aggregate
 `Evaluation Results` baseline. The baseline is `0.75`.
 
+Individual misses are useful harness debt. For a verified real bug, write the
+expected `should_find` for the bug Warden should catch even if the current
+pipeline fails, drops the candidate in verification, finds only an adjacent
+duplicate, or uses the wrong severity. Do not tune assertions to the current
+output just to get a passing eval. Remove or skip a bug fixture only when the
+source finding is not actually a reachable bug under the target skill.
+
 ## Eval Layers
 
 - `evals/*.yaml`: small full-pipeline suites using test skills.
@@ -49,7 +56,8 @@ real skill under test.
    `evals/fixtures/<scenario>/github/<owner>/<repo>/<repo-relative-path>` to
    preserve source context while eval output uses `<scenario>/<repo-relative-path>`.
    Scaffolded source repositories are still passed to prompts as repository context.
-3. Write a specific `should_find` assertion and useful `should_not_find` guards.
+3. Write a specific `should_find` assertion for the verified bug, not for the
+   current Warden output, and add useful `should_not_find` guards.
 4. Run the narrow case first with `pnpm evals -t <scenario>`.
 5. Run the suite with `pnpm evals -t <category>`.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -222,6 +222,19 @@ JUnit annotations and a job summary for per-case test reporting, then gates the
 workflow on the aggregate `Evaluation Results` score. The current baseline
 threshold is `0.75`.
 
+## Expected Misses
+
+Eval fixtures are benchmark targets, not proof that the current harness already
+passes. When a source finding is verified as a real bug, encode the bug Warden
+should find even if the current pipeline misses it, verifies it away, reports a
+nearby duplicate, or assigns a different severity. Do not weaken `should_find`
+or delete a real bug fixture just to make today's eval run green.
+
+Only remove or avoid a bug fixture when the source finding is not a real,
+reachable bug under the skill's criteria. If Warden reports the wrong adjacent
+issue, keep the expected assertion focused on the verified bug and use the miss
+to improve discovery, verification, merging, or judging later.
+
 ## Adding a New Eval
 
 1. Pick an existing skill directory, or create `evals/<skill>/`

--- a/evals/code-review/sentry-vitest-evals-duration-sixty-seconds.json
+++ b/evals/code-review/sentry-vitest-evals-duration-sixty-seconds.json
@@ -1,0 +1,23 @@
+{
+  "given": "GitHub reporter duration formatting rounds seconds at minute boundaries without carrying into the next unit",
+  "files": [
+    "fixtures/sentry-vitest-evals-duration-sixty-seconds/github/getsentry/vitest-evals/packages/github-reporter/src/utils.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "formatDuration rounds display seconds without normalizing carry into the next unit, so values near minute boundaries can render as 60s or 1m 60s instead of 1m 0s or 2m 0s"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues",
+    "duration values below one second being rounded to milliseconds",
+    "using Intl.NumberFormat for integer formatting"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/vitest-evals/pull/56#discussion_r3255240096",
+    "repository": "getsentry/vitest-evals",
+    "side": "head",
+    "body": "Regression seed from Cursor Bugbot. Verified real: rounding seconds without carrying into the next unit can produce unnormalized duration strings at minute boundaries, including the reported Xm 60s case."
+  }
+}

--- a/evals/code-review/sentry-vitest-evals-github-reporter-positional-json.json
+++ b/evals/code-review/sentry-vitest-evals-github-reporter-positional-json.json
@@ -1,0 +1,23 @@
+{
+  "given": "GitHub reporter CLI argument parsing initializes a default JSON report path before parsing arguments while also keeping a positional JSON path fallback",
+  "files": [
+    "fixtures/sentry-vitest-evals-github-reporter-positional-json/github/getsentry/vitest-evals/packages/github-reporter/src/cli.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "parseArgs initializes jsonPath from VITEST_EVALS_JSON_REPORT or vitest-results.json before argument parsing, so the default-case branch intended to accept a bare positional JSON report path is unreachable and vitest-evals-github-report my-results.json throws Unknown argument instead of using that file"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues",
+    "the documented --json flag being broken",
+    "the CLI lacking a default JSON path when no arguments are provided"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/vitest-evals/pull/56#discussion_r3255238970",
+    "repository": "getsentry/vitest-evals",
+    "side": "head",
+    "body": "Regression seed from Sentry-disclosed potential bug. Verified real: parseArgs defaults jsonPath before checking the positional fallback, making a bare report path unreachable. Severity is intentionally not asserted; Sentry labeled it low, while Warden may treat shipped CLI argument failures under its published-interface rubric."
+  }
+}

--- a/evals/fixtures/sentry-vitest-evals-duration-sixty-seconds/github/getsentry/vitest-evals/packages/github-reporter/src/utils.ts
+++ b/evals/fixtures/sentry-vitest-evals-duration-sixty-seconds/github/getsentry/vitest-evals/packages/github-reporter/src/utils.ts
@@ -1,0 +1,19 @@
+export function renderJobSummaryDuration(durationMs: number | undefined) {
+  return `Duration: ${formatDuration(durationMs)}`;
+}
+
+export function formatDuration(ms: number | undefined) {
+  if (ms === undefined || !Number.isFinite(ms)) {
+    return "n/a";
+  }
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}

--- a/evals/fixtures/sentry-vitest-evals-github-reporter-positional-json/github/getsentry/vitest-evals/packages/github-reporter/src/cli.ts
+++ b/evals/fixtures/sentry-vitest-evals-github-reporter-positional-json/github/getsentry/vitest-evals/packages/github-reporter/src/cli.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+type CliOptions = {
+  jsonPath?: string;
+};
+
+type VitestJsonReport = {
+  success: boolean;
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.jsonPath) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+
+  const report = JSON.parse(
+    await readFile(options.jsonPath, "utf8"),
+  ) as VitestJsonReport;
+  console.log(report.success ? "passed" : "failed");
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    jsonPath: process.env.VITEST_EVALS_JSON_REPORT ?? "vitest-results.json",
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--json":
+        options.jsonPath = readValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+        return options;
+      default:
+        if (!arg.startsWith("-") && !options.jsonPath) {
+          options.jsonPath = arg;
+          break;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readValue(args: string[], index: number, flag: string) {
+  const value = args[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function usage() {
+  return "Usage: vitest-evals-github-report [--json <vitest-results.json>]";
+}

--- a/src/evals/index.test.ts
+++ b/src/evals/index.test.ts
@@ -214,9 +214,12 @@ describe('standalone scenario files', () => {
       baseDir: evalsDir,
     });
 
-    expect(metas.length).toBe(2);
-    expect(metas.map((meta) => meta.name)).toContain('eval-optional-assertion-rationale');
-    expect(metas.map((meta) => meta.name)).toContain('robots-prefix-blocks-public-metadata');
+    expect(metas.map((meta) => meta.name)).toEqual(expect.arrayContaining([
+      'eval-optional-assertion-rationale',
+      'robots-prefix-blocks-public-metadata',
+      'sentry-vitest-evals-duration-sixty-seconds',
+      'sentry-vitest-evals-github-reporter-positional-json',
+    ]));
     expect(metas.every((meta) => meta.skillName === 'code-review')).toBe(true);
     expect(metas[0]?.skillPath).toContain('src/builtin-skills/code-review/SKILL.md');
   });


### PR DESCRIPTION
Adds two code-review benchmark scenarios from getsentry/vitest-evals#56 for reporter correctness bugs. The fixtures are focused source-context repros based on the PR-head code for the positional JSON path parser issue and the duration formatting boundary issue. The PR also documents that verified bug evals should remain benchmark targets even when the current harness misses them.

**Reporter Fixtures**

Capture compact source-context fixtures for the GitHub reporter CLI parser and duration formatter, each with a standalone code-review scenario.

**Eval Guidance**

Document that expected misses are useful harness debt and that assertions should describe the verified bug, not the current Warden output.

Refs https://github.com/getsentry/vitest-evals/pull/56