### PR TITLE
feat(triggers): Add pull request label gating

### DIFF
--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -211,14 +211,18 @@ name = "security-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "code-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 ```
 
 ### Skills
@@ -244,6 +248,8 @@ Triggers define when a skill runs. Each skill can have one or more triggers. Tri
 |-------|-------------|
 | `type` | `pull_request`, `local`, `schedule` |
 | `actions` | Event actions for `pull_request` type |
+| `draft` | Draft state for `pull_request` type |
+| `labels` | Pull request labels that can also match the trigger |
 | `failOn` | Override failure threshold |
 | `reportOn` | Override reporting threshold |
 | `maxFindings` | Override max findings |
@@ -253,7 +259,20 @@ Triggers define when a skill runs. Each skill can have one or more triggers. Tri
 | `model` | Override the main agent model for this trigger |
 | `maxTurns` | Override max agentic turns |
 
-Pull request actions: `opened`, `synchronize`, `reopened`, `closed`.
+Pull request actions: `opened`, `synchronize`, `reopened`, `closed`, `labeled`.
+
+Label opt-in example:
+
+```toml
+[[skills]]
+name = "security-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
+```
 
 ### Filters
 
@@ -537,7 +556,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}

--- a/packages/docs/src/content/docs/config.mdx
+++ b/packages/docs/src/content/docs/config.mdx
@@ -16,14 +16,18 @@ name = "security-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "code-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 ```
 
 ## Sections

--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -114,7 +114,9 @@ model = "anthropic/claude-opus-4-5"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 model = "anthropic/claude-sonnet-4-6"
 ```
 

--- a/packages/docs/src/content/docs/config/skills.mdx
+++ b/packages/docs/src/content/docs/config/skills.mdx
@@ -79,7 +79,9 @@ ignorePaths = ["**/*.test.ts"]
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 ```
 
 ## Skill References

--- a/packages/docs/src/content/docs/config/triggers.mdx
+++ b/packages/docs/src/content/docs/config/triggers.mdx
@@ -33,6 +33,13 @@ Triggers can override output settings and the main agent model.
   </div>
   <div>
     <dt>
+      <code>labels</code>
+      <span class="sentry-property-meta">string[]</span>
+    </dt>
+    <dd>Pull request labels that can also match the trigger. Use with <code>draft = false</code> to let a label opt draft PRs into a run.</dd>
+  </div>
+  <div>
+    <dt>
       <code>failOn</code>
       <span class="sentry-property-meta">severity</span>
     </dt>
@@ -107,6 +114,31 @@ type = "pull_request"
 actions = ["opened", "synchronize"]
 draft = false
 ```
+
+## Label Opt-In
+
+Add the <code>labeled</code> pull request action in both GitHub Actions and
+<code>warden.toml</code> when labels should trigger Warden.
+
+```yaml title=".github/workflows/warden.yml"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+```
+
+```toml title="warden.toml"
+[[skills]]
+name = "security-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
+```
+
+This runs on non-draft PRs as usual. Draft PRs stay quiet unless the
+<code>Warden</code> label is present.
 
 ## Schedule Triggers
 

--- a/packages/docs/src/content/docs/github/org.mdx
+++ b/packages/docs/src/content/docs/github/org.mdx
@@ -88,7 +88,7 @@ name: Warden
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   warden:

--- a/packages/docs/src/content/docs/github/workflow.mdx
+++ b/packages/docs/src/content/docs/github/workflow.mdx
@@ -21,7 +21,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
@@ -56,7 +56,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}

--- a/packages/docs/src/content/docs/quickstart.mdx
+++ b/packages/docs/src/content/docs/quickstart.mdx
@@ -65,14 +65,18 @@ name = "security-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "code-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 ```
 
 Add more skills when your codebase has specific review needs.

