### PR TITLE
ci(evals): only trigger on eval path changes

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -16,8 +16,6 @@ on:
     paths:
       - "packages/evals/**"
       - ".github/workflows/evals.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
@@ -35,8 +33,6 @@ jobs:
             const evalPaths = [
               'packages/evals/',
               '.github/workflows/evals.yml',
-              'package.json',
-              'pnpm-lock.yaml',
             ];
 
             function setRun(run, reason) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Stop running the Evals workflow for PRs that only touch `package.json` or `pnpm-lock.yaml`.

## Why

#345 (a `@sentry/starlight-theme` bump that only modified the docs lockfile entries) triggered the full evals suite. The lockfile and root `package.json` were listed as eval paths in two places:

1. `on.push.paths` — any merge to `main` touching the lockfile would run evals on push.
2. The `evalPaths` array inside the `should-run` job — any PR touching those files matched and ran evals.

## How

Removed `package.json` and `pnpm-lock.yaml` from both lists. Evals now run only when:

- `packages/evals/**` changes,
- `.github/workflows/evals.yml` changes,
- the `run-evals` label is applied to a PR, or
- the workflow is manually dispatched.

The `pull_request` trigger stays broad (no `paths:` filter) on purpose. GitHub applies path filters to every event type in a trigger block, so adding `paths` there would silently drop `labeled` events on non-eval PRs and break the `run-evals` escape hatch. The `should-run` job is cheap (single script step, no checkout) so the broad trigger costs almost nothing.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0ACFA5JBDX/p1779397757902829?thread_ts=1779397757.902829&cid=C0ACFA5JBDX)

<div><a href="https://cursor.com/agents/bc-375a4abc-6472-5d15-9491-5ba9fecc1757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-375a4abc-6472-5d15-9491-5ba9fecc1757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

