### PR TITLE
fix(action): Report skipped PR trigger checks

### DIFF
--- a/packages/docs/src/content/docs/github/workflow.mdx
+++ b/packages/docs/src/content/docs/github/workflow.mdx
@@ -92,6 +92,16 @@ If the target repo also has a root `warden.toml`, Warden loads it in the same
 run. Repo-local config can add skills and repo-local defaults, but it does not
 weaken org-enforced base skills.
 
+## Required Status Checks
+
+If Warden is a required status check, require the core `warden` check or a
+per-skill check like `warden: security-review`.
+
+Keep workflow-level `paths` and `paths-ignore` filters off required Warden
+workflows. Let Warden start, then let `warden.toml` decide which triggers match.
+For each configured pull request trigger, Warden creates a check run. Triggers
+that do not actually run for the current event complete as neutral.
+
 ## Action Inputs
 
 <dl class="sentry-key-value-list">

--- a/src/action/workflow/__fixtures__/action-mismatch/warden.toml
+++ b/src/action/workflow/__fixtures__/action-mismatch/warden.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[skills]]
+name = "labeled-skill"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["labeled"]

--- a/src/action/workflow/__fixtures__/partial-match/warden.toml
+++ b/src/action/workflow/__fixtures__/partial-match/warden.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[[skills]]
+name = "skipped-skill"
+paths = ["docs/**"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize"]
+
+[[skills]]
+name = "run-skill"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize"]

--- a/src/action/workflow/pr-workflow.test.ts
+++ b/src/action/workflow/pr-workflow.test.ts
@@ -12,10 +12,12 @@ import type { ExistingComment } from '../../output/dedup.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const FIXTURES_DIR = join(__dirname, '__fixtures__');
+const ACTION_MISMATCH_FIXTURES_DIR = join(FIXTURES_DIR, 'action-mismatch');
 const BASE_ONLY_FIXTURES_DIR = join(FIXTURES_DIR, 'base-only');
 const NO_MATCH_FIXTURES_DIR = join(FIXTURES_DIR, 'no-match');
 const NO_MATCH_RUNTIME_CLAUDE_FIXTURES_DIR = join(FIXTURES_DIR, 'no-match-runtime-claude');
 const NO_CONFIG_FIXTURES_DIR = join(FIXTURES_DIR, 'no-config');
+const PARTIAL_MATCH_FIXTURES_DIR = join(FIXTURES_DIR, 'partial-match');
 const RUNTIME_CLAUDE_FIXTURES_DIR = join(FIXTURES_DIR, 'runtime-claude');
 const EMPTY_AUXILIARY_MODEL_FIXTURES_DIR = join(FIXTURES_DIR, 'empty-auxiliary-model');
 const LAYERED_AUXILIARY_MODEL_FIXTURES_DIR = join(FIXTURES_DIR, 'layered-auxiliary-model');
@@ -150,6 +152,7 @@ function createMockOctokit(options: MockOctokitOptions = {}): Octokit {
   ];
 
   const files = options.prFiles ?? defaultFiles;
+  let nextCheckRunId = 1;
 
   return {
     paginate: vi.fn(() => Promise.resolve(files)),
@@ -162,7 +165,12 @@ function createMockOctokit(options: MockOctokitOptions = {}): Octokit {
     },
     checks: {
       create: vi.fn(() =>
-        Promise.resolve({ data: { id: 1, html_url: 'https://example.com/check' } })
+        Promise.resolve({
+          data: {
+            id: nextCheckRunId++,
+            html_url: `https://example.com/check/${nextCheckRunId - 1}`,
+          },
+        })
       ),
       update: vi.fn(() => Promise.resolve({ data: {} })),
     },
@@ -468,7 +476,25 @@ describe('runPRWorkflow', () => {
 
       // Core check should still be updated even when workflow fails
       const updateCheck = vi.mocked(mockOctokit.checks.update);
-      expect(updateCheck).toHaveBeenCalled();
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 2,
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            title: 'Skill execution failed',
+            summary: expect.stringContaining('Skill failed'),
+          }),
+        })
+      );
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 1,
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            summary: expect.stringContaining('| test-skill | 0 |'),
+          }),
+        })
+      );
     });
   });
 