--- a/packages/warden/src/cli/commands/add.ts
+++ b/packages/warden/src/cli/commands/add.ts
@@ -232,7 +232,9 @@ async function resolveSkillName(
 const DEFAULT_TRIGGERS = [
   {
     type: 'pull_request' as const,
-    actions: ['opened', 'synchronize', 'reopened'],
+    actions: ['opened', 'synchronize', 'reopened', 'labeled'],
+    draft: false,
+    labels: ['Warden'],
   },
 ];
 

--- a/packages/warden/src/cli/commands/init.test.ts
+++ b/packages/warden/src/cli/commands/init.test.ts
@@ -69,6 +69,9 @@ describe('init command', () => {
       const content = readFileSync(join(tempDir, 'warden.toml'), 'utf-8');
       expect(content).toContain('version = 1');
       expect(content).toContain('runtime = "pi"');
+      expect(content).toContain('# actions = ["opened", "synchronize", "reopened", "labeled"]');
+      expect(content).toContain('# draft = false');
+      expect(content).toContain('# labels = ["Warden"]');
     });
 
     it('creates workflow with correct content', async () => {
@@ -78,6 +81,7 @@ describe('init command', () => {
       const content = readFileSync(join(tempDir, '.github', 'workflows', 'warden.yml'), 'utf-8');
       expect(content).toContain('name: Warden');
       expect(content).toContain('pull_request');
+      expect(content).toContain('types: [opened, synchronize, reopened, labeled]');
       expect(content).toContain('permissions:');
       expect(content).toContain('pull-requests: write');
       expect(content).toContain('checks: write');

--- a/packages/warden/src/cli/commands/init.ts
+++ b/packages/warden/src/cli/commands/init.ts
@@ -100,7 +100,9 @@ reportOn = "medium"
 #
 # [[skills.triggers]]
 # type = "pull_request"
-# actions = ["opened", "synchronize", "reopened"]
+# actions = ["opened", "synchronize", "reopened", "labeled"]
+# draft = false
+# labels = ["Warden"]
 `;
 }
 
@@ -113,7 +115,7 @@ function generateWorkflowYaml(): string {
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 # contents: write required for resolving review threads via GraphQL
 # See: https://github.com/orgs/community/discussions/44650

--- a/packages/warden/src/config/loader.test.ts
+++ b/packages/warden/src/config/loader.test.ts
@@ -294,6 +294,20 @@ describe('resolveSkillConfigs', () => {
     expect(resolved?.draft).toBe(false);
   });
 
+  it('preserves trigger label filters', () => {
+    const config: WardenConfig = {
+      version: 1,
+      skills: [{
+        name: 'test-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened', 'labeled'], labels: ['trigger-warden'] }],
+      }],
+    };
+
+    const [resolved] = resolveSkillConfigs(config);
+
+    expect(resolved?.labels).toEqual(['trigger-warden']);
+  });
+
   describe('ignorePaths merging', () => {
     it('uses defaults.ignorePaths when skill has none', () => {
       const config: WardenConfig = {
@@ -1179,6 +1193,33 @@ describe('trigger type config', () => {
     const result = WardenConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     expect(result.data?.skills[0]?.triggers?.[0]?.type).toBe('pull_request');
+  });
+
+  it('accepts pull_request label filters', () => {
+    const config = {
+      version: 1,
+      skills: [{
+        name: 'test',
+        triggers: [{ type: 'pull_request', actions: ['opened', 'labeled'], labels: ['trigger-warden'] }],
+      }],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.skills[0]?.triggers?.[0]?.labels).toEqual(['trigger-warden']);
+  });
+
+  it('rejects label filters for non-pull_request triggers', () => {
+    const config = {
+      version: 1,
+      skills: [{
+        name: 'test',
+        triggers: [{ type: 'local', labels: ['Warden'] }],
+      }],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
   });
 
   it('accepts local trigger type', () => {

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -344,6 +344,8 @@ export interface ResolvedTrigger {
   actions?: string[];
   /** Draft state for pull_request triggers. false means non-draft only. */
   draft?: boolean;
+  /** Pull request labels that can match this trigger. */
+  labels?: string[];
   /** Remote repository reference */
   remote?: string;
   /** Repository root to use when resolving local skill names or paths */
@@ -496,6 +498,7 @@ export function resolveSkillConfigs(
           type: trigger.type,
           actions: trigger.actions,
           draft: trigger.draft,
+          labels: trigger.labels,
           remote: skill.remote,
           ...skillSource,
           filters,

--- a/packages/warden/src/config/schema.ts
+++ b/packages/warden/src/config/schema.ts
@@ -87,6 +87,8 @@ export const SkillTriggerSchema = z.object({
   actions: z.array(z.string()).min(1).optional(),
   /** Match pull_request triggers by draft state. Set false to run only on non-draft PRs. */
   draft: z.boolean().optional(),
+  /** Match pull_request triggers when any listed label is present. */
+  labels: z.array(z.string()).min(1).optional(),
   // Per-trigger overrides (flattened output fields)
   failOn: SeverityThresholdSchema.optional(),
   reportOn: SeverityThresholdSchema.optional(),
@@ -102,19 +104,23 @@ export const SkillTriggerSchema = z.object({
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Schedule-specific configuration. Only used when type is 'schedule'. */
   schedule: ScheduleConfigSchema.optional(),
-}).refine(
-  (data) => {
-    // actions is required for pull_request type
-    if (data.type === 'pull_request') {
-      return data.actions !== undefined && data.actions.length > 0;
-    }
-    return true;
-  },
-  {
-    message: "actions is required for pull_request triggers",
-    path: ["actions"],
+}).superRefine((data, ctx) => {
+  if (data.type === 'pull_request' && (!data.actions || data.actions.length === 0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "actions is required for pull_request triggers",
+      path: ["actions"],
+    });
   }
-);
+
+  if (data.type !== 'pull_request' && data.labels) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "labels is only supported for pull_request triggers",
+      path: ["labels"],
+    });
+  }
+});
 export type SkillTrigger = z.infer<typeof SkillTriggerSchema>;
 
 // Skill configuration (top-level [[skills]])

--- a/packages/warden/src/config/writer.test.ts
+++ b/packages/warden/src/config/writer.test.ts
@@ -31,6 +31,17 @@ describe('generateSkillToml', () => {
     expect(result).toContain('draft = false');
   });
 
+  it('generates pull request label filters', () => {
+    const result = generateSkillToml({
+      name: 'test-skill',
+      triggers: [
+        { type: 'pull_request', actions: ['opened', 'labeled'], labels: ['trigger-warden'] },
+      ],
+    });
+
+    expect(result).toContain('labels = ["trigger-warden"]');
+  });
+
   it('includes remote field when present', () => {
     const skill: SkillConfig = {
       name: 'security-review',

--- a/packages/warden/src/config/writer.ts
+++ b/packages/warden/src/config/writer.ts
@@ -75,6 +75,11 @@ export function generateSkillToml(skill: SkillConfig): string {
         lines.push(`draft = ${trigger.draft}`);
       }
 
+      if (trigger.labels && trigger.labels.length > 0) {
+        const labelsStr = trigger.labels.map((label) => `"${label}"`).join(', ');
+        lines.push(`labels = [${labelsStr}]`);
+      }
+
       // Trigger-level overrides
       if (trigger.model) {
         lines.push(`model = "${trigger.model}"`);

--- a/packages/warden/src/event/context.test.ts
+++ b/packages/warden/src/event/context.test.ts
@@ -31,6 +31,10 @@ describe('buildEventContext', () => {
       title: 'Test PR',
       body: 'Test description',
       draft: false,
+      labels: [
+        { name: 'trigger-warden' },
+        { name: 'needs-review' },
+      ],
       user: {
         login: 'test-user',
       },
@@ -69,6 +73,7 @@ describe('buildEventContext', () => {
 
     expect(context.eventType).toBe('pull_request');
     expect(context.action).toBe('opened');
+    expect(context.label).toBeUndefined();
     expect(context.repository).toEqual({
       owner: 'test-owner',
       name: 'test-repo',
@@ -81,6 +86,7 @@ describe('buildEventContext', () => {
     expect(context.pullRequest?.body).toBe('Test description');
     expect(context.pullRequest?.author).toBe('test-user');
     expect(context.pullRequest?.draft).toBe(false);
+    expect(context.pullRequest?.labels).toEqual(['trigger-warden', 'needs-review']);
     expect(context.pullRequest?.baseBranch).toBe('main');
     expect(context.pullRequest?.headBranch).toBe('feature-branch');
     expect(context.pullRequest?.headSha).toBe('abc123def456');
@@ -126,6 +132,37 @@ describe('buildEventContext', () => {
     const context = await buildEventContext('pull_request', draftPayload, '/test/repo', mockOctokit);
 
     expect(context.pullRequest?.draft).toBe(true);
+  });
+
+  it('defaults pull request labels to an empty list', async () => {
+    const payloadWithoutLabels = {
+      ...validPayload,
+      pull_request: {
+        ...validPayload.pull_request,
+        labels: undefined,
+      },
+    };
+
+    mockPaginate.mockResolvedValue([]);
+
+    const context = await buildEventContext('pull_request', payloadWithoutLabels, '/test/repo', mockOctokit);
+
+    expect(context.pullRequest?.labels).toEqual([]);
+  });
+
+  it('captures labeled event label name', async () => {
+    const labeledPayload = {
+      ...validPayload,
+      action: 'labeled',
+      label: { name: 'trigger-warden' },
+    };
+
+    mockPaginate.mockResolvedValue([]);
+
+    const context = await buildEventContext('pull_request', labeledPayload, '/test/repo', mockOctokit);
+
+    expect(context.action).toBe('labeled');
+    expect(context.label).toBe('trigger-warden');
   });
 
   it('throws EventContextError for invalid payload', async () => {

--- a/packages/warden/src/event/context.ts
+++ b/packages/warden/src/event/context.ts
@@ -13,6 +13,10 @@ const GitHubUserSchema = z.object({
   login: z.string(),
 });
 
+const GitHubLabelSchema = z.object({
+  name: z.string(),
+});
+
 const GitHubRepoSchema = z.object({
   name: z.string(),
   full_name: z.string(),
@@ -25,6 +29,7 @@ const GitHubPullRequestSchema = z.object({
   title: z.string(),
   body: z.string().nullable(),
   draft: z.boolean().optional(),
+  labels: z.array(GitHubLabelSchema).optional(),
   user: GitHubUserSchema,
   base: z.object({
     ref: z.string(),
@@ -38,6 +43,7 @@ const GitHubPullRequestSchema = z.object({
 
 const GitHubEventPayloadSchema = z.object({
   action: z.string(),
+  label: GitHubLabelSchema.optional(),
   repository: GitHubRepoSchema,
   pull_request: GitHubPullRequestSchema.optional(),
 });
@@ -88,6 +94,7 @@ export async function buildEventContext(
       body: pr.body,
       author: pr.user.login,
       draft: pr.draft ?? false,
+      labels: pr.labels?.map((label) => label.name) ?? [],
       baseBranch: pr.base.ref,
       headBranch: pr.head.ref,
       headSha: pr.head.sha,
@@ -99,6 +106,7 @@ export async function buildEventContext(
   const context: EventContext = {
     eventType: eventName as EventContext['eventType'],
     action: payload.action,
+    label: payload.label?.name,
     repository,
     pullRequest,
     diffContextSource: { type: 'working-tree' },

--- a/packages/warden/src/triggers/matcher.test.ts
+++ b/packages/warden/src/triggers/matcher.test.ts
@@ -123,6 +123,7 @@ describe('matchTrigger', () => {
       title: 'Test PR',
       body: 'Test body',
       author: 'user',
+      labels: [],
       baseBranch: 'main',
       headBranch: 'feature',
       headSha: 'abc123',
@@ -182,6 +183,106 @@ describe('matchTrigger', () => {
       },
     };
     const trigger = { ...baseTrigger, draft: false };
+    expect(matchTrigger(trigger, context, 'local')).toBe(true);
+  });
+
+  it('matches draft pull requests when a configured label is present', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+        labels: ['trigger-warden'],
+      },
+    };
+    const trigger = { ...baseTrigger, draft: false, labels: ['trigger-warden'] };
+    expect(matchTrigger(trigger, context, 'github')).toBe(true);
+  });
+
+  it('does not match draft pull requests when configured labels are absent', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+        labels: ['needs-review'],
+      },
+    };
+    const trigger = { ...baseTrigger, draft: false, labels: ['trigger-warden'] };
+    expect(matchTrigger(trigger, context, 'github')).toBe(false);
+  });
+
+  it('matches non-draft pull requests without requiring configured labels', () => {
+    const trigger = { ...baseTrigger, draft: false, labels: ['trigger-warden'] };
+    expect(matchTrigger(trigger, baseContext, 'github')).toBe(true);
+  });
+
+  it('matches label-only triggers when a configured label is present', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        labels: ['trigger-warden'],
+      },
+    };
+    const trigger = { ...baseTrigger, labels: ['trigger-warden'] };
+    expect(matchTrigger(trigger, context, 'github')).toBe(true);
+  });
+
+  it('matches labeled events when the event label is configured', () => {
+    const context = {
+      ...baseContext,
+      action: 'labeled',
+      label: 'trigger-warden',
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+        labels: ['trigger-warden'],
+      },
+    };
+    const trigger = {
+      ...baseTrigger,
+      actions: ['opened', 'synchronize', 'labeled'],
+      draft: false,
+      labels: ['trigger-warden'],
+    };
+    expect(matchTrigger(trigger, context, 'github')).toBe(true);
+  });
+
+  it('does not match labeled events when the event label is not configured', () => {
+    const context = {
+      ...baseContext,
+      action: 'labeled',
+      label: 'needs-review',
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        labels: ['trigger-warden', 'needs-review'],
+      },
+    };
+    const trigger = {
+      ...baseTrigger,
+      actions: ['opened', 'synchronize', 'labeled'],
+      draft: false,
+      labels: ['trigger-warden'],
+    };
+    expect(matchTrigger(trigger, context, 'github')).toBe(false);
+  });
+
+  it('does not match label-only triggers when configured labels are absent', () => {
+    const trigger = { ...baseTrigger, labels: ['trigger-warden'] };
+    expect(matchTrigger(trigger, baseContext, 'github')).toBe(false);
+  });
+
+  it('ignores label filters in local environment', () => {
+    const context = {
+      ...baseContext,
+      pullRequest: {
+        ...baseContext.pullRequest!,
+        draft: true,
+        labels: [],
+      },
+    };
+    const trigger = { ...baseTrigger, draft: false, labels: ['trigger-warden'] };
     expect(matchTrigger(trigger, context, 'local')).toBe(true);
   });
 
@@ -302,6 +403,7 @@ describe('filterContextByPaths', () => {
       title: 'Test PR',
       body: 'Test body',
       author: 'user',
+      labels: [],
       baseBranch: 'main',
       headBranch: 'feature',
       headSha: 'abc123',

--- a/packages/warden/src/triggers/matcher.ts
+++ b/packages/warden/src/triggers/matcher.ts
@@ -125,6 +125,28 @@ function matchPathFilters(
   return true;
 }
 
+function matchPullRequestState(trigger: ResolvedTrigger, context: EventContext): boolean {
+  const labels = context.pullRequest?.labels ?? [];
+  const labelMatches =
+    trigger.labels !== undefined &&
+    trigger.labels.some((label) => labels.includes(label));
+  const eventLabelMatches =
+    trigger.labels !== undefined &&
+    context.label !== undefined &&
+    trigger.labels.includes(context.label);
+
+  if (context.action === 'labeled' && trigger.labels !== undefined && !eventLabelMatches) {
+    return false;
+  }
+
+  if (trigger.draft === undefined) {
+    return trigger.labels === undefined || labelMatches;
+  }
+
+  const draftMatches = (context.pullRequest?.draft ?? false) === trigger.draft;
+  return draftMatches || labelMatches;
+}
+
 /**
  * Return a copy of the context with only files matching the path filters.
  * If no filters are set, returns the original context unchanged (no copy).
@@ -205,10 +227,7 @@ export function matchTrigger(
       if (!trigger.actions?.includes(context.action)) {
         return false;
       }
-      if (
-        trigger.draft !== undefined &&
-        (context.pullRequest?.draft ?? false) !== trigger.draft
-      ) {
+      if (!matchPullRequestState(trigger, context)) {
         return false;
       }
     }

--- a/packages/warden/src/types/index.test.ts
+++ b/packages/warden/src/types/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { filterFindingsByConfidence, ConfidenceThresholdSchema } from './index.js';
+import {
+  filterFindingsByConfidence,
+  ConfidenceThresholdSchema,
+  PullRequestActionSchema,
+} from './index.js';
 import type { Finding } from './index.js';
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
@@ -23,6 +27,12 @@ describe('ConfidenceThresholdSchema', () => {
   it('rejects invalid values', () => {
     expect(() => ConfidenceThresholdSchema.parse('critical')).toThrow();
     expect(() => ConfidenceThresholdSchema.parse('')).toThrow();
+  });
+});
+
+describe('PullRequestActionSchema', () => {
+  it('accepts labeled pull request events', () => {
+    expect(PullRequestActionSchema.parse('labeled')).toBe('labeled');
   });
 });
 

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -340,6 +340,7 @@ export const PullRequestContextSchema = z.object({
   body: z.string().nullable(),
   author: z.string(),
   draft: z.boolean().optional(),
+  labels: z.array(z.string()).optional(),
   baseBranch: z.string(),
   headBranch: z.string(),
   headSha: z.string(),
@@ -361,6 +362,7 @@ export type RepositoryContext = z.infer<typeof RepositoryContextSchema>;
 export const EventContextSchema = z.object({
   eventType: GitHubEventTypeSchema,
   action: z.string(),
+  label: z.string().optional(),
   repository: RepositoryContextSchema,
   pullRequest: PullRequestContextSchema.optional(),
   repoPath: z.string(),

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -301,6 +301,7 @@ export const PullRequestActionSchema = z.enum([
   'synchronize',
   'reopened',
   'closed',
+  'labeled',
 ]);
 export type PullRequestAction = z.infer<typeof PullRequestActionSchema>;
 


### PR DESCRIPTION
Add pull request label gates so Warden can skip draft PRs by default while still allowing an explicit opt-in with the `Warden` label. Generated configs now listen for label events and default skill triggers run on non-draft PRs or when the opt-in label is applied.

**Trigger Matching**

Pull request contexts now include PR labels and the specific label from `labeled` events. Label-gated triggers ignore unrelated label changes so adding `needs-tests` does not accidentally run Warden.

**Configuration Defaults**

`warden add`, `warden init`, and docs use `draft = false` with `labels = ["Warden"]` and include the `labeled` pull request action.

Fixes GH-358