### PR TITLE
docs(config): Document model runtime selection

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
     starlight({
       title: "Warden",
       description: "Define skills in Markdown. Compose them into agents that review every change.",
+      customCss: ["./src/styles/docs.css"],
       pagination: false,
       sidebar: [
         {
@@ -70,6 +71,7 @@ export default defineConfig({
               label: "warden.toml",
               items: [
                 { label: "Overview", link: "/config" },
+                { label: "Models and Runtimes", link: "/config/models" },
                 { label: "Skill Entries", link: "/config/skills" },
                 { label: "Triggers", link: "/config/triggers" },
                 { label: "Output and Defaults", link: "/config/output" },

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -205,12 +205,12 @@ Skills define what Warden analyzes and when.
 | `failOn` | Minimum severity to fail: `critical`, `high`, `medium`, `low`, `info`, `off` |
 | `reportOn` | Minimum severity to report |
 | `remote` | GitHub repository for remote skills: `owner/repo` or `owner/repo@sha` |
-| `model` | Model override |
+| `model` | Override the main agent model for this skill |
 | `maxTurns` | Max agentic turns per hunk |
 
 ### Triggers
 
-Triggers define when a skill runs. Each skill can have one or more triggers. Triggers can override any output setting.
+Triggers define when a skill runs. Each skill can have one or more triggers. Triggers can override output settings and the main agent model.
 
 | Field | Description |
 |-------|-------------|
@@ -222,7 +222,7 @@ Triggers define when a skill runs. Each skill can have one or more triggers. Tri
 | `reportOnSuccess` | Override report-on-success behavior |
 | `requestChanges` | Override REQUEST_CHANGES behavior |
 | `failCheck` | Override check failure behavior |
-| `model` | Override model |
+| `model` | Override the main agent model for this trigger |
 | `maxTurns` | Override max agentic turns |
 
 Pull request actions: `opened`, `synchronize`, `reopened`, `closed`.
@@ -257,28 +257,58 @@ Control how findings are reported. Set at the skill level or in defaults.
 
 ### Defaults
 
-Default settings inherited by all skills. Individual skills can override any setting.
+Default settings inherited by all skills. Individual skills can override output
+settings and the main agent model.
 
 ```toml
 [defaults]
-runtime = "pi"
-model = "openai/gpt-5.5"
-maxTurns = 30
 failOn = "high"
 reportOn = "medium"
 requestChanges = false
 failCheck = false
 ignorePaths = ["**/vendor/**", "**/node_modules/**"]
+```
+
+### Models and Runtimes
+
+Runtime is configured under `[defaults]`. The default runtime is `pi`.
+
+```toml
+[defaults]
+runtime = "pi"
+
+[defaults.agent]
+model = "anthropic/claude-sonnet-4-6"
+maxTurns = 30
 
 [defaults.auxiliary]
 model = "anthropic/claude-haiku-4-5"
+maxRetries = 3
 
 [defaults.synthesis]
 model = "anthropic/claude-opus-4-5"
 ```
 
-Model precedence: trigger > skill > defaults > CLI flag (`-m`) > env var (`WARDEN_MODEL`). Most specific wins.
-Synthesis fallback: `defaults.synthesis.model` falls back to `defaults.auxiliary.model` when not set.
+Runtime values:
+
+- `pi` - default. Model values must use `provider/model` selectors such as `openai/gpt-5.5` or `anthropic/claude-sonnet-4-6`.
+- `claude` - runs through Claude Code. Use Claude Code model IDs and Anthropic API key or Claude Code OAuth auth.
+
+Runtime selection is global within a config layer. `runtime` is not currently a skill-level or trigger-level field.
+
+Model lanes:
+
+- `defaults.agent.model` - main repo-aware skill analysis. Preferred default model field.
+- `defaults.auxiliary.model` - structured helper calls such as extraction, repair, merging, dedupe, and fix evaluation.
+- `defaults.synthesis.model` - post-analysis synthesis and consolidation. Falls back to `defaults.auxiliary.model` when unset.
+
+`defaults.model` and `defaults.maxTurns` are legacy shorthand for the agent lane.
+
+Main agent model precedence: trigger `model` > skill `model` > `defaults.agent.model` > legacy `defaults.model` > CLI flag (`-m`) > env var (`WARDEN_MODEL`) > SDK/runtime default.
+
+Auxiliary and synthesis models only come from `[defaults.auxiliary]` and `[defaults.synthesis]`. They do not inherit skill or trigger `model` overrides.
+
+Generated skill commands (`warden build` and `warden improve`) use the synthesis lane. Their model fallback order is `defaults.synthesis.model` > `defaults.auxiliary.model` > CLI flag (`-m`) > env var (`WARDEN_MODEL`) > SDK/runtime default.
 
 ### Chunking
 
@@ -373,7 +403,7 @@ Resolution order:
 
 | Variable | Description |
 |----------|-------------|
-| `WARDEN_MODEL` | Model override |
+| `WARDEN_MODEL` | Fallback model selector when config and CLI do not set one |
 | `WARDEN_OPENAI_API_KEY` | OpenAI API key for OpenAI Pi models |
 | `WARDEN_ANTHROPIC_API_KEY` | Anthropic API key for Anthropic Pi models or Claude runtime |
 | `WARDEN_SKILL_CACHE_TTL` | Cache duration for unpinned remote skills. Default: 24h |
@@ -446,7 +476,7 @@ Add these as organization or repository secrets:
 
 | Secret | Description |
 |--------|-------------|
-| `WARDEN_MODEL` | Pi model selector |
+| `WARDEN_MODEL` | Fallback model selector when config does not set one |
 | `WARDEN_OPENAI_API_KEY` | OpenAI API key for OpenAI Pi models |
 | `WARDEN_ANTHROPIC_API_KEY` | Anthropic API key for Anthropic Pi models or Claude runtime |
 | `WARDEN_SENTRY_DSN` *(optional)* | Sentry DSN for telemetry |

--- a/packages/docs/src/content/docs/cli/build.mdx
+++ b/packages/docs/src/content/docs/cli/build.mdx
@@ -24,7 +24,7 @@ roots.
 | --- | --- |
 | `-C, --cwd <path>` | Run as if invoked from this directory. |
 | `--config <path>` | Path to `warden.toml`. |
-| `-m, --model <model>` | Model fallback when config does not specify one. |
+| `-m, --model <model>` | Model fallback when `warden.toml` does not specify one. See [Models and Runtimes](/config/models/). |
 | `--json` | Output results as JSON. |
 | `--regenerate` | Ignore cached generated skill artifacts and build again. |
 | `-p, --prompt <value>` | Generated skill prompt. Prefix with `@` to read from a file. |
@@ -43,4 +43,3 @@ warden build security -p @prompt.md
 warden build ./skills/security -p @prompt.md
 warden build sentry-security --json
 ```
-

--- a/packages/docs/src/content/docs/cli/improve.mdx
+++ b/packages/docs/src/content/docs/cli/improve.mdx
@@ -23,7 +23,7 @@ generated-skill reviewer loop.
 | --- | --- |
 | `-C, --cwd <path>` | Run as if invoked from this directory. |
 | `--config <path>` | Path to `warden.toml`. |
-| `-m, --model <model>` | Model fallback when config does not specify one. |
+| `-m, --model <model>` | Model fallback when `warden.toml` does not specify one. See [Models and Runtimes](/config/models/). |
 | `--json` | Output results as JSON. |
 | `-p, --prompt <value>` | Improvement brief. Prefix with `@` to read from a file. |
 | `--quiet` | Errors and final summary only. |
@@ -40,4 +40,3 @@ warden improve security -p "Deepen source provenance and reference routing"
 warden improve security -p @feedback.md
 warden improve ./skills/security -p @feedback.md
 ```
-

--- a/packages/docs/src/content/docs/cli/run.mdx
+++ b/packages/docs/src/content/docs/cli/run.mdx
@@ -25,7 +25,7 @@ The bare `warden` command is an alias for this command.
 | `-C, --cwd <path>` | Run as if invoked from this directory. |
 | `--skill <name\|path>` | Run only this skill by name or path. Names fall back to built-ins. |
 | `--config <path>` | Path to `warden.toml`. |
-| `-m, --model <model>` | Model fallback when config does not specify one. |
+| `-m, --model <model>` | Model fallback when `warden.toml` does not specify one. See [Models and Runtimes](/config/models/). |
 | `--json` | Output results as JSON. |
 | `-o, --output <path>` | Write full run output to a JSONL file. |
 | `--fail-on <severity>` | Exit with code 1 if findings meet this severity. |
@@ -53,4 +53,3 @@ warden "src/**/*.ts" --skill security-review
 warden HEAD~3
 warden --staged --fix
 ```
-

--- a/packages/docs/src/content/docs/config.mdx
+++ b/packages/docs/src/content/docs/config.mdx
@@ -33,6 +33,10 @@ actions = ["opened", "synchronize"]
     <strong>Skill Entries</strong>
     <span>Skill fields, filters, remotes, and model overrides.</span>
   </a>
+  <a class="api-link-card" href="/config/models/">
+    <strong>Models and Runtimes</strong>
+    <span>Pi selectors, Claude runtime, model lanes, and precedence.</span>
+  </a>
   <a class="api-link-card" href="/config/triggers/">
     <strong>Triggers</strong>
     <span>Pull request, local, and schedule trigger settings.</span>
@@ -55,7 +59,7 @@ actions = ["opened", "synchronize"]
 
 | Variable | Purpose |
 | --- | --- |
-| `WARDEN_MODEL` | Pi model selector, such as `openai/gpt-5.5` or `anthropic/claude-sonnet-4-6`. |
+| `WARDEN_MODEL` | Fallback model selector when `warden.toml` and `--model` do not set one. See [Models and Runtimes](/config/models/). |
 | `WARDEN_OPENAI_API_KEY` | OpenAI API key when using an OpenAI Pi model. |
 | `WARDEN_ANTHROPIC_API_KEY` | Anthropic API key when using an Anthropic Pi model or the Claude runtime. |
 | `WARDEN_SKILL_CACHE_TTL` | Cache duration for unpinned remote skills. Default: 24h. |

--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -1,0 +1,132 @@
+---
+title: Models and Runtimes
+description: Configure Warden model selection, runtime backends, and model precedence.
+editUrl: false
+---
+
+Warden selects one runtime backend for a config layer and can use separate model
+lanes for different kinds of model work.
+
+## Runtime
+
+The runtime selects the backend used for model-backed execution. Configure it
+under `[defaults]`:
+
+```toml title="warden.toml"
+[defaults]
+runtime = "pi"
+```
+
+| Runtime | Purpose |
+| --- | --- |
+| `pi` | Default. Runs through Pi. Model values must use `provider/model` selectors. |
+| `claude` | Runs through Claude Code. Requires Anthropic API key or Claude Code OAuth auth. |
+
+Runtime selection is global within a config layer. `runtime` is not currently a
+skill-level or trigger-level field.
+
+## Pi Model Selectors
+
+When `runtime = "pi"`, configured model values must include a provider prefix:
+
+```toml title="warden.toml"
+[defaults.agent]
+model = "anthropic/claude-sonnet-4-6"
+```
+
+Examples:
+
+| Selector | Credential |
+| --- | --- |
+| `openai/gpt-5.5` | `WARDEN_OPENAI_API_KEY` |
+| `anthropic/claude-sonnet-4-6` | `WARDEN_ANTHROPIC_API_KEY` |
+
+## Claude Runtime Models
+
+When `runtime = "claude"`, use the model IDs accepted by Claude Code:
+
+```toml title="warden.toml"
+[defaults]
+runtime = "claude"
+
+[defaults.agent]
+model = "claude-sonnet-4-6"
+```
+
+In GitHub Actions, set `WARDEN_ANTHROPIC_API_KEY` or provide Claude Code OAuth
+auth. Locally, Claude runtime can also use existing Claude Code auth.
+
+## Model Lanes
+
+Warden can use different models for different stages:
+
+| Field | Purpose |
+| --- | --- |
+| `defaults.agent.model` | Main repo-aware skill analysis. Preferred default model field. |
+| `defaults.auxiliary.model` | Structured helper calls such as extraction, repair, merging, dedupe, and fix evaluation. |
+| `defaults.synthesis.model` | Post-analysis synthesis and consolidation. Falls back to `defaults.auxiliary.model` when unset. |
+
+```toml title="warden.toml"
+[defaults]
+runtime = "pi"
+
+[defaults.agent]
+model = "anthropic/claude-sonnet-4-6"
+maxTurns = 30
+
+[defaults.auxiliary]
+model = "anthropic/claude-haiku-4-5"
+maxRetries = 3
+
+[defaults.synthesis]
+model = "anthropic/claude-opus-4-5"
+```
+
+`defaults.model` and `defaults.maxTurns` are legacy shorthand for the agent
+lane. Prefer `defaults.agent.model` and `defaults.agent.maxTurns` in new config.
+
+## Overrides
+
+Skills and triggers can override the main agent model:
+
+```toml title="warden.toml"
+[[skills]]
+name = "security-review"
+model = "anthropic/claude-opus-4-5"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize"]
+model = "anthropic/claude-sonnet-4-6"
+```
+
+The CLI `--model` flag and `WARDEN_MODEL` environment variable are fallbacks.
+They only apply when the resolved skill or trigger path does not set a model.
+
+Main agent model precedence, from highest to lowest:
+
+| Source | Notes |
+| --- | --- |
+| `skills.triggers.model` | Most specific. Applies to one trigger. |
+| `skills.model` | Applies to one skill. |
+| `defaults.agent.model` | Preferred global default. |
+| `defaults.model` | Legacy global default. |
+| `--model` | CLI fallback. |
+| `WARDEN_MODEL` | Environment fallback. |
+| SDK/runtime default | Used when no explicit model is set. |
+
+Auxiliary and synthesis models only come from `[defaults.auxiliary]` and
+`[defaults.synthesis]`. They do not inherit skill or trigger `model` overrides.
+
+## Generated Skill Commands
+
+`warden build` and `warden improve` use the synthesis lane because they generate
+or revise skill artifacts. Their model fallback order is:
+
+| Source | Notes |
+| --- | --- |
+| `defaults.synthesis.model` | Preferred generated-skill model. |
+| `defaults.auxiliary.model` | Fallback when synthesis is unset. |
+| `--model` | CLI fallback for this command. |
+| `WARDEN_MODEL` | Environment fallback. |
+| SDK/runtime default | Used when no explicit model is set. |

--- a/packages/docs/src/content/docs/config/output.mdx
+++ b/packages/docs/src/content/docs/config/output.mdx
@@ -4,7 +4,8 @@ description: Configure reporting, failure behavior, and inherited defaults.
 editUrl: false
 ---
 
-Output settings control what gets reported and when Warden should fail.
+Output settings control what gets reported and when Warden should fail. Model
+and runtime defaults live under [Models and Runtimes](/config/models/).
 
 ## Output Fields
 
@@ -32,24 +33,9 @@ override them.
 
 ```toml title="warden.toml"
 [defaults]
-runtime = "pi"
-model = "anthropic/claude-sonnet-4-6"
-maxTurns = 30
 failOn = "high"
 reportOn = "medium"
 requestChanges = false
 failCheck = false
 ignorePaths = ["**/vendor/**", "**/node_modules/**"]
-
-[defaults.auxiliary]
-model = "anthropic/claude-haiku-4-5"
-
-[defaults.synthesis]
-model = "anthropic/claude-opus-4-5"
 ```
-
-Model precedence is: trigger, skill, defaults, CLI flag, then `WARDEN_MODEL`.
-Most specific wins.
-
-`defaults.synthesis.model` falls back to `defaults.auxiliary.model` when it is
-not set.

--- a/packages/docs/src/content/docs/config/skills.mdx
+++ b/packages/docs/src/content/docs/config/skills.mdx
@@ -16,7 +16,7 @@ Skills define what Warden analyzes and when.
 | `failOn` | Minimum severity to fail: `critical`, `high`, `medium`, `low`, `info`, `off`. |
 | `reportOn` | Minimum severity to report. |
 | `remote` | GitHub repository for remote skills: `owner/repo` or `owner/repo@sha`. |
-| `model` | Optional model override. |
+| `model` | Override the main agent model for this skill. See [Models and Runtimes](/config/models/). |
 | `maxTurns` | Optional max agentic turns per hunk. |
 
 ## Filters

--- a/packages/docs/src/content/docs/config/triggers.mdx
+++ b/packages/docs/src/content/docs/config/triggers.mdx
@@ -5,7 +5,7 @@ editUrl: false
 ---
 
 Triggers define when a skill runs. Each skill can have one or more triggers.
-Triggers can override output and model settings.
+Triggers can override output settings and the main agent model.
 
 ## Fields
 
@@ -19,7 +19,7 @@ Triggers can override output and model settings.
 | `reportOnSuccess` | Override report-on-success behavior. |
 | `requestChanges` | Override `REQUEST_CHANGES` behavior. |
 | `failCheck` | Override check failure behavior. |
-| `model` | Override model for this trigger. |
+| `model` | Override the main agent model for this trigger. See [Models and Runtimes](/config/models/). |
 | `maxTurns` | Override max agentic turns. |
 
 ## Pull Request Actions

--- a/packages/docs/src/content/docs/github/org.mdx
+++ b/packages/docs/src/content/docs/github/org.mdx
@@ -14,7 +14,7 @@ Go to **Organization Settings > Secrets and variables > Actions**, then add:
 
 | Secret | Purpose |
 | --- | --- |
-| `WARDEN_MODEL` | Pi model selector for all repos using the shared workflow. |
+| `WARDEN_MODEL` | Fallback model selector for repos that do not set a model in `warden.toml`. |
 | `WARDEN_OPENAI_API_KEY` | OpenAI key for OpenAI Pi models. |
 | `WARDEN_ANTHROPIC_API_KEY` | Anthropic key for Anthropic Pi models or Claude runtime. |
 | `WARDEN_SENTRY_DSN` | Optional telemetry DSN. |

--- a/packages/docs/src/content/docs/github/repository.mdx
+++ b/packages/docs/src/content/docs/github/repository.mdx
@@ -19,11 +19,12 @@ This creates:
 
 ## Secrets
 
-Add the provider credentials used by your configured model:
+Add the provider credentials used by your configured model. `WARDEN_MODEL` is a
+fallback when `warden.toml` does not set a model; see [Models and Runtimes](/config/models/).
 
 | Secret | Purpose |
 | --- | --- |
-| `WARDEN_MODEL` | Pi model selector. |
+| `WARDEN_MODEL` | Fallback model selector. |
 | `WARDEN_OPENAI_API_KEY` | OpenAI key for OpenAI Pi models. |
 | `WARDEN_ANTHROPIC_API_KEY` | Anthropic key for Anthropic Pi models or Claude runtime. |
 | `WARDEN_SENTRY_DSN` | Optional telemetry DSN. |
@@ -45,4 +46,3 @@ Add the generated app secrets:
 | `WARDEN_PRIVATE_KEY` | Full PEM private key contents. |
 
 Then use `actions/create-github-app-token` and pass the app token to Warden.
-

--- a/packages/docs/src/content/docs/quickstart.mdx
+++ b/packages/docs/src/content/docs/quickstart.mdx
@@ -26,7 +26,8 @@ export WARDEN_ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 CI environments require the same provider credentials as repository or
-organization secrets.
+organization secrets. See [Models and Runtimes](/config/models/) for config
+defaults, per-skill overrides, and Claude runtime selection.
 
 ## Initialize
 

--- a/packages/docs/src/styles/docs.css
+++ b/packages/docs/src/styles/docs.css
@@ -1,0 +1,21 @@
+.sl-markdown-content table {
+  table-layout: fixed;
+  white-space: normal;
+}
+
+.sl-markdown-content th,
+.sl-markdown-content td {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.sl-markdown-content th:first-child,
+.sl-markdown-content td:first-child {
+  width: 9rem;
+}
+
+.sl-markdown-content th code,
+.sl-markdown-content td code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}


### PR DESCRIPTION
Add a dedicated Models and Runtimes reference for Warden config so model selection, runtime selection, model lanes, and precedence are described in one place. Existing CLI, GitHub setup, config, and llms.txt references now point back to that source of truth instead of repeating partial fallback rules.

**Model and Runtime Reference**

The new page documents Pi provider/model selectors, Claude runtime behavior, main agent model precedence, auxiliary and synthesis model lanes, and generated-skill command model fallback order.

**Docs Table Wrapping**

Starlight markdown tables now wrap long cell contents and inline code on narrow screens, fixing mobile overflow on table-heavy pages like /config/runner and /config/models.