### PR TITLE
feat(triggers): Support non-draft pull request filters

### DIFF
--- a/packages/docs/src/content/docs/config/triggers.mdx
+++ b/packages/docs/src/content/docs/config/triggers.mdx
@@ -26,6 +26,13 @@ Triggers can override output settings and the main agent model.
   </div>
   <div>
     <dt>
+      <code>draft</code>
+      <span class="sentry-property-meta">boolean</span>
+    </dt>
+    <dd>Draft state for <code>pull_request</code> triggers. Set <code>false</code> to run only on non-draft PRs.</dd>
+  </div>
+  <div>
+    <dt>
       <code>failOn</code>
       <span class="sentry-property-meta">severity</span>
     </dt>
@@ -98,6 +105,7 @@ name = "security-review"
 [[skills.triggers]]
 type = "pull_request"
 actions = ["opened", "synchronize"]
+draft = false
 ```
 
 ## Schedule Triggers

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -280,6 +280,20 @@ describe('resolveSkillConfigs', () => {
     expect(resolved?.filters.ignorePaths).toEqual(['*.test.ts']);
   });
 
+  it('preserves trigger draft filters', () => {
+    const config: WardenConfig = {
+      version: 1,
+      skills: [{
+        name: 'test-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened'], draft: false }],
+      }],
+    };
+
+    const [resolved] = resolveSkillConfigs(config);
+
+    expect(resolved?.draft).toBe(false);
+  });
+
   describe('ignorePaths merging', () => {
     it('uses defaults.ignorePaths when skill has none', () => {
       const config: WardenConfig = {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -342,6 +342,8 @@ export interface ResolvedTrigger {
   type: TriggerType | '*';
   /** Actions for pull_request triggers */
   actions?: string[];
+  /** Draft state for pull_request triggers. false means non-draft only. */
+  draft?: boolean;
   /** Remote repository reference */
   remote?: string;
   /** Repository root to use when resolving local skill names or paths */
@@ -493,6 +495,7 @@ export function resolveSkillConfigs(
           skill: skill.name,
           type: trigger.type,
           actions: trigger.actions,
+          draft: trigger.draft,
           remote: skill.remote,
           ...skillSource,
           filters,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -85,6 +85,8 @@ export const SkillTriggerSchema = z.object({
   type: TriggerTypeSchema,
   /** Actions to trigger on (only for pull_request type) */
   actions: z.array(z.string()).min(1).optional(),
+  /** Match pull_request triggers by draft state. Set false to run only on non-draft PRs. */
+  draft: z.boolean().optional(),
   // Per-trigger overrides (flattened output fields)
   failOn: SeverityThresholdSchema.optional(),
   reportOn: SeverityThresholdSchema.optional(),

--- a/src/config/writer.test.ts
+++ b/src/config/writer.test.ts
@@ -20,6 +20,17 @@ describe('generateSkillToml', () => {
     expect(result).toContain('actions = ["opened", "synchronize"]');
   });
 
+  it('generates pull request draft filters', () => {
+    const result = generateSkillToml({
+      name: 'test-skill',
+      triggers: [
+        { type: 'pull_request', actions: ['opened'], draft: false },
+      ],
+    });
+
+    expect(result).toContain('draft = false');
+  });
+
   it('includes remote field when present', () => {
     const skill: SkillConfig = {
       name: 'security-review',

--- a/src/config/writer.ts
+++ b/src/config/writer.ts
@@ -71,6 +71,10 @@ export function generateSkillToml(skill: SkillConfig): string {
         lines.push(`actions = [${actionsStr}]`);
       }
 
+      if (trigger.draft !== undefined) {
+        lines.push(`draft = ${trigger.draft}`);
+      }
+
       // Trigger-level overrides
       if (trigger.model) {
         lines.push(`model = "${trigger.model}"`);

--- a/src/event/context.test.ts
+++ b/src/event/context.test.ts
@@ -30,6 +30,7 @@ describe('buildEventContext', () => {
       number: 1,
       title: 'Test PR',
       body: 'Test description',
+      draft: false,
       user: {
         login: 'test-user',
       },
@@ -79,6 +80,7 @@ describe('buildEventContext', () => {
     expect(context.pullRequest?.title).toBe('Test PR');
     expect(context.pullRequest?.body).toBe('Test description');
     expect(context.pullRequest?.author).toBe('test-user');
+    expect(context.pullRequest?.draft).toBe(false);
     expect(context.pullRequest?.baseBranch).toBe('main');
     expect(context.pullRequest?.headBranch).toBe('feature-branch');
     expect(context.pullRequest?.headSha).toBe('abc123def456');
@@ -108,6 +110,22 @@ describe('buildEventContext', () => {
     const context = await buildEventContext('pull_request', payloadWithNullBody, '/test/repo', mockOctokit);
 
     expect(context.pullRequest?.body).toBeNull();
+  });
+
+  it('captures draft pull request state', async () => {
+    const draftPayload = {
+      ...validPayload,
+      pull_request: {
+        ...validPayload.pull_request,
+        draft: true,
+      },
+    };
+
+    mockPaginate.mockResolvedValue([]);
+
+    const context = await buildEventContext('pull_request', draftPayload, '/test/repo', mockOctokit);
+
+    expect(context.pullRequest?.draft).toBe(true);
   });
 
   it('throws EventContextError for invalid payload', async () => {

--- a/src/event/context.ts
+++ b/src/event/context.ts
@@ -24,6 +24,7 @@ const GitHubPullRequestSchema = z.object({
   number: z.number(),
   title: z.string(),
   body: z.string().nullable(),
+  draft: z.boolean().optional(),
   user: GitHubUserSchema,
   base: z.object({
     ref: z.string(),
@@ -86,6 +87,7 @@ export async function buildEventContext(
       title: pr.title,
       body: pr.body,
       author: pr.user.login,
+      draft: pr.draft ?? false,
       baseBranch: pr.base.ref,
       headBranch: pr.head.ref,
       headSha: pr.head.sha,

--- a/src/triggers/matcher.test.ts
+++ b/src/triggers/matcher.test.ts
@@ -156,6 +156,35 @@ describe('matchTrigger', () => {
     expect(matchTrigger(trigger, baseContext, 'github')).toBe(false);
   });
 
+  it('matches non-draft pull requests when draft is false', () => {
+    const trigger = { ...baseTrigger, draft: false };
+    expect(matchTrigger(trigger, baseContext, 'github')).toBe(true);
+  });
+
+  it('does not match draft pull requests when draft is false', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+      },
+    };
+    const trigger = { ...baseTrigger, draft: false };
+    expect(matchTrigger(trigger, context, 'github')).toBe(false);
+  });
+
+  it('ignores draft filters in local environment', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+      },
+    };
+    const trigger = { ...baseTrigger, draft: false };
+    expect(matchTrigger(trigger, context, 'local')).toBe(true);
+  });
+
   it('matches with path filter', () => {
     const trigger = { ...baseTrigger, filters: { paths: ['src/**/*.ts'] } };
     expect(matchTrigger(trigger, baseContext, 'github')).toBe(true);

--- a/src/triggers/matcher.ts
+++ b/src/triggers/matcher.ts
@@ -205,6 +205,12 @@ export function matchTrigger(
       if (!trigger.actions?.includes(context.action)) {
         return false;
       }
+      if (
+        trigger.draft !== undefined &&
+        (context.pullRequest?.draft ?? false) !== trigger.draft
+      ) {
+        return false;
+      }
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -339,6 +339,7 @@ export const PullRequestContextSchema = z.object({
   title: z.string(),
   body: z.string().nullable(),
   author: z.string(),
+  draft: z.boolean().optional(),
   baseBranch: z.string(),
   headBranch: z.string(),
   headSha: z.string(),


### PR DESCRIPTION
Add a pull request trigger option for draft state so configured skills can run only after a PR is ready for review. Repositories can set `draft = false` on a pull request trigger to skip draft PRs while preserving existing local-run behavior.

**Trigger Matching**

GitHub event context now captures `pull_request.draft`, and pull request triggers compare it when the new option is configured. Missing draft state is treated as non-draft for compatibility.

**Configuration**

The trigger schema and generated TOML support the new boolean field, and the docs show `draft = false` alongside pull request actions.