@@ -486,6 +512,29 @@ describe('runPRWorkflow', () => {
 
       expect(mockSetFailed).toHaveBeenCalledWith(
         expect.stringContaining('Authentication not found')
+      );
+      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'warden: test-skill' })
+      );
+      expect(mockOctokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 2,
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            title: 'Skill execution failed',
+            summary: expect.stringContaining('Authentication not found'),
+          }),
+        })
+      );
+      expect(mockOctokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 1,
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            title: 'Warden failed',
+            summary: expect.stringContaining('Authentication not found'),
+          }),
+        })
       );
       expect(mockRunSkillTask).not.toHaveBeenCalled();
     });
@@ -558,6 +607,24 @@ describe('runPRWorkflow', () => {
       expect(mockSetFailed).not.toHaveBeenCalled();
       // Should not run any skills
       expect(mockRunSkillTask).not.toHaveBeenCalled();
+      // Should not run cleanup without a config scope
+      expect(mockFetchExistingComments).not.toHaveBeenCalled();
+      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'warden',
+          head_sha: 'abc123def456',
+        })
+      );
+      expect(mockOctokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 1,
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'No warden.toml found',
+            summary: expect.stringContaining('No warden.toml found. Skipping analysis.'),
+          }),
+        })
+      );
       // Should log a warning
       expect(consoleLogSpy).toHaveBeenCalledWith(
         '::warning::No warden.toml found. Skipping analysis.'
@@ -678,6 +745,129 @@ describe('runPRWorkflow', () => {
       expect(createCheck).toHaveBeenCalledWith(
         expect.objectContaining({
           name: expect.stringContaining('test-skill'),
+        })
+      );
+    });
+
+    it('creates and completes the core check when no triggers match', async () => {
+      mockFetchExistingComments.mockResolvedValue([]);
+
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs(),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        NO_MATCH_FIXTURES_DIR
+      );
+
+      const createCheck = vi.mocked(mockOctokit.checks.create);
+      const updateCheck = vi.mocked(mockOctokit.checks.update);
+
+      expect(createCheck).toHaveBeenCalledTimes(2);
+      expect(createCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          head_sha: 'abc123def456',
+          name: 'warden',
+        })
+      );
+      expect(createCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          head_sha: 'abc123def456',
+          name: 'warden: test-skill',
+        })
+      );
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 2,
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'Skipped',
+            summary: expect.stringContaining('Trigger did not run for this event.'),
+          }),
+        })
+      );
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 1,
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'No triggers matched',
+            summary: expect.stringContaining('No triggers matched for this event.'),
+          }),
+        })
+      );
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          output: expect.objectContaining({
+            summary: expect.stringContaining('0 skills analyzed'),
+          }),
+        })
+      );
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+    });
+
+    it('creates neutral checks for skipped triggers while running matched triggers', async () => {
+      mockRunSkillTask.mockResolvedValue({
+        name: 'run-skill',
+        report: createSkillReport({ skill: 'run-skill' }),
+      });
+
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs(),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        PARTIAL_MATCH_FIXTURES_DIR
+      );
+
+      const createCheck = vi.mocked(mockOctokit.checks.create);
+      const updateCheck = vi.mocked(mockOctokit.checks.update);
+
+      expect(mockRunSkillTask).toHaveBeenCalledTimes(1);
+      expect(mockRunSkillTask.mock.calls[0]![0].displayName).toBe('run-skill');
+      expect(createCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'warden: skipped-skill' })
+      );
+      expect(createCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'warden: run-skill' })
+      );
+      expect(updateCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'Skipped',
+            summary: expect.stringContaining('Trigger did not run for this event.'),
+          }),
+        })
+      );
+    });
+
+    it('creates neutral checks for triggers skipped by pull request action', async () => {
+      mockFetchExistingComments.mockResolvedValue([]);
+
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs(),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        ACTION_MISMATCH_FIXTURES_DIR
+      );
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'warden: labeled-skill' })
+      );
+      expect(mockOctokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'Skipped',
+            summary: expect.stringContaining('Trigger did not run for this event.'),
+          }),
         })
       );
     });
