### PR TITLE
ci: add docs build verification workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Docs
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, "release/*"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Build docs
+        run: pnpm --filter dex-docs build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a standalone `docs.yml` workflow so a broken `dex-docs` Astro build can't slip into `main` unnoticed.

## What

New `.github/workflows/docs.yml` that mirrors the setup conventions of `ci.yml`:

- Triggers on push to `main`/`release/*` and PRs to `main`
- Same toolchain: pnpm, Node 24, frozen lockfile, pnpm cache
- Runs `pnpm build` first (docs depend on `@sentry/warden` via `workspace:*`)
- Then `pnpm --filter dex-docs build` to compile the Astro site
- Only requests `contents: read`

## Why

`packages/docs` was never verified in CI. `lint-staged` builds it locally on `.astro` changes, but nothing caught regressions server-side. Splitting it into its own workflow keeps it fully parallel with the main CI job rather than adding sequential time to the existing build.

Verified locally:

```
pnpm install --frozen-lockfile
pnpm build
pnpm --filter dex-docs build
# → 32 page(s) built in 4.74s
```

Closes #344.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0ACFA5JBDX/p1779393601500979?thread_ts=1779393601.500979&cid=C0ACFA5JBDX)

<div><a href="https://cursor.com/agents/bc-3f2f12c5-b140-505f-b49f-9bda82df87ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f2f12c5-b140-505f-b49f-9bda82df87ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

