### PR TITLE
fix(action): install Claude Code only for Claude runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,26 +66,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install Claude Code CLI
-      shell: bash
-      run: |
-        CLAUDE_CODE_VERSION="2.1.32"
-        echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
-        for attempt in 1 2 3; do
-          echo "Installation attempt $attempt..."
-          if curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION"; then
-            break
-          fi
-          if [ $attempt -eq 3 ]; then
-            echo "Failed to install Claude Code after 3 attempts"
-            exit 1
-          fi
-          echo "Installation failed, retrying..."
-          sleep 5
-        done
-        echo "Claude Code installed successfully"
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
     - name: Run Warden
       id: warden
       shell: bash
@@ -101,5 +81,4 @@ runs:
         INPUT_REQUEST_CHANGES: ${{ inputs.request-changes }}
         INPUT_FAIL_CHECK: ${{ inputs.fail-check }}
         INPUT_PARALLEL: ${{ inputs.parallel }}
-        CLAUDE_CODE_PATH: ${{ env.HOME }}/.local/bin/claude
       run: node ${{ github.action_path }}/dist/action/index.js

--- a/src/action/workflow/base.test.ts
+++ b/src/action/workflow/base.test.ts
@@ -1,9 +1,28 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { EventContext, SkillReport } from '../../types/index.js';
-import { getFindingsOutputPath, writeFindingsOutput } from './base.js';
+import type { ActionInputs } from '../inputs.js';
+
+vi.mock('../../utils/exec.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    execFileNonInteractive: vi.fn(),
+    execNonInteractive: vi.fn(),
+  };
+});
+
+import { execFileNonInteractive, execNonInteractive } from '../../utils/exec.js';
+import {
+  getFindingsOutputPath,
+  prepareRuntimeEnvironment,
+  writeFindingsOutput,
+} from './base.js';
+
+const mockExecFile = vi.mocked(execFileNonInteractive);
+const mockExec = vi.mocked(execNonInteractive);
 
 describe('findings output', () => {
   let tempDir: string;
@@ -12,6 +31,7 @@ describe('findings output', () => {
   let previousRunnerTemp: string | undefined;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tempDir = mkdtempSync(join(tmpdir(), 'warden-findings-output-'));
     previousGithubOutput = process.env['GITHUB_OUTPUT'];
     previousGithubWorkspace = process.env['GITHUB_WORKSPACE'];
@@ -67,6 +87,76 @@ describe('findings output', () => {
     expect(getFindingsOutputPath()).toBe(join(runnerTemp, 'warden-findings.json'));
   });
 });
+
+describe('runtime setup', () => {
+  let previousClaudeCodePath: string | undefined;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    previousClaudeCodePath = process.env['CLAUDE_CODE_PATH'];
+    previousHome = process.env['HOME'];
+    delete process.env['CLAUDE_CODE_PATH'];
+    process.env['HOME'] = '/tmp/warden-home';
+  });
+
+  afterEach(() => {
+    if (previousClaudeCodePath === undefined) {
+      delete process.env['CLAUDE_CODE_PATH'];
+    } else {
+      process.env['CLAUDE_CODE_PATH'] = previousClaudeCodePath;
+    }
+
+    if (previousHome === undefined) {
+      delete process.env['HOME'];
+    } else {
+      process.env['HOME'] = previousHome;
+    }
+  });
+
+  it('does not install anything for Pi-only triggers', async () => {
+    const env = await prepareRuntimeEnvironment([{ runtime: 'pi' }], createInputs());
+
+    expect(env).toEqual({});
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('installs Claude Code when any matched trigger uses the Claude runtime', async () => {
+    let installed = false;
+    const homeClaudePath = '/tmp/warden-home/.local/bin/claude';
+    mockExecFile.mockImplementation((file, args) => {
+      if (file === 'test' && args[1] === homeClaudePath && installed) {
+        return '';
+      }
+      throw new Error('not executable');
+    });
+    mockExec.mockImplementation(() => {
+      installed = true;
+      return 'install output';
+    });
+
+    await expect(
+      prepareRuntimeEnvironment([{ runtime: 'pi' }, { runtime: 'claude' }], createInputs())
+    ).resolves.toEqual({ pathToClaudeCodeExecutable: homeClaudePath });
+    expect(mockExec).toHaveBeenCalledWith(
+      'curl -fsSL https://claude.ai/install.sh | bash -s -- "2.1.32"',
+      { timeout: 120_000 }
+    );
+  });
+});
+
+function createInputs(overrides: Partial<ActionInputs> = {}): ActionInputs {
+  return {
+    anthropicApiKey: 'test-key',
+    oauthToken: '',
+    githubToken: 'github-token',
+    configPath: 'warden.toml',
+    maxFindings: 50,
+    parallel: 4,
+    ...overrides,
+  };
+}
 
 function createContext(repoPath: string): EventContext {
   return {

--- a/src/action/workflow/base.ts
+++ b/src/action/workflow/base.ts
@@ -91,6 +91,7 @@ export interface RuntimeEnvironment {
   pathToClaudeCodeExecutable?: string;
 }
 
+/** Prepare runtime-specific process dependencies required by matched triggers. */
 export async function prepareRuntimeEnvironment(
   triggers: Iterable<{ runtime?: RuntimeName }>,
   inputs: ActionInputs

--- a/src/action/workflow/base.ts
+++ b/src/action/workflow/base.ts
@@ -9,10 +9,11 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { Octokit } from '@octokit/rest';
-import { execFileNonInteractive } from '../../utils/exec.js';
+import { execFileNonInteractive, execNonInteractive } from '../../utils/exec.js';
 import { isRepoRelativePath, normalizePath } from '../../utils/path.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import { countSeverity } from '../../triggers/matcher.js';
+import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
 import type { ActionInputs } from '../inputs.js';
 
@@ -83,8 +84,46 @@ export function logGroupEnd(): void {
 }
 
 // -----------------------------------------------------------------------------
+// Runtime setup
+// -----------------------------------------------------------------------------
+
+export interface RuntimeEnvironment {
+  pathToClaudeCodeExecutable?: string;
+}
+
+export async function prepareRuntimeEnvironment(
+  triggers: Iterable<{ runtime?: RuntimeName }>,
+  inputs: ActionInputs
+): Promise<RuntimeEnvironment> {
+  const runtimes = new Set<RuntimeName>();
+  for (const trigger of triggers) {
+    runtimes.add(trigger.runtime ?? 'pi');
+  }
+
+  const env: RuntimeEnvironment = {};
+  for (const runtime of runtimes) {
+    switch (runtime) {
+      case 'pi':
+        break;
+      case 'claude':
+        ensureClaudeAuth(inputs);
+        env.pathToClaudeCodeExecutable = await findClaudeCodeExecutable();
+        break;
+    }
+  }
+
+  return env;
+}
+
+// -----------------------------------------------------------------------------
 // Claude Code CLI
 // -----------------------------------------------------------------------------
+
+const CLAUDE_CODE_VERSION = '2.1.32';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Test whether a path is an executable file.
@@ -98,20 +137,16 @@ function isExecutable(path: string): boolean {
   }
 }
 
-/**
- * Find the Claude Code CLI executable path.
- * Required in CI environments where the SDK can't auto-detect the CLI location.
- */
-export async function findClaudeCodeExecutable(): Promise<string> {
-  // Check environment variable first (set by action.yml)
+function findInstalledClaudeCodeExecutable(): string | undefined {
   const envPath = process.env['CLAUDE_CODE_PATH'];
   if (envPath && isExecutable(envPath)) {
     return envPath;
   }
 
   // Standard install location from claude.ai/install.sh
-  const homeLocalBin = `${process.env['HOME']}/.local/bin/claude`;
-  if (isExecutable(homeLocalBin)) {
+  const home = process.env['HOME'];
+  const homeLocalBin = home ? `${home}/.local/bin/claude` : undefined;
+  if (homeLocalBin && isExecutable(homeLocalBin)) {
     return homeLocalBin;
   }
 
@@ -129,8 +164,53 @@ export async function findClaudeCodeExecutable(): Promise<string> {
     if (isExecutable(p)) return p;
   }
 
+  return undefined;
+}
+
+async function installClaudeCodeExecutable(): Promise<void> {
+  console.log(`Installing Claude Code v${CLAUDE_CODE_VERSION}...`);
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    console.log(`Installation attempt ${attempt}...`);
+    try {
+      const output = execNonInteractive(
+        `curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_VERSION}"`,
+        { timeout: 120_000 }
+      );
+      if (output) {
+        console.log(output);
+      }
+      console.log('Claude Code installed successfully');
+      return;
+    } catch (error) {
+      if (attempt === 3) {
+        setFailed(`Failed to install Claude Code after 3 attempts: ${error}`);
+      }
+      console.log('Installation failed, retrying...');
+      await sleep(5000);
+    }
+  }
+}
+
+/**
+ * Find the Claude Code CLI executable path, installing it on demand when the
+ * selected runtime needs Claude Code in CI.
+ */
+export async function findClaudeCodeExecutable(): Promise<string> {
+  const existingPath = findInstalledClaudeCodeExecutable();
+  if (existingPath) {
+    return existingPath;
+  }
+
+  await installClaudeCodeExecutable();
+
+  const installedPath = findInstalledClaudeCodeExecutable();
+  if (installedPath) {
+    return installedPath;
+  }
+
   setFailed(
-    'Claude Code CLI not found. Ensure Claude Code is installed via https://claude.ai/install.sh'
+    'Claude Code CLI not found after installation. Ensure Claude Code is installed via https://claude.ai/install.sh'
   );
 }
 

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -88,6 +88,19 @@ vi.mock('./base.js', async () => {
       );
     }),
     findClaudeCodeExecutable: vi.fn(() => '/usr/local/bin/claude'),
+    prepareRuntimeEnvironment: vi.fn((triggers: Iterable<{ runtime?: string }>, inputs: ActionInputs) => {
+      const usesClaude = Array.from(triggers).some((trigger) => (trigger.runtime ?? 'pi') === 'claude');
+      if (!usesClaude) {
+        return Promise.resolve({});
+      }
+      if (!inputs.anthropicApiKey && !inputs.oauthToken) {
+        mockedSetFailed(
+          'Authentication not found. Provide an API key via anthropic-api-key input, ' +
+            'WARDEN_ANTHROPIC_API_KEY env var, or OAuth token via CLAUDE_CODE_OAUTH_TOKEN env var.'
+        );
+      }
+      return Promise.resolve({ pathToClaudeCodeExecutable: '/usr/local/bin/claude' });
+    }),
     getAuthenticatedBotLogin: vi.fn(() => Promise.resolve('warden[bot]')),
   };
 });

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -53,7 +53,7 @@ import {
   ensureClaudeAuth,
   logGroup,
   logGroupEnd,
-  findClaudeCodeExecutable,
+  prepareRuntimeEnvironment,
   handleTriggerErrors,
   collectTriggerErrors,
   computeWorkflowOutputs,
@@ -313,11 +313,7 @@ async function executeAllTriggers(
   inputs: ActionInputs
 ): Promise<TriggerResult[]> {
   const concurrency = runnerConcurrency ?? inputs.parallel;
-  const usesClaudeRuntime = matchedTriggers.some((trigger) => (trigger.runtime ?? 'pi') === 'claude');
-  if (usesClaudeRuntime) {
-    ensureClaudeAuth(inputs);
-  }
-  const claudePath = usesClaudeRuntime ? await findClaudeCodeExecutable() : undefined;
+  const runtimeEnv = await prepareRuntimeEnvironment(matchedTriggers, inputs);
 
   const semaphore = new Semaphore(concurrency);
   const abortController = new AbortController();
@@ -332,7 +328,7 @@ async function executeAllTriggers(
         octokit,
         context,
         anthropicApiKey: inputs.anthropicApiKey,
-        claudePath,
+        claudePath: runtimeEnv.pathToClaudeCodeExecutable,
         globalFailOn: inputs.failOn,
         globalReportOn: inputs.reportOn,
         globalMaxFindings: inputs.maxFindings,

--- a/src/action/workflow/schedule.test.ts
+++ b/src/action/workflow/schedule.test.ts
@@ -43,6 +43,19 @@ vi.mock('./base.js', async () => {
       );
     }),
     findClaudeCodeExecutable: vi.fn(() => '/usr/local/bin/claude'),
+    prepareRuntimeEnvironment: vi.fn((triggers: Iterable<{ runtime?: string }>, inputs: ActionInputs) => {
+      const usesClaude = Array.from(triggers).some((trigger) => (trigger.runtime ?? 'pi') === 'claude');
+      if (!usesClaude) {
+        return Promise.resolve({});
+      }
+      if (!inputs.anthropicApiKey && !inputs.oauthToken) {
+        mockedSetFailed(
+          'Authentication not found. Provide an API key via anthropic-api-key input, ' +
+            'WARDEN_ANTHROPIC_API_KEY env var, or OAuth token via CLAUDE_CODE_OAUTH_TOKEN env var.'
+        );
+      }
+      return Promise.resolve({ pathToClaudeCodeExecutable: '/usr/local/bin/claude' });
+    }),
     getDefaultBranchFromAPI: vi.fn(() => Promise.resolve('main')),
     // Override handleTriggerErrors to use the mocked setFailed
     handleTriggerErrors: (triggerErrors: string[], totalTriggers: number) => {

--- a/src/action/workflow/schedule.ts
+++ b/src/action/workflow/schedule.ts
@@ -27,10 +27,9 @@ import {
   setOutput,
   setFailed,
   ActionFailedError,
-  ensureClaudeAuth,
   logGroup,
   logGroupEnd,
-  findClaudeCodeExecutable,
+  prepareRuntimeEnvironment,
   handleTriggerErrors,
   getDefaultBranchFromAPI,
   writeFindingsOutput,
@@ -204,11 +203,7 @@ async function runScheduleWorkflowInner(
       const skill = await resolveSkillAsync(resolved.skill, skillRoot, {
         remote: resolved.remote,
       });
-      const usesClaudeRuntime = (resolved.runtime ?? 'pi') === 'claude';
-      if (usesClaudeRuntime) {
-        ensureClaudeAuth(inputs);
-      }
-      const claudePath = usesClaudeRuntime ? await findClaudeCodeExecutable() : undefined;
+      const runtimeEnv = await prepareRuntimeEnvironment([resolved], inputs);
       const report = await runSkill(skill, context, {
         apiKey: inputs.anthropicApiKey,
         model: resolved.model,
@@ -221,7 +216,7 @@ async function runScheduleWorkflowInner(
         auxiliaryMaxRetries: resolved.auxiliaryMaxRetries,
         verifyFindings: resolved.verifyFindings,
         telemetryTriggerName: resolved.name,
-        pathToClaudeCodeExecutable: claudePath,
+        pathToClaudeCodeExecutable: runtimeEnv.pathToClaudeCodeExecutable,
       });
       console.log(`Found ${report.findings.length} findings`);
 


### PR DESCRIPTION
Companion PR to issue [#333](https://github.com/getsentry/warden/issues/333)
See writeup and evidence in the issue. I am more than happy to amend in particular to generalise, just let me know if you don't like implementation

Pi writeup below:

## Summary
- Move Claude Code setup out of the composite action's unconditional pre-step and into the JS runtime setup path, after matched triggers have been resolved.
- This keeps the fix small: Claude Code is installed/found only when a matched trigger uses `runtime = "claude"`; Pi runtime runs skip Claude Code setup.

## Detail
- Changes:
  - Remove the unconditional Claude Code install step from `action.yml`
  - Add a small action-layer runtime setup helper after matched triggers are resolved
  - Skip Claude Code setup for `runtime = "pi"`
  - For `runtime = "claude"`, validate auth and install/find Claude Code on demand using the current install script/version/retry behaviour
- Context: see https://github.com/getsentry/warden/issues/333 for the detailed motivation and evidence. In short, Pi-only action runs currently install Claude Code even though the Pi runtime does not use it, which is confusing and adds avoidable CI time.
- Tests
  - `pnpm vitest run src/action/workflow/base.test.ts src/action/workflow/pr-workflow.test.ts src/action/workflow/schedule.test.ts src/action/triggers/executor.test.ts`
  - `pnpm typecheck`
  - `pnpm lint`
  - `pnpm build`
  - End-to-end smoke test in a dummy repo: https://github.com/tmustier/warden-test/actions/runs/26031290149
    - Pi runtime invoked the model and asserted Claude Code was not installed
    - Claude runtime installed Claude Code, invoked the model, and asserted the executable exists