@@ -1006,6 +1196,16 @@ describe('runPRWorkflow', () => {
 
       expect(mockSetFailed).toHaveBeenCalledWith(
         expect.stringContaining('Authentication not found')
+      );
+      expect(mockOctokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 1,
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            title: 'Warden failed',
+            summary: expect.stringContaining('Authentication not found'),
+          }),
+        })
       );
       expect(mockEvaluateFixAttempts).not.toHaveBeenCalled();
       expect(mockRunSkillTask).not.toHaveBeenCalled();

--- a/src/action/workflow/pr-workflow.ts
+++ b/src/action/workflow/pr-workflow.ts
@@ -43,9 +43,13 @@ import { canUseRuntimeAuth } from '../../sdk/extract.js';
 import { ProviderFailureCircuitBreaker } from '../../sdk/circuit-breaker.js';
 import {
   createCoreCheck,
+  createSkillCheck,
+  failSkillCheck,
   updateCoreCheck,
+  updateSkillCheck,
   buildCoreSummaryData,
   determineCoreConclusion,
+  type CheckOptions,
 } from '../checks/manager.js';
 import {
   setOutput,
@@ -71,6 +75,8 @@ interface InitResult {
   runnerConcurrency?: number;
   auxiliaryOptions: AuxiliaryWorkflowOptions;
   matchedTriggers: ResolvedTrigger[];
+  skippedTriggers: ResolvedTrigger[];
+  skipCoreCheck?: SkippedCoreCheck;
 }
 
 interface GitHubSetupResult {
@@ -91,6 +97,30 @@ interface AuxiliaryWorkflowOptions {
   runtime?: RuntimeName;
   model?: string;
   maxRetries?: number;
+}
+
+interface SkippedCoreCheck {
+  title: string;
+  message: string;
+}
+
+function reportsPullRequestCheck(trigger: ResolvedTrigger, context: EventContext): boolean {
+  return (
+    Boolean(context.pullRequest) &&
+    (trigger.type === 'pull_request' || trigger.type === '*')
+  );
+}
+
+function checkOptionsForPullRequest(context: EventContext): CheckOptions | undefined {
+  if (!context.pullRequest) {
+    return undefined;
+  }
+
+  return {
+    owner: context.repository.owner,
+    repo: context.repository.name,
+    headSha: context.pullRequest.headSha,
+  };
 }
 
 function resolveWorkflowAuxiliaryOptions(layered: LoadedLayeredConfig): AuxiliaryWorkflowOptions {
@@ -149,7 +179,7 @@ async function initializeWorkflow(
   eventName: string,
   eventPath: string,
   repoPath: string
-): Promise<InitResult | null> {
+): Promise<InitResult> {
   let eventPayload: unknown;
   try {
     eventPayload = JSON.parse(readFileSync(eventPath, 'utf-8'));
@@ -202,6 +232,9 @@ async function initializeWorkflow(
     skillRootsByName = buildSkillRootsByName(repoPath, layered, inputs.baseSkillRoot);
     const resolvedTriggers = resolveLayeredSkillConfigs(layered, undefined, skillRootsByName);
     const matchedTriggers = resolvedTriggers.filter((t) => matchTrigger(t, context, 'github'));
+    const skippedTriggers = resolvedTriggers.filter(
+      (t) => reportsPullRequestCheck(t, context) && !matchedTriggers.includes(t)
+    );
 
     if (matchedTriggers.length > 0) {
       logGroup('Matched triggers');
@@ -213,15 +246,26 @@ async function initializeWorkflow(
       console.log('No triggers matched for this event');
     }
 
-    return { context, runnerConcurrency, auxiliaryOptions, matchedTriggers };
+    return { context, runnerConcurrency, auxiliaryOptions, matchedTriggers, skippedTriggers };
   } catch (error) {
     if (
       error instanceof ConfigLoadError &&
       error.message.includes('not found') &&
       !inputs.baseConfigPath
     ) {
-      console.log('::warning::No warden.toml found. Skipping analysis.');
-      return null;
+      const message = 'No warden.toml found. Skipping analysis.';
+      console.log(`::warning::${message}`);
+      return {
+        context,
+        runnerConcurrency,
+        auxiliaryOptions,
+        matchedTriggers: [],
+        skippedTriggers: [],
+        skipCoreCheck: {
+          title: 'No warden.toml found',
+          message,
+        },
+      };
     }
     throw error;
   }
@@ -601,7 +645,8 @@ async function finalizeWorkflow(
   reports: SkillReport[],
   shouldFailAction: boolean,
   failureReasons: string[],
-  canResolveStale: boolean
+  canResolveStale: boolean,
+  triggerErrors: string[]
 ): Promise<void> {
   // Dismiss previous CHANGES_REQUESTED if all blocking issues are resolved.
   // Requires: all triggers succeeded, current run would not request changes,
@@ -650,7 +695,10 @@ async function finalizeWorkflow(
   if (coreCheckId && context.pullRequest) {
     try {
       const summaryData = buildCoreSummaryData(results, reports);
-      const coreConclusion = determineCoreConclusion(shouldFailAction, outputs.findingsCount);
+      const coreConclusion = determineCoreConclusion(
+        shouldFailAction || triggerErrors.length > 0,
+        outputs.findingsCount
+      );
 
       await updateCoreCheck(octokit, coreCheckId, summaryData, coreConclusion, {
         owner: context.repository.owner,
@@ -667,6 +715,162 @@ async function finalizeWorkflow(
   }
 
   logAction(`Analysis complete: ${outputs.findingsCount} total findings`);
+}
+
+/** Complete the core check for a PR run that intentionally skipped analysis. */
+async function completeSkippedCoreCheck(
+  octokit: Octokit,
+  context: EventContext,
+  coreCheckId: number | undefined,
+  skipped: SkippedCoreCheck
+): Promise<void> {
+  const options = checkOptionsForPullRequest(context);
+  if (!coreCheckId || !options) {
+    return;
+  }
+
+  try {
+    await updateCoreCheck(
+      octokit,
+      coreCheckId,
+      {
+        ...buildCoreSummaryData([], []),
+        title: skipped.title,
+        message: skipped.message,
+      },
+      'neutral',
+      options
+    );
+  } catch (error) {
+    Sentry.captureException(error, { tags: { operation: 'update_core_check_skipped' } });
+    warnAction(`Failed to update core check: ${error}`);
+  }
+}
+
+/** Complete per-skill checks for configured PR triggers that did not run. */
+async function completeSkippedSkillChecks(
+  octokit: Octokit,
+  context: EventContext,
+  skippedTriggers: ResolvedTrigger[]
+): Promise<void> {
+  const options = checkOptionsForPullRequest(context);
+  if (!options || skippedTriggers.length === 0) {
+    return;
+  }
+
+  for (const trigger of skippedTriggers) {
+    try {
+      const skillCheck = await createSkillCheck(octokit, trigger.skill, options);
+
+      await updateSkillCheck(
+        octokit,
+        skillCheck.checkRunId,
+        {
+          skill: trigger.skill,
+          summary: 'Trigger did not run for this event.',
+          findings: [],
+        },
+        {
+          ...options,
+          failOn: trigger.failOn,
+          reportOn: trigger.reportOn,
+          minConfidence: trigger.minConfidence ?? 'medium',
+          failCheck: trigger.failCheck,
+          conclusion: 'neutral',
+          title: 'Skipped',
+        }
+      );
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          operation: 'update_skipped_skill_check',
+          trigger_name: trigger.name,
+          skill_name: trigger.skill,
+        },
+      });
+      warnAction(`Failed to update skipped skill check for ${trigger.skill}: ${error}`);
+    }
+  }
+}
+
+/**
+ * Fail per-skill checks when workflow setup fails before triggers are dispatched.
+ */
+async function failUndispatchedSkillChecks(
+  octokit: Octokit,
+  context: EventContext,
+  triggers: ResolvedTrigger[],
+  error: unknown
+): Promise<void> {
+  const options = checkOptionsForPullRequest(context);
+  if (!options || triggers.length === 0) {
+    return;
+  }
+
+  for (const trigger of triggers) {
+    try {
+      const skillCheck = await createSkillCheck(octokit, trigger.skill, options);
+
+      await failSkillCheck(octokit, skillCheck.checkRunId, error, options);
+    } catch (checkError) {
+      Sentry.captureException(checkError, {
+        tags: {
+          operation: 'fail_undispatched_skill_check',
+          trigger_name: trigger.name,
+          skill_name: trigger.skill,
+        },
+      });
+      warnAction(`Failed to mark skill check as failed for ${trigger.skill}: ${checkError}`);
+    }
+  }
+}
+
+/**
+ * Mark the core check failed when an early PR workflow phase fails after check creation.
+ */
+async function failCoreCheck(
+  octokit: Octokit,
+  context: EventContext,
+  coreCheckId: number | undefined,
+  error: unknown
+): Promise<void> {
+  const options = checkOptionsForPullRequest(context);
+  if (!coreCheckId || !options) {
+    return;
+  }
+
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  try {
+    await updateCoreCheck(
+      octokit,
+      coreCheckId,
+      {
+        ...buildCoreSummaryData([], []),
+        title: 'Warden failed',
+        message: `Error: ${errorMessage}`,
+      },
+      'failure',
+      options
+    );
+  } catch (checkError) {
+    Sentry.captureException(checkError, { tags: { operation: 'fail_core_check' } });
+    warnAction(`Failed to mark core check as failed: ${checkError}`);
+  }
+}
+
+async function runOrFailCore<T>(
+  octokit: Octokit,
+  context: EventContext,
+  coreCheckId: number | undefined,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    await failCoreCheck(octokit, context, coreCheckId, error);
+    throw error;
+  }
 }
 
 /**
@@ -757,24 +961,14 @@ export async function runPRWorkflow(
         () => initializeWorkflow(octokit, inputs, eventName, eventPath, repoPath),
       );
 
-      if (!initResult) {
-        setOutput('findings-count', 0);
-        setOutput('high-count', 0);
-        setOutput('summary', 'No warden.toml found');
-        try {
-          const fullName = process.env['GITHUB_REPOSITORY'] ?? '';
-          const [o = '', n = ''] = fullName.split('/');
-          writeFindingsOutput([], {
-            eventType: 'pull_request',
-            action: '',
-            repository: { owner: o, name: n, fullName, defaultBranch: '' },
-            repoPath,
-          });
-        } catch { /* non-fatal */ }
-        return;
-      }
-
-      const { context, runnerConcurrency, auxiliaryOptions, matchedTriggers } = initResult;
+      const {
+        context,
+        runnerConcurrency,
+        auxiliaryOptions,
+        matchedTriggers,
+        skippedTriggers,
+        skipCoreCheck,
+      } = initResult;
       span.setAttribute('warden.trigger.count', matchedTriggers.length);
 
       // Set Sentry context after building event context
@@ -801,64 +995,96 @@ export async function runPRWorkflow(
         'trace.id': traceId,
       });
 
-      if (matchedTriggers.length === 0) {
-        await cleanupOrphanedComments(
-          octokit,
-          context,
-          inputs,
-          auxiliaryOptions
-        );
-        setOutput('findings-count', 0);
-        setOutput('high-count', 0);
-        setOutput('summary', 'No triggers matched');
-        try { writeFindingsOutput([], context); } catch { /* non-fatal */ }
-        return;
-      }
-
       const { coreCheckId, previousReviewInfo } = await Sentry.startSpan(
         { op: 'workflow.setup', name: 'setup github state' },
         () => setupGitHubState(octokit, context),
       );
 
-      const results = await Sentry.startSpan(
-        {
-          op: 'workflow.execute',
-          name: 'execute triggers',
-          attributes: { 'warden.trigger.count': matchedTriggers.length },
-        },
-        () => executeAllTriggers(matchedTriggers, octokit, context, runnerConcurrency, inputs),
-      );
+      await completeSkippedSkillChecks(octokit, context, skippedTriggers);
 
-      const reviewPhase = await Sentry.startSpan(
-        { op: 'workflow.review', name: 'post reviews' },
-        () => postReviewsAndTrackFailures(octokit, context, results, inputs, auxiliaryOptions),
+      if (skipCoreCheck) {
+        setOutput('findings-count', 0);
+        setOutput('high-count', 0);
+        setOutput('summary', skipCoreCheck.title);
+        try { writeFindingsOutput([], context); } catch { /* non-fatal */ }
+        await completeSkippedCoreCheck(octokit, context, coreCheckId, skipCoreCheck);
+        return;
+      }
+
+      if (matchedTriggers.length === 0) {
+        await runOrFailCore(octokit, context, coreCheckId, async () => {
+          await cleanupOrphanedComments(
+            octokit,
+            context,
+            inputs,
+            auxiliaryOptions
+          );
+          setOutput('findings-count', 0);
+          setOutput('high-count', 0);
+          setOutput('summary', 'No triggers matched');
+          try { writeFindingsOutput([], context); } catch { /* non-fatal */ }
+          await completeSkippedCoreCheck(octokit, context, coreCheckId, {
+            title: 'No triggers matched',
+            message: 'No triggers matched for this event.',
+          });
+        });
+        return;
+      }
+
+      let results: TriggerResult[];
+      try {
+        results = await Sentry.startSpan(
+          {
+            op: 'workflow.execute',
+            name: 'execute triggers',
+            attributes: { 'warden.trigger.count': matchedTriggers.length },
+          },
+          () => executeAllTriggers(matchedTriggers, octokit, context, runnerConcurrency, inputs),
+        );
+      } catch (error) {
+        await failUndispatchedSkillChecks(octokit, context, matchedTriggers, error);
+        await failCoreCheck(octokit, context, coreCheckId, error);
+        throw error;
+      }
+
+      const reviewPhase = await runOrFailCore(
+        octokit,
+        context,
+        coreCheckId,
+        () => Sentry.startSpan(
+          { op: 'workflow.review', name: 'post reviews' },
+          () => postReviewsAndTrackFailures(octokit, context, results, inputs, auxiliaryOptions),
+        ),
       );
 
       const triggerErrors = collectTriggerErrors(results);
-      handleTriggerErrors(triggerErrors, matchedTriggers.length);
-
       const canResolveStale = shouldResolveStaleComments(results);
       const allFindings = reviewPhase.reports.flatMap((r) => r.findings);
       span.setAttribute('warden.finding.count', allFindings.length);
 
-      await Sentry.startSpan(
-        { op: 'workflow.resolve', name: 'resolve stale comments' },
-        async (resolveSpan) => {
-          const resolutionResult = await evaluateFixesAndResolveStale(
-            octokit, context, reviewPhase.fetchedComments,
-            allFindings, reviewPhase.activeWardenCommentIds,
-            canResolveStale, inputs.anthropicApiKey,
-            auxiliaryOptions,
-          );
-          resolveSpan.setAttribute(
-            'warden.feedback.auto_resolve.fix_eval_count',
-            resolutionResult.autoResolvedByFixEvaluation
-          );
-          resolveSpan.setAttribute(
-            'warden.feedback.auto_resolve.stale_count',
-            resolutionResult.autoResolvedByStaleCheck
-          );
-        },
+      await runOrFailCore(
+        octokit,
+        context,
+        coreCheckId,
+        () => Sentry.startSpan(
+          { op: 'workflow.resolve', name: 'resolve stale comments' },
+          async (resolveSpan) => {
+            const resolutionResult = await evaluateFixesAndResolveStale(
+              octokit, context, reviewPhase.fetchedComments,
+              allFindings, reviewPhase.activeWardenCommentIds,
+              canResolveStale, inputs.anthropicApiKey,
+              auxiliaryOptions,
+            );
+            resolveSpan.setAttribute(
+              'warden.feedback.auto_resolve.fix_eval_count',
+              resolutionResult.autoResolvedByFixEvaluation
+            );
+            resolveSpan.setAttribute(
+              'warden.feedback.auto_resolve.stale_count',
+              resolutionResult.autoResolvedByStaleCheck
+            );
+          },
+        ),
       );
 
       await finalizeWorkflow(
@@ -866,7 +1092,10 @@ export async function runPRWorkflow(
         results, reviewPhase.reports,
         reviewPhase.shouldFailAction, reviewPhase.failureReasons,
         canResolveStale,
+        triggerErrors,
       );
+
+      handleTriggerErrors(triggerErrors, matchedTriggers.length);
     },
   );
 }

--- a/src/output/github-checks.ts
+++ b/src/output/github-checks.ts
@@ -41,12 +41,20 @@ export interface UpdateSkillCheckOptions extends CheckOptions {
   minConfidence?: ConfidenceThreshold;
   /** Whether to fail the check run when findings exceed failOn. Default: false */
   failCheck?: boolean;
+  /** Optional check conclusion override for intentional no-op runs. */
+  conclusion?: CheckConclusion;
+  /** Optional check output title override. */
+  title?: string;
 }
 
 /**
  * Summary data for the core warden check.
  */
 export interface CoreCheckSummaryData {
+  /** Optional check output title override. */
+  title?: string;
+  /** Optional message shown when there are no findings to summarize. */
+  message?: string;
   totalSkills: number;
   totalFindings: number;
   findingsBySeverity: Record<Severity, number>;
@@ -217,16 +225,17 @@ export async function updateSkillCheck(
 ): Promise<void> {
   // Conclusion is based on confidence-filtered findings (consistent with CLI path)
   const filteredForConclusion = filterFindings(report.findings, undefined, options.minConfidence);
-  const conclusion = determineConclusion(filteredForConclusion, options.failOn, options.failCheck);
+  const conclusion =
+    options.conclusion ?? determineConclusion(filteredForConclusion, options.failOn, options.failCheck);
   // Annotations are filtered by reportOn threshold and confidence
   const annotations = findingsToAnnotations(report.findings, options.reportOn, options.minConfidence);
 
   const summary = buildSkillSummary(report);
 
   const filteredCount = filteredForConclusion.length;
-  const title = filteredCount === 0
+  const title = options.title ?? (filteredCount === 0
     ? 'No issues'
-    : `${filteredCount} issue${filteredCount === 1 ? '' : 's'}`;
+    : `${filteredCount} issue${filteredCount === 1 ? '' : 's'}`);
 
   await octokit.checks.update({
     owner: options.owner,
@@ -303,9 +312,11 @@ export async function updateCoreCheck(
 ): Promise<void> {
   const summary = buildCoreSummary(summaryData);
 
-  const title = summaryData.totalFindings === 0
-    ? 'No issues'
-    : `${summaryData.totalFindings} issue${summaryData.totalFindings === 1 ? '' : 's'}`;
+  const title = summaryData.title ?? (
+    summaryData.totalFindings === 0
+      ? 'No issues'
+      : `${summaryData.totalFindings} issue${summaryData.totalFindings === 1 ? '' : 's'}`
+  );
 
   await octokit.checks.update({
     owner: options.owner,
@@ -438,7 +449,7 @@ function buildCoreSummary(data: CoreCheckSummaryData): string {
       lines.push(`*...and ${remaining} more*`, '');
     }
   } else {
-    lines.push('No issues found.', '');
+    lines.push(data.message ? escapeHtml(data.message) : 'No issues found.', '');
   }
 
   // Skills table in collapsible section


### PR DESCRIPTION
Ensure Warden reports a terminal check for every configured pull request trigger, even when the trigger is skipped by action or path filters. Skipped trigger checks complete as neutral so per-skill required checks like `warden: security-review` are present without running analysis.

**Core Check Completion**

Missing configuration and no-match PR runs now complete the core `warden` check as neutral instead of returning before reporting status. Trigger execution errors now cause the aggregate check to fail before the action exits.

**Skipped Trigger Checks**

The PR workflow creates neutral per-skill checks for skipped PR-capable triggers while still running matched triggers normally. This keeps branch protection reliable without broadening what Warden analyzes.

Fixes #351