### PR TITLE
feat(warden): Emit reporting observations

### DIFF
--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -12,7 +12,7 @@ export type FindingOutcome =
 
 export type DedupeSource = 'warden' | 'external';
 export type DedupeMatchType = 'hash' | 'semantic';
-export type SkippedReason = 'max_findings' | 'no_renderable_review' | 'consolidated';
+export type SkippedReason = 'max_findings' | 'consolidated';
 export type FilteredReason = 'report_threshold';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
@@ -91,7 +91,7 @@ export const FindingObservationSchema = z.discriminatedUnion('outcome', [
     outcome: z.literal('skipped'),
     finding: FindingSchema,
     skill: z.string().optional(),
-    skippedReason: z.enum(['max_findings', 'no_renderable_review', 'consolidated']),
+    skippedReason: z.enum(['max_findings', 'consolidated']),
   }),
   z.object({
     outcome: z.literal('resolved'),

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -20,7 +20,7 @@ export const DedupeDetailSchema = z.object({
   source: z.enum(['warden', 'external']),
   matchType: z.enum(['hash', 'semantic']),
   existingFindingId: z.string().optional(),
-  existingCommentId: z.number().int(),
+  existingCommentId: z.number().int().positive().optional(),
   existingThreadId: z.string().optional(),
   existingResolved: z.boolean().optional(),
   actor: z.string().optional(),

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -12,8 +12,11 @@ export type FindingOutcome =
 
 export type DedupeSource = 'warden' | 'external';
 export type DedupeMatchType = 'hash' | 'semantic';
-export type SkippedReason = 'max_findings' | 'consolidated';
-export type FilteredReason = 'report_threshold';
+export type SkippedReason = 'max_findings' | 'duplicate_in_batch';
+export type FilteredReason =
+  | 'reporting_disabled'
+  | 'below_severity_threshold'
+  | 'below_confidence_threshold';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
 export const DedupeDetailSchema = z.object({
@@ -85,13 +88,17 @@ export const FindingObservationSchema = z.discriminatedUnion('outcome', [
     outcome: z.literal('filtered'),
     finding: FindingSchema,
     skill: z.string().optional(),
-    filteredReason: z.literal('report_threshold'),
+    filteredReason: z.enum([
+      'reporting_disabled',
+      'below_severity_threshold',
+      'below_confidence_threshold',
+    ]),
   }),
   z.object({
     outcome: z.literal('skipped'),
     finding: FindingSchema,
     skill: z.string().optional(),
-    skippedReason: z.enum(['max_findings', 'consolidated']),
+    skippedReason: z.enum(['max_findings', 'duplicate_in_batch']),
   }),
   z.object({
     outcome: z.literal('resolved'),

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -12,7 +12,7 @@ export type FindingOutcome =
 
 export type DedupeSource = 'warden' | 'external';
 export type DedupeMatchType = 'hash' | 'semantic';
-export type SkippedReason = 'max_findings' | 'no_renderable_review';
+export type SkippedReason = 'max_findings' | 'no_renderable_review' | 'consolidated';
 export type FilteredReason = 'report_threshold';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
@@ -91,7 +91,7 @@ export const FindingObservationSchema = z.discriminatedUnion('outcome', [
     outcome: z.literal('skipped'),
     finding: FindingSchema,
     skill: z.string().optional(),
-    skippedReason: z.enum(['max_findings', 'no_renderable_review']),
+    skippedReason: z.enum(['max_findings', 'no_renderable_review', 'consolidated']),
   }),
   z.object({
     outcome: z.literal('resolved'),

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import type { Finding } from '../../types/index.js';
+import { FindingSchema } from '../../types/index.js';
 
 export type FindingOutcome =
   | 'posted'
@@ -14,22 +16,94 @@ export type SkippedReason = 'max_findings' | 'no_renderable_review';
 export type FilteredReason = 'report_threshold';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
-export interface DedupeDetail {
-  source: DedupeSource;
-  matchType: DedupeMatchType;
-  existingFindingId?: string;
-  existingCommentId: number;
-  existingThreadId?: string;
-  existingResolved?: boolean;
-  actor?: string;
-}
+export const DedupeDetailSchema = z.object({
+  source: z.enum(['warden', 'external']),
+  matchType: z.enum(['hash', 'semantic']),
+  existingFindingId: z.string().optional(),
+  existingCommentId: z.number().int(),
+  existingThreadId: z.string().optional(),
+  existingResolved: z.boolean().optional(),
+  actor: z.string().optional(),
+});
 
-export interface FindingObservation {
-  outcome: FindingOutcome;
+export type DedupeDetail = z.infer<typeof DedupeDetailSchema>;
+
+interface BaseFindingObservation {
   finding: Finding;
   skill?: string;
-  dedupe?: DedupeDetail;
-  skippedReason?: SkippedReason;
-  filteredReason?: FilteredReason;
-  resolvedReason?: ResolvedReason;
 }
+
+export interface PostedFindingObservation extends BaseFindingObservation {
+  outcome: 'posted';
+}
+
+export interface DedupedFindingObservation extends BaseFindingObservation {
+  outcome: 'deduped';
+  dedupe: DedupeDetail;
+}
+
+export interface FilteredFindingObservation extends BaseFindingObservation {
+  outcome: 'filtered';
+  filteredReason: FilteredReason;
+}
+
+export interface SkippedFindingObservation extends BaseFindingObservation {
+  outcome: 'skipped';
+  skippedReason: SkippedReason;
+}
+
+export interface ResolvedFindingObservation extends BaseFindingObservation {
+  outcome: 'resolved';
+  resolvedReason: ResolvedReason;
+}
+
+export interface FailedFindingObservation extends BaseFindingObservation {
+  outcome: 'failed';
+}
+
+export type FindingObservation =
+  | PostedFindingObservation
+  | DedupedFindingObservation
+  | FilteredFindingObservation
+  | SkippedFindingObservation
+  | ResolvedFindingObservation
+  | FailedFindingObservation;
+
+export const FindingObservationSchema = z.discriminatedUnion('outcome', [
+  z.object({
+    outcome: z.literal('posted'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+  }),
+  z.object({
+    outcome: z.literal('deduped'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+    dedupe: DedupeDetailSchema,
+  }),
+  z.object({
+    outcome: z.literal('filtered'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+    filteredReason: z.literal('report_threshold'),
+  }),
+  z.object({
+    outcome: z.literal('skipped'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+    skippedReason: z.enum(['max_findings', 'no_renderable_review']),
+  }),
+  z.object({
+    outcome: z.literal('resolved'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+    resolvedReason: z.enum(['fix_evaluation', 'stale_check']),
+  }),
+  z.object({
+    outcome: z.literal('failed'),
+    finding: FindingSchema,
+    skill: z.string().optional(),
+  }),
+]);
+
+export type ParsedFindingObservation = z.infer<typeof FindingObservationSchema>;

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -5,7 +5,6 @@ import { FindingSchema } from '../../types/index.js';
 export type FindingOutcome =
   | 'posted'
   | 'deduped'
-  | 'filtered'
   | 'skipped'
   | 'resolved'
   | 'failed';
@@ -13,10 +12,6 @@ export type FindingOutcome =
 export type DedupeSource = 'warden' | 'external';
 export type DedupeMatchType = 'hash' | 'semantic';
 export type SkippedReason = 'max_findings' | 'duplicate_in_batch';
-export type FilteredReason =
-  | 'reporting_disabled'
-  | 'below_severity_threshold'
-  | 'below_confidence_threshold';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
 export const DedupeDetailSchema = z.object({
@@ -45,11 +40,6 @@ export interface DedupedFindingObservation extends BaseFindingObservation {
   dedupe: DedupeDetail;
 }
 
-export interface FilteredFindingObservation extends BaseFindingObservation {
-  outcome: 'filtered';
-  filteredReason: FilteredReason;
-}
-
 export interface SkippedFindingObservation extends BaseFindingObservation {
   outcome: 'skipped';
   skippedReason: SkippedReason;
@@ -67,7 +57,6 @@ export interface FailedFindingObservation extends BaseFindingObservation {
 export type FindingObservation =
   | PostedFindingObservation
   | DedupedFindingObservation
-  | FilteredFindingObservation
   | SkippedFindingObservation
   | ResolvedFindingObservation
   | FailedFindingObservation;
@@ -83,16 +72,6 @@ export const FindingObservationSchema = z.discriminatedUnion('outcome', [
     finding: FindingSchema,
     skill: z.string().optional(),
     dedupe: DedupeDetailSchema,
-  }),
-  z.object({
-    outcome: z.literal('filtered'),
-    finding: FindingSchema,
-    skill: z.string().optional(),
-    filteredReason: z.enum([
-      'reporting_disabled',
-      'below_severity_threshold',
-      'below_confidence_threshold',
-    ]),
   }),
   z.object({
     outcome: z.literal('skipped'),

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -1,0 +1,35 @@
+import type { Finding } from '../../types/index.js';
+
+export type FindingOutcome =
+  | 'posted'
+  | 'deduped'
+  | 'filtered'
+  | 'skipped'
+  | 'resolved'
+  | 'failed';
+
+export type DedupeSource = 'warden' | 'external';
+export type DedupeMatchType = 'hash' | 'semantic';
+export type SkippedReason = 'max_findings' | 'no_renderable_review';
+export type FilteredReason = 'report_threshold';
+export type ResolvedReason = 'fix_evaluation' | 'stale_check';
+
+export interface DedupeDetail {
+  source: DedupeSource;
+  matchType: DedupeMatchType;
+  existingFindingId?: string;
+  existingCommentId: number;
+  existingThreadId?: string;
+  existingResolved?: boolean;
+  actor?: string;
+}
+
+export interface FindingObservation {
+  outcome: FindingOutcome;
+  finding: Finding;
+  skill?: string;
+  dedupe?: DedupeDetail;
+  skippedReason?: SkippedReason;
+  filteredReason?: FilteredReason;
+  resolvedReason?: ResolvedReason;
+}

--- a/packages/warden/src/action/reporting/output.test.ts
+++ b/packages/warden/src/action/reporting/output.test.ts
@@ -42,6 +42,32 @@ describe('findings output schema', () => {
       })
     ).toThrow();
   });
+
+  it('rejects sentinel dedupe comment IDs', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(() =>
+      FindingsOutputSchema.parse({
+        ...output,
+        findingObservations: [
+          {
+            outcome: 'deduped',
+            finding: createFinding(),
+            skill: 'test-skill',
+            dedupe: {
+              source: 'warden',
+              matchType: 'hash',
+              existingFindingId: 'WRD-001',
+              existingCommentId: -1,
+            },
+          },
+        ],
+      })
+    ).toThrow();
+  });
 });
 
 function createFinding(): Finding {

--- a/packages/warden/src/action/reporting/output.test.ts
+++ b/packages/warden/src/action/reporting/output.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { EventContext, Finding, SkillReport } from '../../types/index.js';
+import { buildFindingsOutput, FindingsOutputSchema } from './output.js';
+
+describe('findings output schema', () => {
+  it('builds a schema-valid public findings payload', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [
+      {
+        outcome: 'posted',
+        finding: createFinding(),
+        skill: 'test-skill',
+      },
+    ], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(FindingsOutputSchema.parse(output)).toEqual(output);
+    expect(output.summary).toEqual({
+      totalFindings: 1,
+      findingsBySeverity: { high: 1, medium: 0, low: 0 },
+      totalSkills: 1,
+    });
+  });
+
+  it('rejects outcome details that do not match the observation kind', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(() =>
+      FindingsOutputSchema.parse({
+        ...output,
+        findingObservations: [
+          {
+            outcome: 'deduped',
+            finding: createFinding(),
+            skill: 'test-skill',
+          },
+        ],
+      })
+    ).toThrow();
+  });
+});
+
+function createFinding(): Finding {
+  return {
+    id: 'WRD-001',
+    severity: 'high',
+    confidence: 'high',
+    title: 'Finding title',
+    description: 'Finding description',
+    location: { path: 'src/index.ts', startLine: 1 },
+  };
+}
+
+function createReport(): SkillReport {
+  return {
+    skill: 'test-skill',
+    summary: 'Found 1 issue',
+    findings: [createFinding()],
+  };
+}
+
+function createContext(): EventContext {
+  return {
+    eventType: 'pull_request',
+    action: 'opened',
+    repository: {
+      owner: 'getsentry',
+      name: 'warden',
+      fullName: 'getsentry/warden',
+      defaultBranch: 'main',
+    },
+    pullRequest: {
+      number: 362,
+      title: 'Test PR',
+      body: '',
+      author: 'user-123',
+      baseBranch: 'main',
+      headBranch: 'feature',
+      headSha: 'abc123',
+      baseSha: 'def456',
+      files: [],
+    },
+    repoPath: '/tmp/warden',
+  };
+}

--- a/packages/warden/src/action/reporting/output.ts
+++ b/packages/warden/src/action/reporting/output.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import type { EventContext, SkillReport } from '../../types/index.js';
+import {
+  FindingSchema,
+  GitHubEventTypeSchema,
+  LocationSchema,
+  SourceSnippetSchema,
+  SuggestedFixSchema,
+  UsageStatsSchema,
+} from '../../types/index.js';
+import type { FindingObservation } from './outcomes.js';
+import { FindingObservationSchema } from './outcomes.js';
+
+const ExportedFindingSchema = z.object({
+  id: z.string(),
+  severity: FindingSchema.shape.severity,
+  confidence: FindingSchema.shape.confidence,
+  title: z.string(),
+  description: z.string(),
+  location: LocationSchema.optional(),
+  additionalLocations: z.array(LocationSchema).optional(),
+  suggestedFix: SuggestedFixSchema.optional(),
+  sourceSnippet: SourceSnippetSchema.optional(),
+});
+
+export const FindingsOutputSchema = z.object({
+  version: z.literal('1'),
+  timestamp: z.string().datetime(),
+  repository: z.object({
+    owner: z.string(),
+    name: z.string(),
+    fullName: z.string(),
+  }),
+  event: GitHubEventTypeSchema,
+  pullRequest: z.object({
+    number: z.number().int(),
+    author: z.string(),
+    title: z.string(),
+    baseBranch: z.string(),
+    headBranch: z.string(),
+    headSha: z.string(),
+  }).optional(),
+  runId: z.string(),
+  summary: z.object({
+    totalFindings: z.number().int().nonnegative(),
+    findingsBySeverity: z.object({
+      high: z.number().int().nonnegative(),
+      medium: z.number().int().nonnegative(),
+      low: z.number().int().nonnegative(),
+    }),
+    totalSkills: z.number().int().nonnegative(),
+  }),
+  skills: z.array(z.object({
+    name: z.string(),
+    summary: z.string(),
+    model: z.string().optional(),
+    durationMs: z.number().nonnegative().optional(),
+    usage: UsageStatsSchema.optional(),
+    findings: z.array(ExportedFindingSchema),
+  })),
+  findingObservations: z.array(FindingObservationSchema),
+});
+
+export type FindingsOutput = z.infer<typeof FindingsOutputSchema>;
+
+interface BuildFindingsOutputOptions {
+  timestamp?: string;
+  runId?: string;
+}
+
+/** Build the public findings export payload. */
+export function buildFindingsOutput(
+  reports: SkillReport[],
+  context: EventContext,
+  findingObservations: FindingObservation[] = [],
+  options: BuildFindingsOutputOptions = {}
+): FindingsOutput {
+  const allFindings = reports.flatMap((r) => r.findings);
+  const output = {
+    version: '1',
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    repository: {
+      owner: context.repository.owner,
+      name: context.repository.name,
+      fullName: context.repository.fullName,
+    },
+    event: context.eventType,
+    ...(context.pullRequest && {
+      pullRequest: {
+        number: context.pullRequest.number,
+        author: context.pullRequest.author,
+        title: context.pullRequest.title,
+        baseBranch: context.pullRequest.baseBranch,
+        headBranch: context.pullRequest.headBranch,
+        headSha: context.pullRequest.headSha,
+      },
+    }),
+    runId: options.runId ?? process.env['GITHUB_RUN_ID'] ?? '',
+    summary: {
+      totalFindings: allFindings.length,
+      findingsBySeverity: {
+        high: allFindings.filter((f) => f.severity === 'high').length,
+        medium: allFindings.filter((f) => f.severity === 'medium').length,
+        low: allFindings.filter((f) => f.severity === 'low').length,
+      },
+      totalSkills: reports.length,
+    },
+    skills: reports.map((r) => ({
+      name: r.skill,
+      summary: r.summary,
+      model: r.model,
+      durationMs: r.durationMs,
+      usage: r.usage,
+      findings: r.findings.map((f) => ({
+        id: f.id,
+        severity: f.severity,
+        confidence: f.confidence,
+        title: f.title,
+        description: f.description,
+        location: f.location,
+        additionalLocations: f.additionalLocations,
+        suggestedFix: f.suggestedFix,
+        sourceSnippet: f.sourceSnippet,
+      })),
+    })),
+    findingObservations,
+  };
+
+  return FindingsOutputSchema.parse(output);
+}

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -251,6 +251,72 @@ describe('postTriggerReview', () => {
     ]);
   });
 
+  it('does not mark deduped findings as failed when later duplicate handling errors', async () => {
+    const duplicateFinding = createFinding({ id: 'duplicate-finding' });
+    const newFinding = createFinding({ id: 'new-finding', location: { path: 'test.ts', startLine: 20 } });
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 2 issues',
+        findings: [duplicateFinding, newFinding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult({
+        review: {
+          event: 'COMMENT',
+          body: 'Test review',
+          comments: [
+            { path: 'test.ts', line: 10, body: 'Duplicate comment' },
+            { path: 'test.ts', line: 20, body: 'New comment' },
+          ],
+        },
+      }),
+      reportOn: 'low',
+    };
+
+    const existingComment = createExistingComment({
+      isWarden: false,
+      actor: 'coderabbitai',
+      threadId: 'thread-1',
+    });
+    const duplicateAction = {
+      type: 'react_external' as const,
+      originalFindingId: duplicateFinding.id,
+      finding: duplicateFinding,
+      existingComment,
+      matchType: 'hash' as const,
+    };
+
+    vi.mocked(deduplicateFindings).mockResolvedValue({
+      newFindings: [newFinding],
+      duplicateActions: [duplicateAction],
+    });
+    vi.mocked(processDuplicateActions).mockRejectedValue(new Error('Duplicate action failed'));
+
+    const ctx: ReviewPostingContext = {
+      result,
+      existingComments: [existingComment],
+      apiKey: 'test-key',
+    };
+
+    const postResult = await postTriggerReview(ctx, mockDeps);
+
+    expect(postResult.posted).toBe(false);
+    expect(postResult.findingObservations).toEqual([
+      expect.objectContaining({
+        outcome: 'deduped',
+        finding: duplicateFinding,
+        skill: 'test-skill',
+      }),
+      {
+        outcome: 'failed',
+        finding: newFinding,
+        skill: 'test-skill',
+      },
+    ]);
+  });
+
   it('posts REQUEST_CHANGES when all findings deduplicated but failOn threshold met', async () => {
     const finding = createFinding({ severity: 'high' });
     const result: TriggerResult = {

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -137,6 +137,40 @@ describe('postTriggerReview', () => {
     expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
   });
 
+  it('marks renderable findings skipped when no review render result exists', async () => {
+    const finding = createFinding();
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 1 issue',
+        findings: [finding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: undefined,
+      reportOn: 'low',
+    };
+
+    const ctx: ReviewPostingContext = {
+      result,
+      existingComments: [],
+      apiKey: 'test-key',
+    };
+
+    const postResult = await postTriggerReview(ctx, mockDeps);
+
+    expect(postResult.posted).toBe(false);
+    expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(postResult.findingObservations).toEqual([
+      {
+        outcome: 'skipped',
+        finding,
+        skill: 'test-skill',
+        skippedReason: 'no_renderable_review',
+      },
+    ]);
+  });
+
   it('posts a review with findings', async () => {
     const finding = createFinding();
     const result: TriggerResult = {

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -201,12 +201,16 @@ describe('postTriggerReview', () => {
       reportOn: 'low',
     };
 
-    const existingComment = createExistingComment({ isWarden: false });
+    const existingComment = createExistingComment({
+      isWarden: false,
+      actor: 'coderabbitai',
+      threadId: 'thread-1',
+    });
 
     // Mock that the finding is a duplicate
     vi.mocked(deduplicateFindings).mockResolvedValue({
       newFindings: [],
-      duplicateActions: [{ type: 'react_external', finding, existingComment, matchType: 'hash' }],
+      duplicateActions: [{ type: 'react_external', originalFindingId: finding.id, finding, existingComment, matchType: 'hash' }],
     });
     vi.mocked(processDuplicateActions).mockResolvedValue({ updated: 0, reacted: 1, skipped: 0, failed: 0 });
 
@@ -225,12 +229,26 @@ describe('postTriggerReview', () => {
     });
     expect(processDuplicateActions).toHaveBeenCalledWith(
       mockOctokit, 'test-owner', 'test-repo',
-      [{ type: 'react_external', finding, existingComment, matchType: 'hash' }],
+      [{ type: 'react_external', originalFindingId: finding.id, finding, existingComment, matchType: 'hash' }],
       'test-skill'
     );
     // Since all findings were duplicates and failOn not triggered, nothing new to post
     expect(postResult.posted).toBe(false);
     expect(postResult.activeWardenCommentIds.size).toBe(0);
+    expect(postResult.findingObservations).toEqual([
+      expect.objectContaining({
+        outcome: 'deduped',
+        finding,
+        skill: 'test-skill',
+        dedupe: expect.objectContaining({
+          source: 'external',
+          matchType: 'hash',
+          existingCommentId: 1,
+          existingThreadId: 'thread-1',
+          actor: 'coderabbitai',
+        }),
+      }),
+    ]);
   });
 
   it('posts REQUEST_CHANGES when all findings deduplicated but failOn threshold met', async () => {
@@ -255,12 +273,13 @@ describe('postTriggerReview', () => {
       requestChanges: true,
     };
 
-    const existingComment = createExistingComment({ isWarden: true });
+    const existingComment = createExistingComment({ isWarden: true, findingId: 'WRZ-XPL' });
+    const recenteredFinding = { ...finding, id: 'WRZ-XPL' };
 
     // Mock that the finding is a duplicate (already posted in previous run)
     vi.mocked(deduplicateFindings).mockResolvedValue({
       newFindings: [],
-      duplicateActions: [{ type: 'update_warden', finding, existingComment, matchType: 'hash' }],
+      duplicateActions: [{ type: 'update_warden', originalFindingId: finding.id, finding: recenteredFinding, existingComment, matchType: 'hash' }],
     });
     vi.mocked(processDuplicateActions).mockResolvedValue({ updated: 1, reacted: 0, skipped: 0, failed: 0 });
 
@@ -289,12 +308,24 @@ describe('postTriggerReview', () => {
     });
     expect(processDuplicateActions).toHaveBeenCalledWith(
       mockOctokit, 'test-owner', 'test-repo',
-      [{ type: 'update_warden', finding, existingComment, matchType: 'hash' }],
+      [{ type: 'update_warden', originalFindingId: finding.id, finding: recenteredFinding, existingComment, matchType: 'hash' }],
       'test-skill'
     );
     // Even though all findings were deduplicated, REQUEST_CHANGES should still be posted
     expect(postResult.posted).toBe(true);
     expect([...postResult.activeWardenCommentIds]).toEqual([1]);
+    expect(result.report?.findings[0]?.id).toBe('WRZ-XPL');
+    expect(postResult.findingObservations).toEqual([
+      expect.objectContaining({
+        outcome: 'deduped',
+        finding: recenteredFinding,
+        skill: 'test-skill',
+        dedupe: expect.objectContaining({
+          source: 'warden',
+          existingFindingId: 'WRZ-XPL',
+        }),
+      }),
+    ]);
     expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'REQUEST_CHANGES',

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -137,7 +137,7 @@ describe('postTriggerReview', () => {
     expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
   });
 
-  it('marks renderable findings skipped when no review render result exists', async () => {
+  it('does not emit a public skipped reason when no review render result exists', async () => {
     const finding = createFinding();
     const result: TriggerResult = {
       triggerName: 'test-trigger',
@@ -161,14 +161,10 @@ describe('postTriggerReview', () => {
 
     expect(postResult.posted).toBe(false);
     expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
-    expect(postResult.findingObservations).toEqual([
-      {
-        outcome: 'skipped',
-        finding,
-        skill: 'test-skill',
-        skippedReason: 'no_renderable_review',
-      },
-    ]);
+    expect(console.warn).toHaveBeenCalledWith(
+      '::warning::Trigger test-trigger produced reportable findings without a render result'
+    );
+    expect(postResult.findingObservations).toEqual([]);
   });
 
   it('posts a review with findings', async () => {

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -33,6 +33,7 @@ describe('postTriggerReview', () => {
     vi.mocked(consolidateBatchFindings).mockImplementation(async (findings) => ({
       findings,
       removedCount: 0,
+      removedFindings: [],
     }));
   });
 
@@ -137,7 +138,7 @@ describe('postTriggerReview', () => {
     expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
   });
 
-  it('records severity threshold as the filter reason', async () => {
+  it('does not emit posting observations for threshold-suppressed findings', async () => {
     const finding = createFinding({ severity: 'low' });
     const result: TriggerResult = {
       triggerName: 'test-trigger',
@@ -153,41 +154,7 @@ describe('postTriggerReview', () => {
 
     const postResult = await postTriggerReview({ result, existingComments: [], apiKey: 'test-key' }, mockDeps);
 
-    expect(postResult.findingObservations).toEqual([
-      {
-        outcome: 'filtered',
-        finding,
-        skill: 'test-skill',
-        filteredReason: 'below_severity_threshold',
-      },
-    ]);
-  });
-
-  it('records confidence threshold as the filter reason', async () => {
-    const finding = createFinding({ confidence: 'low' });
-    const result: TriggerResult = {
-      triggerName: 'test-trigger',
-      report: {
-        skill: 'test-skill',
-        summary: 'Found 1 issue',
-        findings: [finding],
-        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
-      },
-      renderResult: createRenderResult(),
-      reportOn: 'low',
-      minConfidence: 'medium',
-    };
-
-    const postResult = await postTriggerReview({ result, existingComments: [], apiKey: 'test-key' }, mockDeps);
-
-    expect(postResult.findingObservations).toEqual([
-      {
-        outcome: 'filtered',
-        finding,
-        skill: 'test-skill',
-        filteredReason: 'below_confidence_threshold',
-      },
-    ]);
+    expect(postResult.findingObservations).toEqual([]);
   });
 
   it('does not emit a public skipped reason when no review render result exists', async () => {
@@ -653,6 +620,55 @@ describe('postTriggerReview', () => {
 
     expect(postResult.posted).toBe(false);
     expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves max findings skipped observations when posting fails', async () => {
+    const finding1 = createFinding({ id: 'f1' });
+    const finding2 = createFinding({ id: 'f2', location: { path: 'test.ts', startLine: 20 } });
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 2 issues',
+        findings: [finding1, finding2],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult({
+        review: {
+          event: 'COMMENT',
+          body: '',
+          comments: [
+            { path: 'test.ts', line: 10, body: 'Comment 1' },
+            { path: 'test.ts', line: 20, body: 'Comment 2' },
+          ],
+        },
+      }),
+      reportOn: 'low',
+      maxFindings: 1,
+    };
+
+    vi.mocked(mockOctokit.pulls.createReview).mockRejectedValueOnce(new Error('Resource not accessible by integration'));
+
+    const postResult = await postTriggerReview({
+      result,
+      existingComments: [],
+      apiKey: 'test-key',
+    }, mockDeps);
+
+    expect(postResult.posted).toBe(false);
+    expect(postResult.findingObservations).toEqual([
+      {
+        outcome: 'skipped',
+        finding: finding2,
+        skill: 'test-skill',
+        skippedReason: 'max_findings',
+      },
+      {
+        outcome: 'failed',
+        finding: finding1,
+        skill: 'test-skill',
+      },
+    ]);
   });
 
   it('consolidates batch findings before dedup when multiple findings exist', async () => {

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -635,6 +635,7 @@ describe('postTriggerReview', () => {
     vi.mocked(consolidateBatchFindings).mockResolvedValue({
       findings: [finding1],
       removedCount: 1,
+      removedFindings: [finding2],
     });
 
     vi.mocked(findingToExistingComment).mockReturnValue(createExistingComment());
@@ -665,6 +666,19 @@ describe('postTriggerReview', () => {
     expect(postResult.posted).toBe(true);
     // Only the consolidated finding should be posted
     expect(postResult.newComments).toHaveLength(1);
+    expect(postResult.findingObservations).toEqual([
+      {
+        outcome: 'skipped',
+        finding: finding2,
+        skill: 'test-skill',
+        skippedReason: 'consolidated',
+      },
+      {
+        outcome: 'posted',
+        finding: finding1,
+        skill: 'test-skill',
+      },
+    ]);
   });
 
   it('skips consolidation when only one finding exists', async () => {

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -285,6 +285,66 @@ describe('postTriggerReview', () => {
     ]);
   });
 
+  it('omits sentinel comment IDs from dedupe observations', async () => {
+    const finding = createFinding();
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 1 issue',
+        findings: [finding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult({
+        review: {
+          event: 'COMMENT',
+          body: 'Test review',
+          comments: [{ path: 'test.ts', line: 10, body: 'Test comment' }],
+        },
+      }),
+      reportOn: 'low',
+    };
+
+    const existingComment = createExistingComment({
+      id: -1,
+      isWarden: true,
+      findingId: finding.id,
+    });
+
+    vi.mocked(deduplicateFindings).mockResolvedValue({
+      newFindings: [],
+      duplicateActions: [{ type: 'update_warden', originalFindingId: finding.id, finding, existingComment, matchType: 'hash' }],
+    });
+    vi.mocked(processDuplicateActions).mockResolvedValue({ updated: 0, reacted: 0, skipped: 1, failed: 0 });
+
+    const ctx: ReviewPostingContext = {
+      result,
+      existingComments: [existingComment],
+      apiKey: 'test-key',
+    };
+
+    const postResult = await postTriggerReview(ctx, mockDeps);
+    const [observation] = postResult.findingObservations;
+
+    expect(observation).toEqual(
+      expect.objectContaining({
+        outcome: 'deduped',
+        finding,
+        skill: 'test-skill',
+        dedupe: expect.objectContaining({
+          source: 'warden',
+          matchType: 'hash',
+          existingFindingId: finding.id,
+        }),
+      })
+    );
+    if (observation?.outcome !== 'deduped') {
+      throw new Error('Expected deduped observation');
+    }
+    expect(observation.dedupe).not.toHaveProperty('existingCommentId');
+    expect(postResult.activeWardenCommentIds.size).toBe(0);
+  });
+
   it('does not mark deduped findings as failed when later duplicate handling errors', async () => {
     const duplicateFinding = createFinding({ id: 'duplicate-finding' });
     const newFinding = createFinding({ id: 'new-finding', location: { path: 'test.ts', startLine: 20 } });

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -137,6 +137,59 @@ describe('postTriggerReview', () => {
     expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
   });
 
+  it('records severity threshold as the filter reason', async () => {
+    const finding = createFinding({ severity: 'low' });
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 1 issue',
+        findings: [finding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult(),
+      reportOn: 'medium',
+    };
+
+    const postResult = await postTriggerReview({ result, existingComments: [], apiKey: 'test-key' }, mockDeps);
+
+    expect(postResult.findingObservations).toEqual([
+      {
+        outcome: 'filtered',
+        finding,
+        skill: 'test-skill',
+        filteredReason: 'below_severity_threshold',
+      },
+    ]);
+  });
+
+  it('records confidence threshold as the filter reason', async () => {
+    const finding = createFinding({ confidence: 'low' });
+    const result: TriggerResult = {
+      triggerName: 'test-trigger',
+      report: {
+        skill: 'test-skill',
+        summary: 'Found 1 issue',
+        findings: [finding],
+        usage: { inputTokens: 100, outputTokens: 50, costUSD: 0.01 },
+      },
+      renderResult: createRenderResult(),
+      reportOn: 'low',
+      minConfidence: 'medium',
+    };
+
+    const postResult = await postTriggerReview({ result, existingComments: [], apiKey: 'test-key' }, mockDeps);
+
+    expect(postResult.findingObservations).toEqual([
+      {
+        outcome: 'filtered',
+        finding,
+        skill: 'test-skill',
+        filteredReason: 'below_confidence_threshold',
+      },
+    ]);
+  });
+
   it('does not emit a public skipped reason when no review render result exists', async () => {
     const finding = createFinding();
     const result: TriggerResult = {
@@ -667,7 +720,7 @@ describe('postTriggerReview', () => {
         outcome: 'skipped',
         finding: finding2,
         skill: 'test-skill',
-        skippedReason: 'consolidated',
+        skippedReason: 'duplicate_in_batch',
       },
       {
         outcome: 'posted',

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -239,15 +239,13 @@ export async function postTriggerReview(
   }
   const reportOnSuccess = result.reportOnSuccess ?? false;
 
-  // Skip if nothing to post
+  // Skip if review rendering is disabled. In the normal action path this is
+  // only possible when reportOn is "off", which leaves no filtered findings.
   if (!result.renderResult) {
-    for (const finding of filteredFindings) {
-      findingObservations.push({
-        outcome: 'skipped',
-        finding,
-        skill: result.report.skill,
-        skippedReason: 'no_renderable_review',
-      });
+    if (filteredFindings.length > 0) {
+      console.warn(
+        `::warning::Trigger ${result.triggerName} produced reportable findings without a render result`
+      );
     }
     return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
   }

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -244,6 +244,8 @@ export async function postTriggerReview(
     return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
   }
 
+  let findingsToMarkFailed = filteredFindings;
+
   try {
     // Cross-location merging already happened in runSkillTask().
     // Consolidate findings within this batch (intra-batch dedup).
@@ -260,6 +262,7 @@ export async function postTriggerReview(
         agentName: result.report.skill,
       });
       findingsToPost = consolidateResult.findings;
+      findingsToMarkFailed = findingsToPost;
 
       if (consolidateResult.usage) {
         const consolidateAux = { consolidate: consolidateResult.usage };
@@ -286,6 +289,7 @@ export async function postTriggerReview(
       });
       result.report.findings = recenterReportFindingIds(result.report.findings, dedupResult.duplicateActions);
       findingsToPost = dedupResult.newFindings;
+      findingsToMarkFailed = findingsToPost;
       findingObservations.push(...buildDedupeObservations(dedupResult.duplicateActions, result.report.skill));
 
       // Merge dedup usage into the report's auxiliary usage
@@ -407,7 +411,7 @@ export async function postTriggerReview(
       activeWardenCommentIds,
       findingObservations: [
         ...findingObservations,
-        ...filteredFindings.map((finding) => ({ outcome: 'failed' as const, finding, skill: result.report?.skill })),
+        ...findingsToMarkFailed.map((finding) => ({ outcome: 'failed' as const, finding, skill: result.report?.skill })),
       ],
       shouldFail: false,
     };

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -275,6 +275,14 @@ export async function postTriggerReview(
       });
       findingsToPost = consolidateResult.findings;
       findingsToMarkFailed = findingsToPost;
+      for (const finding of consolidateResult.removedFindings ?? []) {
+        findingObservations.push({
+          outcome: 'skipped',
+          finding,
+          skill: result.report.skill,
+          skippedReason: 'consolidated',
+        });
+      }
 
       if (consolidateResult.usage) {
         const consolidateAux = { consolidate: consolidateResult.usage };

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -6,8 +6,8 @@
  */
 
 import type { Octokit } from '@octokit/rest';
-import type { EventContext, Finding } from '../../types/index.js';
-import { filterFindings } from '../../types/index.js';
+import type { ConfidenceThreshold, EventContext, Finding, SeverityThreshold } from '../../types/index.js';
+import { CONFIDENCE_ORDER, filterFindings, SEVERITY_ORDER } from '../../types/index.js';
 import { shouldFail } from '../../triggers/matcher.js';
 import type { RenderResult } from '../../output/types.js';
 import { renderSkillReport, renderFindingsBody } from '../../output/renderer.js';
@@ -23,7 +23,7 @@ import { canUseRuntimeAuth } from '../../sdk/extract.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
 import { logAction, warnAction } from '../../cli/output/tty.js';
-import type { FindingObservation } from '../reporting/outcomes.js';
+import type { FilteredReason, FindingObservation } from '../reporting/outcomes.js';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -114,6 +114,31 @@ function recenterReportFindingIds(reportFindings: Finding[], actions: Deduplicat
     const recenteredId = ids.get(finding.id);
     return recenteredId ? { ...finding, id: recenteredId } : finding;
   });
+}
+
+function findingFilterReason(
+  finding: Finding,
+  reportOn?: SeverityThreshold,
+  minConfidence?: ConfidenceThreshold
+): FilteredReason | undefined {
+  if (reportOn === 'off') {
+    return 'reporting_disabled';
+  }
+
+  if (reportOn && SEVERITY_ORDER[finding.severity] > SEVERITY_ORDER[reportOn]) {
+    return 'below_severity_threshold';
+  }
+
+  if (
+    minConfidence &&
+    minConfidence !== 'off' &&
+    finding.confidence &&
+    CONFIDENCE_ORDER[finding.confidence] > CONFIDENCE_ORDER[minConfidence]
+  ) {
+    return 'below_confidence_threshold';
+  }
+
+  return undefined;
 }
 
 // -----------------------------------------------------------------------------
@@ -233,7 +258,7 @@ export async function postTriggerReview(
         outcome: 'filtered',
         finding,
         skill: result.report.skill,
-        filteredReason: 'report_threshold',
+        filteredReason: findingFilterReason(finding, result.reportOn, result.minConfidence) ?? 'below_severity_threshold',
       });
     }
   }
@@ -278,7 +303,7 @@ export async function postTriggerReview(
           outcome: 'skipped',
           finding,
           skill: result.report.skill,
-          skippedReason: 'consolidated',
+          skippedReason: 'duplicate_in_batch',
         });
       }
 

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -6,8 +6,8 @@
  */
 
 import type { Octokit } from '@octokit/rest';
-import type { ConfidenceThreshold, EventContext, Finding, SeverityThreshold } from '../../types/index.js';
-import { CONFIDENCE_ORDER, filterFindings, SEVERITY_ORDER } from '../../types/index.js';
+import type { EventContext, Finding } from '../../types/index.js';
+import { filterFindings } from '../../types/index.js';
 import { shouldFail } from '../../triggers/matcher.js';
 import type { RenderResult } from '../../output/types.js';
 import { renderSkillReport, renderFindingsBody } from '../../output/renderer.js';
@@ -23,7 +23,7 @@ import { canUseRuntimeAuth } from '../../sdk/extract.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
 import { logAction, warnAction } from '../../cli/output/tty.js';
-import type { FilteredReason, FindingObservation } from '../reporting/outcomes.js';
+import type { FindingObservation } from '../reporting/outcomes.js';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -114,31 +114,6 @@ function recenterReportFindingIds(reportFindings: Finding[], actions: Deduplicat
     const recenteredId = ids.get(finding.id);
     return recenteredId ? { ...finding, id: recenteredId } : finding;
   });
-}
-
-function findingFilterReason(
-  finding: Finding,
-  reportOn?: SeverityThreshold,
-  minConfidence?: ConfidenceThreshold
-): FilteredReason | undefined {
-  if (reportOn === 'off') {
-    return 'reporting_disabled';
-  }
-
-  if (reportOn && SEVERITY_ORDER[finding.severity] > SEVERITY_ORDER[reportOn]) {
-    return 'below_severity_threshold';
-  }
-
-  if (
-    minConfidence &&
-    minConfidence !== 'off' &&
-    finding.confidence &&
-    CONFIDENCE_ORDER[finding.confidence] > CONFIDENCE_ORDER[minConfidence]
-  ) {
-    return 'below_confidence_threshold';
-  }
-
-  return undefined;
 }
 
 // -----------------------------------------------------------------------------
@@ -251,17 +226,6 @@ export async function postTriggerReview(
 
   // Filter findings by reportOn threshold and confidence
   const filteredFindings = filterFindings(result.report.findings, result.reportOn, result.minConfidence);
-  const filteredIds = new Set(filteredFindings.map((finding) => finding.id));
-  for (const finding of result.report.findings) {
-    if (!filteredIds.has(finding.id)) {
-      findingObservations.push({
-        outcome: 'filtered',
-        finding,
-        skill: result.report.skill,
-        filteredReason: findingFilterReason(finding, result.reportOn, result.minConfidence) ?? 'below_severity_threshold',
-      });
-    }
-  }
   const reportOnSuccess = result.reportOnSuccess ?? false;
 
   // Skip if review rendering is disabled. In the normal action path this is
@@ -411,6 +375,14 @@ export async function postTriggerReview(
         : [];
       // Only overflow-eligible findings should be marked failed if posting throws
       findingsToMarkFailed = postedFindings;
+      for (const finding of skippedFindings) {
+        findingObservations.push({
+          outcome: 'skipped',
+          finding,
+          skill: result.report.skill,
+          skippedReason: 'max_findings',
+        });
+      }
 
       try {
         await postReviewToGitHub(octokit, context, renderResultToPost);
@@ -429,15 +401,6 @@ export async function postTriggerReview(
           newComments.push(comment);
         }
       }
-      for (const finding of skippedFindings) {
-        findingObservations.push({
-          outcome: 'skipped',
-          finding,
-          skill: result.report.skill,
-          skippedReason: 'max_findings',
-        });
-      }
-
       return {
         posted: true,
         newComments,

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -223,6 +223,7 @@ export async function postTriggerReview(
   if (!result.report) {
     return emptyReviewPostResult(newComments, activeWardenCommentIds);
   }
+  const skill = result.report.skill;
 
   // Filter findings by reportOn threshold and confidence
   const filteredFindings = filterFindings(result.report.findings, result.reportOn, result.minConfidence);
@@ -258,7 +259,7 @@ export async function postTriggerReview(
         model: ctx.model,
         hashOnly: !canUseAuxiliaryRuntime,
         maxRetries: ctx.maxRetries,
-        agentName: result.report.skill,
+        agentName: skill,
       });
       findingsToPost = consolidateResult.findings;
       findingsToMarkFailed = findingsToPost;
@@ -266,7 +267,7 @@ export async function postTriggerReview(
         findingObservations.push({
           outcome: 'skipped',
           finding,
-          skill: result.report.skill,
+          skill,
           skippedReason: 'duplicate_in_batch',
         });
       }
@@ -291,13 +292,13 @@ export async function postTriggerReview(
         apiKey,
         runtime: ctx.runtime,
         model: ctx.model,
-        currentSkill: result.report.skill,
+        currentSkill: skill,
         maxRetries: ctx.maxRetries,
       });
       result.report.findings = recenterReportFindingIds(result.report.findings, dedupResult.duplicateActions);
       findingsToPost = dedupResult.newFindings;
       findingsToMarkFailed = findingsToPost;
-      findingObservations.push(...buildDedupeObservations(dedupResult.duplicateActions, result.report.skill));
+      findingObservations.push(...buildDedupeObservations(dedupResult.duplicateActions, skill));
 
       // Merge dedup usage into the report's auxiliary usage
       if (dedupResult.dedupUsage) {
@@ -325,7 +326,7 @@ export async function postTriggerReview(
         context.repository.owner,
         context.repository.name,
         dedupResult.duplicateActions,
-        result.report.skill
+        skill
       );
 
       if (actionCounts.updated > 0) {
@@ -379,7 +380,7 @@ export async function postTriggerReview(
         findingObservations.push({
           outcome: 'skipped',
           finding,
-          skill: result.report.skill,
+          skill,
           skippedReason: 'max_findings',
         });
       }
@@ -391,12 +392,12 @@ export async function postTriggerReview(
           throw error;
         }
         warnAction(`Inline comments failed for ${result.triggerName}, posting findings in review body`);
-        const fallback = moveCommentsToBody(renderResultToPost, postedFindings, result.report.skill);
+        const fallback = moveCommentsToBody(renderResultToPost, postedFindings, skill);
         await postReviewToGitHub(octokit, context, fallback);
       }
       for (const finding of postedFindings) {
-        findingObservations.push({ outcome: 'posted', finding, skill: result.report.skill });
-        const comment = findingToExistingComment(finding, result.report.skill);
+        findingObservations.push({ outcome: 'posted', finding, skill });
+        const comment = findingToExistingComment(finding, skill);
         if (comment) {
           newComments.push(comment);
         }
@@ -419,7 +420,7 @@ export async function postTriggerReview(
       activeWardenCommentIds,
       findingObservations: [
         ...findingObservations,
-        ...findingsToMarkFailed.map((finding) => ({ outcome: 'failed' as const, finding, skill: result.report?.skill })),
+        ...findingsToMarkFailed.map((finding) => ({ outcome: 'failed' as const, finding, skill })),
       ],
       shouldFail: false,
     };

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -23,6 +23,7 @@ import { canUseRuntimeAuth } from '../../sdk/extract.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
 import { logAction, warnAction } from '../../cli/output/tty.js';
+import type { FindingObservation } from '../reporting/outcomes.js';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -50,6 +51,8 @@ export interface ReviewPostResult {
   newComments: ExistingComment[];
   /** Existing Warden comment IDs matched by current findings */
   activeWardenCommentIds: Set<number>;
+  /** Structured finding outcomes produced while posting this review */
+  findingObservations: FindingObservation[];
   /** Whether this trigger should cause the action to fail */
   shouldFail: boolean;
   /** Reason for failure, if any */
@@ -62,6 +65,55 @@ export interface ReviewPostResult {
 export interface ReviewPosterDeps {
   octokit: Octokit;
   context: EventContext;
+}
+
+function emptyReviewPostResult(
+  newComments: ExistingComment[],
+  activeWardenCommentIds: Set<number>,
+  findingObservations: FindingObservation[] = []
+): ReviewPostResult {
+  return { posted: false, newComments, activeWardenCommentIds, findingObservations, shouldFail: false };
+}
+
+function buildDedupeObservations(
+  actions: DeduplicateResult['duplicateActions'],
+  skill: string
+): FindingObservation[] {
+  return actions.map((action) => ({
+    outcome: 'deduped',
+    finding: action.finding,
+    skill,
+    dedupe: {
+      source: action.existingComment.isWarden ? 'warden' : 'external',
+      matchType: action.matchType,
+      existingFindingId: action.existingComment.findingId,
+      existingCommentId: action.existingComment.id,
+      existingThreadId: action.existingComment.threadId,
+      existingResolved: action.existingComment.isResolved,
+      actor: action.existingComment.actor,
+    },
+  }));
+}
+
+function recenterReportFindingIds(reportFindings: Finding[], actions: DeduplicateResult['duplicateActions']): Finding[] {
+  if (actions.length === 0) {
+    return reportFindings;
+  }
+
+  const ids = new Map(
+    actions
+      .filter((action) => action.originalFindingId !== action.finding.id)
+      .map((action) => [action.originalFindingId, action.finding.id])
+  );
+
+  if (ids.size === 0) {
+    return reportFindings;
+  }
+
+  return reportFindings.map((finding) => {
+    const recenteredId = ids.get(finding.id);
+    return recenteredId ? { ...finding, id: recenteredId } : finding;
+  });
 }
 
 // -----------------------------------------------------------------------------
@@ -166,18 +218,30 @@ export async function postTriggerReview(
 
   const newComments: ExistingComment[] = [];
   const activeWardenCommentIds = new Set<number>();
+  const findingObservations: FindingObservation[] = [];
 
   if (!result.report) {
-    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
+    return emptyReviewPostResult(newComments, activeWardenCommentIds);
   }
 
   // Filter findings by reportOn threshold and confidence
   const filteredFindings = filterFindings(result.report.findings, result.reportOn, result.minConfidence);
+  const filteredIds = new Set(filteredFindings.map((finding) => finding.id));
+  for (const finding of result.report.findings) {
+    if (!filteredIds.has(finding.id)) {
+      findingObservations.push({
+        outcome: 'filtered',
+        finding,
+        skill: result.report.skill,
+        filteredReason: 'report_threshold',
+      });
+    }
+  }
   const reportOnSuccess = result.reportOnSuccess ?? false;
 
   // Skip if nothing to post
   if (!result.renderResult || (filteredFindings.length === 0 && !reportOnSuccess)) {
-    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
+    return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
   }
 
   try {
@@ -220,7 +284,9 @@ export async function postTriggerReview(
         currentSkill: result.report.skill,
         maxRetries: ctx.maxRetries,
       });
+      result.report.findings = recenterReportFindingIds(result.report.findings, dedupResult.duplicateActions);
       findingsToPost = dedupResult.newFindings;
+      findingObservations.push(...buildDedupeObservations(dedupResult.duplicateActions, result.report.skill));
 
       // Merge dedup usage into the report's auxiliary usage
       if (dedupResult.dedupUsage) {
@@ -293,6 +359,9 @@ export async function postTriggerReview(
       const postedFindings = result.maxFindings
         ? findingsToPost.slice(0, result.maxFindings)
         : findingsToPost;
+      const skippedFindings = result.maxFindings
+        ? findingsToPost.slice(result.maxFindings)
+        : [];
 
       try {
         await postReviewToGitHub(octokit, context, renderResultToPost);
@@ -305,18 +374,42 @@ export async function postTriggerReview(
         await postReviewToGitHub(octokit, context, fallback);
       }
       for (const finding of postedFindings) {
+        findingObservations.push({ outcome: 'posted', finding, skill: result.report.skill });
         const comment = findingToExistingComment(finding, result.report.skill);
         if (comment) {
           newComments.push(comment);
         }
       }
+      for (const finding of skippedFindings) {
+        findingObservations.push({
+          outcome: 'skipped',
+          finding,
+          skill: result.report.skill,
+          skippedReason: 'max_findings',
+        });
+      }
 
-      return { posted: true, newComments, activeWardenCommentIds, shouldFail: false };
+      return {
+        posted: true,
+        newComments,
+        activeWardenCommentIds,
+        findingObservations,
+        shouldFail: false,
+      };
     }
 
-    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
+    return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
   } catch (error) {
     warnAction(`Failed to post review for ${result.triggerName}: ${error}`);
-    return { posted: false, newComments, activeWardenCommentIds, shouldFail: false };
+    return {
+      posted: false,
+      newComments,
+      activeWardenCommentIds,
+      findingObservations: [
+        ...findingObservations,
+        ...filteredFindings.map((finding) => ({ outcome: 'failed' as const, finding, skill: result.report?.skill })),
+      ],
+      shouldFail: false,
+    };
   }
 }

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -240,7 +240,19 @@ export async function postTriggerReview(
   const reportOnSuccess = result.reportOnSuccess ?? false;
 
   // Skip if nothing to post
-  if (!result.renderResult || (filteredFindings.length === 0 && !reportOnSuccess)) {
+  if (!result.renderResult) {
+    for (const finding of filteredFindings) {
+      findingObservations.push({
+        outcome: 'skipped',
+        finding,
+        skill: result.report.skill,
+        skippedReason: 'no_renderable_review',
+      });
+    }
+    return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
+  }
+
+  if (filteredFindings.length === 0 && !reportOnSuccess) {
     return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
   }
 

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -409,6 +409,8 @@ export async function postTriggerReview(
       const skippedFindings = result.maxFindings
         ? findingsToPost.slice(result.maxFindings)
         : [];
+      // Only overflow-eligible findings should be marked failed if posting throws
+      findingsToMarkFailed = postedFindings;
 
       try {
         await postReviewToGitHub(octokit, context, renderResultToPost);

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -87,7 +87,7 @@ function buildDedupeObservations(
       source: action.existingComment.isWarden ? 'warden' : 'external',
       matchType: action.matchType,
       existingFindingId: action.existingComment.findingId,
-      existingCommentId: action.existingComment.id,
+      ...(action.existingComment.id > 0 ? { existingCommentId: action.existingComment.id } : {}),
       existingThreadId: action.existingComment.threadId,
       existingResolved: action.existingComment.isResolved,
       actor: action.existingComment.actor,

--- a/packages/warden/src/action/workflow/base.test.ts
+++ b/packages/warden/src/action/workflow/base.test.ts
@@ -20,6 +20,7 @@ import {
   prepareRuntimeEnvironment,
   writeFindingsOutput,
 } from './base.js';
+import { FindingsOutputSchema } from '../reporting/output.js';
 
 const mockExecFile = vi.mocked(execFileNonInteractive);
 const mockExec = vi.mocked(execNonInteractive);
@@ -81,11 +82,7 @@ describe('findings output', () => {
       'findings-file=warden-findings.json\n'
     );
 
-    const payload = JSON.parse(readFileSync(filePath, 'utf-8')) as {
-      summary: { totalFindings: number };
-      skills: { findings: { sourceSnippet?: unknown }[] }[];
-      findingObservations: unknown[];
-    };
+    const payload = FindingsOutputSchema.parse(JSON.parse(readFileSync(filePath, 'utf-8')));
     expect(payload.summary.totalFindings).toBe(1);
     expect(payload.skills[0]?.findings[0]?.sourceSnippet).toEqual({
       path: 'src/index.ts',

--- a/packages/warden/src/action/workflow/base.test.ts
+++ b/packages/warden/src/action/workflow/base.test.ts
@@ -65,7 +65,15 @@ describe('findings output', () => {
   it('writes findings to the workspace and exposes a repo-relative output path', () => {
     process.env['GITHUB_WORKSPACE'] = tempDir;
 
-    const filePath = writeFindingsOutput([createReport()], createContext(tempDir));
+    const filePath = writeFindingsOutput(
+      [createReport()],
+      createContext(tempDir),
+      [{
+        outcome: 'posted',
+        skill: 'test-skill',
+        finding: createReport().findings[0]!,
+      }],
+    );
 
     expect(filePath).toBe(join(tempDir, 'warden-findings.json'));
     expect(existsSync(filePath)).toBe(true);
@@ -75,8 +83,23 @@ describe('findings output', () => {
 
     const payload = JSON.parse(readFileSync(filePath, 'utf-8')) as {
       summary: { totalFindings: number };
+      skills: { findings: { sourceSnippet?: unknown }[] }[];
+      findingObservations: unknown[];
     };
     expect(payload.summary.totalFindings).toBe(1);
+    expect(payload.skills[0]?.findings[0]?.sourceSnippet).toEqual({
+      path: 'src/index.ts',
+      startLine: 1,
+      endLine: 3,
+      targetStartLine: 1,
+      targetEndLine: 1,
+      lines: [
+        { line: 1, content: 'const value = input;', highlighted: true },
+        { line: 2, content: 'return value;' },
+        { line: 3, content: '}' },
+      ],
+    });
+    expect(payload.findingObservations).toHaveLength(1);
   });
 
   it('falls back to RUNNER_TEMP when no repo path is provided', () => {
@@ -194,6 +217,18 @@ function createReport(): SkillReport {
         title: 'Example finding',
         description: 'A test finding',
         location: { path: 'src/index.ts', startLine: 1 },
+        sourceSnippet: {
+          path: 'src/index.ts',
+          startLine: 1,
+          endLine: 3,
+          targetStartLine: 1,
+          targetEndLine: 1,
+          lines: [
+            { line: 1, content: 'const value = input;', highlighted: true },
+            { line: 2, content: 'return value;' },
+            { line: 3, content: '}' },
+          ],
+        },
       },
     ],
   };

--- a/packages/warden/src/action/workflow/base.ts
+++ b/packages/warden/src/action/workflow/base.ts
@@ -13,6 +13,7 @@ import { execFileNonInteractive, execNonInteractive } from '../../utils/exec.js'
 import { isRepoRelativePath, normalizePath } from '../../utils/path.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import type { FindingObservation } from '../reporting/outcomes.js';
+import { buildFindingsOutput } from '../reporting/output.js';
 import { countSeverity } from '../../triggers/matcher.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
@@ -376,57 +377,7 @@ export function writeFindingsOutput(
   findingObservations: FindingObservation[] = []
 ): string {
   const filePath = getFindingsOutputPath(context.repoPath);
-  const allFindings = reports.flatMap((r) => r.findings);
-
-  const output = {
-    version: '1',
-    timestamp: new Date().toISOString(),
-    repository: {
-      owner: context.repository.owner,
-      name: context.repository.name,
-      fullName: context.repository.fullName,
-    },
-    event: context.eventType,
-    ...(context.pullRequest && {
-      pullRequest: {
-        number: context.pullRequest.number,
-        author: context.pullRequest.author,
-        title: context.pullRequest.title,
-        baseBranch: context.pullRequest.baseBranch,
-        headBranch: context.pullRequest.headBranch,
-        headSha: context.pullRequest.headSha,
-      },
-    }),
-    runId: process.env['GITHUB_RUN_ID'] ?? '',
-    summary: {
-      totalFindings: allFindings.length,
-      findingsBySeverity: {
-        high: allFindings.filter((f) => f.severity === 'high').length,
-        medium: allFindings.filter((f) => f.severity === 'medium').length,
-        low: allFindings.filter((f) => f.severity === 'low').length,
-      },
-      totalSkills: reports.length,
-    },
-    skills: reports.map((r) => ({
-      name: r.skill,
-      summary: r.summary,
-      model: r.model,
-      durationMs: r.durationMs,
-      usage: r.usage,
-      findings: r.findings.map((f) => ({
-        id: f.id,
-        severity: f.severity,
-        confidence: f.confidence,
-        title: f.title,
-        description: f.description,
-        location: f.location,
-        additionalLocations: f.additionalLocations,
-        suggestedFix: f.suggestedFix,
-        sourceSnippet: f.sourceSnippet,
-      })),
-    })),
-    findingObservations,
-  };
+  const output = buildFindingsOutput(reports, context, findingObservations);
 
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(output, null, 2));

--- a/packages/warden/src/action/workflow/base.ts
+++ b/packages/warden/src/action/workflow/base.ts
@@ -12,6 +12,7 @@ import type { Octokit } from '@octokit/rest';
 import { execFileNonInteractive, execNonInteractive } from '../../utils/exec.js';
 import { isRepoRelativePath, normalizePath } from '../../utils/path.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
+import type { FindingObservation } from '../reporting/outcomes.js';
 import { countSeverity } from '../../triggers/matcher.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { TriggerResult } from '../triggers/executor.js';
@@ -371,7 +372,8 @@ export function getFindingsOutputPath(repoPath?: string): string {
  */
 export function writeFindingsOutput(
   reports: SkillReport[],
-  context: EventContext
+  context: EventContext,
+  findingObservations: FindingObservation[] = []
 ): string {
   const filePath = getFindingsOutputPath(context.repoPath);
   const allFindings = reports.flatMap((r) => r.findings);
@@ -420,8 +422,10 @@ export function writeFindingsOutput(
         location: f.location,
         additionalLocations: f.additionalLocations,
         suggestedFix: f.suggestedFix,
+        sourceSnippet: f.sourceSnippet,
       })),
     })),
+    findingObservations,
   };
 
   mkdirSync(dirname(filePath), { recursive: true });

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -321,6 +321,7 @@ describe('runPRWorkflow', () => {
         duplicateActions: [
           {
             type: 'react_external',
+            originalFindingId: finding.id,
             finding,
             existingComment: {
               id: 1,
@@ -1148,6 +1149,7 @@ describe('runPRWorkflow', () => {
         duplicateActions: [
           {
             type: 'update_warden',
+            originalFindingId: finding.id,
             finding,
             existingComment,
             matchType: 'semantic',

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -5,6 +5,7 @@ import type { Octokit } from '@octokit/rest';
 import type { ActionInputs } from '../inputs.js';
 import type { SkillReport, Finding } from '../../types/index.js';
 import type { ExistingComment } from '../../output/dedup.js';
+import type * as BaseWorkflow from './base.js';
 
 // -----------------------------------------------------------------------------
 // Fixtures Directory
@@ -73,7 +74,7 @@ vi.mock('../fix-evaluation/index.js', () => ({
 
 // Mock base utilities that call process.exit or need system access
 vi.mock('./base.js', async () => {
-  const actual = await vi.importActual('./base.js');
+  const actual = await vi.importActual<typeof BaseWorkflow>('./base.js');
   const mockedSetFailed = vi.fn((msg: string): never => {
     throw new Error(`setFailed: ${msg}`);
   });
@@ -104,6 +105,7 @@ vi.mock('./base.js', async () => {
       return Promise.resolve({ pathToClaudeCodeExecutable: '/usr/local/bin/claude' });
     }),
     getAuthenticatedBotLogin: vi.fn(() => Promise.resolve('warden[bot]')),
+    writeFindingsOutput: vi.fn(actual.writeFindingsOutput),
   };
 });
 
@@ -111,7 +113,7 @@ vi.mock('./base.js', async () => {
 import { runSkillTask } from '../../cli/output/tasks.js';
 import { fetchExistingComments, deduplicateFindings } from '../../output/dedup.js';
 import { evaluateFixAttempts } from '../fix-evaluation/index.js';
-import { setFailed } from './base.js';
+import { setFailed, writeFindingsOutput } from './base.js';
 import { runPRWorkflow } from './pr-workflow.js';
 import { clearSkillsCache } from '../../skills/loader.js';
 import { Semaphore } from '../../utils/index.js';
@@ -122,6 +124,7 @@ const mockFetchExistingComments = vi.mocked(fetchExistingComments);
 const mockDeduplicateFindings = vi.mocked(deduplicateFindings);
 const mockEvaluateFixAttempts = vi.mocked(evaluateFixAttempts);
 const mockSetFailed = vi.mocked(setFailed);
+const mockWriteFindingsOutput = vi.mocked(writeFindingsOutput);
 
 // Type helper for mocking Octokit responses
 type ListReviewsResponse = Awaited<ReturnType<Octokit['pulls']['listReviews']>>;
@@ -248,6 +251,7 @@ describe('runPRWorkflow', () => {
 
     // Default: skill runs successfully with no findings
     mockRunSkillTask.mockResolvedValue({ name: 'test-trigger', report: createSkillReport() });
+    mockWriteFindingsOutput.mockReturnValue('/tmp/warden-findings.json');
 
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -1352,6 +1356,17 @@ describe('runPRWorkflow', () => {
           review_id: 42,
           message: expect.stringContaining('resolved'),
         })
+      );
+      expect(mockWriteFindingsOutput).toHaveBeenLastCalledWith(
+        [],
+        expect.any(Object),
+        [
+          expect.objectContaining({
+            outcome: 'resolved',
+            skill: undefined,
+            resolvedReason: 'fix_evaluation',
+          }),
+        ]
       );
     });
 

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -38,6 +38,7 @@ import { executeTrigger } from '../triggers/executor.js';
 import type { TriggerResult } from '../triggers/executor.js';
 import { postTriggerReview } from '../review/poster.js';
 import { shouldResolveStaleComments } from '../review/coordination.js';
+import type { FindingObservation } from '../reporting/outcomes.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import { canUseRuntimeAuth } from '../../sdk/extract.js';
 import { ProviderFailureCircuitBreaker } from '../../sdk/circuit-breaker.js';
@@ -89,6 +90,7 @@ interface ReviewPhaseResult {
   fetchedComments: ExistingComment[];
   existingComments: ExistingComment[];
   activeWardenCommentIds: Set<number>;
+  findingObservations: FindingObservation[];
   shouldFailAction: boolean;
   failureReasons: string[];
 }
@@ -102,6 +104,25 @@ interface AuxiliaryWorkflowOptions {
 interface SkippedCoreCheck {
   title: string;
   message: string;
+}
+
+function existingCommentToFinding(comment: ExistingComment): Finding {
+  const location = comment.path && comment.line > 0
+    ? {
+        path: comment.path,
+        startLine: comment.line,
+        endLine: comment.line,
+      }
+    : undefined;
+
+  return {
+    id: comment.findingId ?? `comment-${comment.id}`,
+    severity: comment.severity ?? 'low',
+    title: comment.title,
+    description: comment.description,
+    ...(comment.confidence ? { confidence: comment.confidence } : {}),
+    ...(location ? { location } : {}),
+  };
 }
 
 function reportsPullRequestCheck(trigger: ResolvedTrigger, context: EventContext): boolean {
@@ -425,6 +446,7 @@ async function postReviewsAndTrackFailures(
   // Post reviews to GitHub (sequentially to avoid rate limits)
   const reports: SkillReport[] = [];
   const activeWardenCommentIds = new Set<number>();
+  const findingObservations: FindingObservation[] = [];
   let shouldFailAction = false;
   const failureReasons: string[] = [];
 
@@ -448,6 +470,7 @@ async function postReviewsAndTrackFailures(
       // Add newly posted comments to existing comments for cross-trigger deduplication
       existingComments.push(...postResult.newComments);
       postResult.activeWardenCommentIds.forEach((id) => activeWardenCommentIds.add(id));
+      findingObservations.push(...postResult.findingObservations);
 
       // Check if we should fail based on this trigger's config
       // Filter by confidence first so low-confidence findings don't cause failure
@@ -466,6 +489,7 @@ async function postReviewsAndTrackFailures(
     fetchedComments,
     existingComments,
     activeWardenCommentIds,
+    findingObservations,
     shouldFailAction,
     failureReasons,
   };
@@ -489,11 +513,13 @@ async function evaluateFixesAndResolveStale(
   allResolved: boolean;
   autoResolvedByFixEvaluation: number;
   autoResolvedByStaleCheck: number;
+  findingObservations: FindingObservation[];
 }> {
   const wardenComments = fetchedComments.filter((c) => c.isWarden);
   const commentsResolvedByFixEval = new Set<number>();
   const commentsEvaluatedByFixEval = new Set<number>();
   const commentsResolvedByStale = new Set<number>();
+  const findingObservations: FindingObservation[] = [];
   const commentsForFixEvaluation = wardenComments.filter(
     (c) => !activeWardenCommentIds.has(c.id)
   );
@@ -544,6 +570,15 @@ async function evaluateFixesAndResolveStale(
         }
         // Track only actually resolved comments for allResolved check
         resolvedIds.forEach((id) => commentsResolvedByFixEval.add(id));
+        for (const comment of fixEvaluation.toResolve) {
+          if (!resolvedIds.has(comment.id)) continue;
+          findingObservations.push({
+            outcome: 'resolved',
+            finding: existingCommentToFinding(comment),
+            skill: comment.skills?.[0],
+            resolvedReason: 'fix_evaluation',
+          });
+        }
       }
 
       // Post replies for failed fixes and track them so stale pass doesn't override
@@ -611,6 +646,15 @@ async function evaluateFixesAndResolveStale(
           }
         }
         resolvedIds.forEach((id) => commentsResolvedByStale.add(id));
+        for (const comment of staleComments) {
+          if (!resolvedIds.has(comment.id)) continue;
+          findingObservations.push({
+            outcome: 'resolved',
+            finding: existingCommentToFinding(comment),
+            skill: comment.skills?.[0],
+            resolvedReason: 'stale_check',
+          });
+        }
       }
     } catch (error) {
       Sentry.captureException(error, { tags: { operation: 'resolve_stale_comments' } });
@@ -630,6 +674,7 @@ async function evaluateFixesAndResolveStale(
     allResolved,
     autoResolvedByFixEvaluation: commentsResolvedByFixEval.size,
     autoResolvedByStaleCheck: commentsResolvedByStale.size,
+    findingObservations,
   };
 }
 
@@ -643,6 +688,7 @@ async function finalizeWorkflow(
   coreCheckId: number | undefined,
   results: TriggerResult[],
   reports: SkillReport[],
+  findingObservations: FindingObservation[],
   shouldFailAction: boolean,
   failureReasons: string[],
   canResolveStale: boolean,
@@ -685,7 +731,7 @@ async function finalizeWorkflow(
 
   // Write structured findings to file for external export (GCS, S3, etc.)
   try {
-    const findingsPath = writeFindingsOutput(reports, context);
+    const findingsPath = writeFindingsOutput(reports, context, findingObservations);
     logAction(`Findings written to ${findingsPath}`);
   } catch (error) {
     warnAction(`Failed to write findings output: ${error}`);
@@ -1083,6 +1129,7 @@ export async function runPRWorkflow(
               'warden.feedback.auto_resolve.stale_count',
               resolutionResult.autoResolvedByStaleCheck
             );
+            reviewPhase.findingObservations.push(...resolutionResult.findingObservations);
           },
         ),
       );
@@ -1090,6 +1137,7 @@ export async function runPRWorkflow(
       await finalizeWorkflow(
         octokit, context, previousReviewInfo, coreCheckId,
         results, reviewPhase.reports,
+        reviewPhase.findingObservations,
         reviewPhase.shouldFailAction, reviewPhase.failureReasons,
         canResolveStale,
         triggerErrors,

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -1052,7 +1052,11 @@ export async function runPRWorkflow(
         setOutput('findings-count', 0);
         setOutput('high-count', 0);
         setOutput('summary', skipCoreCheck.title);
-        try { writeFindingsOutput([], context); } catch { /* non-fatal */ }
+        try {
+          writeFindingsOutput([], context);
+        } catch (error) {
+          warnAction(`Failed to write findings output: ${error}`);
+        }
         await completeSkippedCoreCheck(octokit, context, coreCheckId, skipCoreCheck);
         return;
       }
@@ -1068,7 +1072,11 @@ export async function runPRWorkflow(
           setOutput('findings-count', 0);
           setOutput('high-count', 0);
           setOutput('summary', 'No triggers matched');
-          try { writeFindingsOutput([], context); } catch { /* non-fatal */ }
+          try {
+            writeFindingsOutput([], context);
+          } catch (error) {
+            warnAction(`Failed to write findings output: ${error}`);
+          }
           await completeSkippedCoreCheck(octokit, context, coreCheckId, {
             title: 'No triggers matched',
             message: 'No triggers matched for this event.',

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -931,9 +931,9 @@ async function cleanupOrphanedComments(
   context: EventContext,
   inputs: ActionInputs,
   auxiliaryOptions: AuxiliaryWorkflowOptions
-): Promise<void> {
+): Promise<FindingObservation[]> {
   if (!context.pullRequest) {
-    return;
+    return [];
   }
 
   let existingComments: ExistingComment[];
@@ -946,12 +946,12 @@ async function cleanupOrphanedComments(
     );
   } catch (error) {
     warnAction(`Failed to fetch existing comments for cleanup: ${error}`);
-    return;
+    return [];
   }
 
   const wardenComments = existingComments.filter((c) => c.isWarden);
   if (wardenComments.length === 0) {
-    return;
+    return [];
   }
 
   if ((auxiliaryOptions.runtime ?? 'pi') === 'claude') {
@@ -960,7 +960,7 @@ async function cleanupOrphanedComments(
 
   logAction(`No triggers matched, but found ${wardenComments.length} existing Warden comments. Running cleanup.`);
 
-  const { allResolved, autoResolvedByFixEvaluation, autoResolvedByStaleCheck } =
+  const { allResolved, autoResolvedByFixEvaluation, autoResolvedByStaleCheck, findingObservations } =
     await evaluateFixesAndResolveStale(
       octokit, context, existingComments, [], new Set(), true, inputs.anthropicApiKey, auxiliaryOptions
     );
@@ -986,6 +986,8 @@ async function cleanupOrphanedComments(
       }
     }
   }
+
+  return findingObservations;
 }
 
 // -----------------------------------------------------------------------------
@@ -1063,7 +1065,7 @@ export async function runPRWorkflow(
 
       if (matchedTriggers.length === 0) {
         await runOrFailCore(octokit, context, coreCheckId, async () => {
-          await cleanupOrphanedComments(
+          const cleanupFindingObservations = await cleanupOrphanedComments(
             octokit,
             context,
             inputs,
@@ -1073,7 +1075,7 @@ export async function runPRWorkflow(
           setOutput('high-count', 0);
           setOutput('summary', 'No triggers matched');
           try {
-            writeFindingsOutput([], context);
+            writeFindingsOutput([], context, cleanupFindingObservations);
           } catch (error) {
             warnAction(`Failed to write findings output: ${error}`);
           }

--- a/packages/warden/src/action/workflow/schedule.ts
+++ b/packages/warden/src/action/workflow/schedule.ts
@@ -107,7 +107,9 @@ async function runScheduleWorkflowInner(
           repository: { owner: o, name: n, fullName, defaultBranch: '' },
           repoPath,
         });
-      } catch { /* non-fatal */ }
+      } catch (writeError) {
+        console.error(`::warning::Failed to write findings output: ${writeError}`);
+      }
       return;
     }
     throw error;
@@ -136,7 +138,9 @@ async function runScheduleWorkflowInner(
         repository: { owner: o, name: n, fullName, defaultBranch: '' },
         repoPath,
       });
-    } catch { /* non-fatal */ }
+    } catch (writeError) {
+      console.error(`::warning::Failed to write findings output: ${writeError}`);
+    }
     return;
   }
 

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -21,6 +21,9 @@ export {
   LocationSchema,
   // Suggested Fix
   SuggestedFixSchema,
+  // Source Snippet
+  SourceSnippetLineSchema,
+  SourceSnippetSchema,
   // Finding
   FindingSchema,
   UsageStatsSchema,
@@ -50,6 +53,8 @@ export type {
   ConfidenceThreshold,
   Location,
   SuggestedFix,
+  SourceSnippetLine,
+  SourceSnippet,
   Finding,
   UsageStats,
   AuxiliaryUsageMap,

--- a/packages/warden/src/output/dedup.test.ts
+++ b/packages/warden/src/output/dedup.test.ts
@@ -852,12 +852,14 @@ describe('consolidateBatchFindings', () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]).toBe(finding);
     expect(result.removedCount).toBe(0);
+    expect(result.removedFindings).toEqual([]);
   });
 
   it('returns empty array unchanged', async () => {
     const result = await consolidateBatchFindings([]);
     expect(result.findings).toHaveLength(0);
     expect(result.removedCount).toBe(0);
+    expect(result.removedFindings).toEqual([]);
   });
 
   it('removes exact hash duplicates within batch', async () => {

--- a/packages/warden/src/output/dedup.test.ts
+++ b/packages/warden/src/output/dedup.test.ts
@@ -830,6 +830,7 @@ describe('consolidateBatchFindings', () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]).toBe(finding1);
     expect(result.removedCount).toBe(1);
+    expect(result.removedFindings).toEqual([finding2]);
   });
 
   it('keeps findings with different hashes at same location in hashOnly mode', async () => {

--- a/packages/warden/src/output/dedup.test.ts
+++ b/packages/warden/src/output/dedup.test.ts
@@ -265,6 +265,57 @@ User input reaches a query.
       actor: 'warden-bot',
     });
   });
+
+  it('derives plain-text title and description for external review comments', async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: 'thread-1',
+                isResolved: true,
+                comments: {
+                  nodes: [
+                    {
+                      id: 'comment-node-1',
+                      databaseId: 456,
+                      body: `<!-- metadata -->
+<details><summary>Trace</summary>Hidden marker</details>
+
+**Needs guard**
+
+Use \`Number.isFinite\` before saving [the value](https://example.com).`,
+                      path: 'src/db.ts',
+                      line: 42,
+                      originalLine: 40,
+                      author: { login: 'reviewer' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const comments = await fetchExistingComments(
+      { graphql } as unknown as Octokit,
+      'getsentry',
+      'warden',
+      123
+    );
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toMatchObject({
+      id: 456,
+      isWarden: false,
+      title: 'Needs guard Use Number.isFinite before saving the value.',
+      description: 'Needs guard Use Number.isFinite before saving the value.',
+    });
+  });
 });
 
 describe('deduplicateFindings', () => {

--- a/packages/warden/src/output/dedup.test.ts
+++ b/packages/warden/src/output/dedup.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Octokit } from '@octokit/rest';
 import {
   generateContentHash,
+  generateFindingMetadata,
   generateMarker,
+  parseWardenFindingMetadata,
   parseMarker,
   parseWardenComment,
   parseWardenFindingId,
@@ -233,6 +235,7 @@ User input reaches a query.
                       path: 'src/db.ts',
                       line: 42,
                       originalLine: 40,
+                      author: { login: 'warden-bot' },
                     },
                   ],
                 },
@@ -259,6 +262,7 @@ User input reaches a query.
       isWarden: true,
       skills: ['security-review'],
       threadId: 'thread-1',
+      actor: 'warden-bot',
     });
   });
 });
@@ -310,6 +314,7 @@ describe('deduplicateFindings', () => {
         description: 'User input passed to query',
         contentHash: generateContentHash('SQL Injection', 'User input passed to query'),
         isWarden: true,
+        findingId: 'WRZ-XPL',
       },
     ];
 
@@ -318,6 +323,7 @@ describe('deduplicateFindings', () => {
     expect(result.duplicateActions).toHaveLength(1);
     expect(result.duplicateActions[0]!.type).toBe('update_warden');
     expect(result.duplicateActions[0]!.matchType).toBe('hash');
+    expect(result.duplicateActions[0]!.finding.id).toBe('WRZ-XPL');
   });
 
   it('keeps findings with different content', async () => {
@@ -688,6 +694,7 @@ describe('findingToExistingComment', () => {
       contentHash: generateContentHash('SQL Injection', 'User input passed to query'),
       isWarden: true,
       skills: [],
+      severity: 'high',
     });
   });
 
@@ -756,6 +763,18 @@ ${marker}`;
 
     const parsed = parseMarker(body);
     expect(parsed).toEqual({ path, line, contentHash: hash });
+  });
+});
+
+describe('finding metadata', () => {
+  it('round-trips severity and confidence from hidden metadata', () => {
+    const metadata = generateFindingMetadata({ severity: 'high', confidence: 'medium' });
+    const body = `**Issue**\n\nDetails\n${metadata}`;
+
+    expect(parseWardenFindingMetadata(body)).toEqual({
+      severity: 'high',
+      confidence: 'medium',
+    });
   });
 });
 

--- a/packages/warden/src/output/dedup.ts
+++ b/packages/warden/src/output/dedup.ts
@@ -778,7 +778,7 @@ const PROXIMITY_THRESHOLD = 5;
 export interface ConsolidateResult {
   findings: Finding[];
   removedCount: number;
-  removedFindings?: Finding[];
+  removedFindings: Finding[];
   usage?: UsageStats;
 }
 

--- a/packages/warden/src/output/dedup.ts
+++ b/packages/warden/src/output/dedup.ts
@@ -851,7 +851,7 @@ export async function consolidateBatchFindings(
   options: ConsolidateOptions = {}
 ): Promise<ConsolidateResult> {
   if (findings.length <= 1) {
-    return { findings, removedCount: 0 };
+    return { findings, removedCount: 0, removedFindings: [] };
   }
 
   // Phase 1: Hash dedup within batch

--- a/packages/warden/src/output/dedup.ts
+++ b/packages/warden/src/output/dedup.ts
@@ -186,6 +186,39 @@ export function parseWardenComment(body: string): { title: string; description: 
   return { title, description };
 }
 
+function sanitizeReviewCommentText(body: string): string {
+  return body
+    .replaceAll(/<details[\s\S]*?<\/details>/gi, ' ')
+    .replaceAll(/<!--[\s\S]*?-->/g, ' ')
+    .replaceAll(/<[^>]+>/g, ' ')
+    .replaceAll(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replaceAll(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replaceAll(/[*_`>#~-]+/g, ' ')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return value.slice(0, maxLength - 3).trimEnd() + '...';
+}
+
+function fallbackCommentDescription(body: string): string {
+  return truncateText(sanitizeReviewCommentText(body), 500);
+}
+
+function fallbackCommentTitle(body: string, commentId: number): string {
+  const description = sanitizeReviewCommentText(body);
+  if (!description) {
+    return `Review comment ${commentId}`;
+  }
+
+  return truncateText(description, 80);
+}
+
 /**
  * Parse the finding ID from a Warden comment's attribution or legacy title.
  */
@@ -469,13 +502,13 @@ export async function fetchExistingComments(
 
       const isWarden = isWardenComment(firstComment.body);
       const marker = isWarden ? parseMarker(firstComment.body) : null;
-      const parsed = parseWardenComment(firstComment.body);
+      const parsed = isWarden ? parseWardenComment(firstComment.body) : null;
       const findingMetadata = isWarden ? parseWardenFindingMetadata(firstComment.body) : null;
 
       // For Warden comments, we need parsed title/description
       // For external comments, we extract what we can or use body as description
-      const title = parsed?.title ?? '';
-      const description = parsed?.description ?? firstComment.body.slice(0, 500);
+      const title = parsed?.title ?? fallbackCommentTitle(firstComment.body, firstComment.databaseId);
+      const description = parsed?.description ?? fallbackCommentDescription(firstComment.body);
 
       comments.push({
         id: firstComment.databaseId,

--- a/packages/warden/src/output/dedup.ts
+++ b/packages/warden/src/output/dedup.ts
@@ -745,6 +745,7 @@ const PROXIMITY_THRESHOLD = 5;
 export interface ConsolidateResult {
   findings: Finding[];
   removedCount: number;
+  removedFindings?: Finding[];
   usage?: UsageStats;
 }
 
@@ -823,6 +824,7 @@ export async function consolidateBatchFindings(
   // Phase 1: Hash dedup within batch
   const seen = new Set<string>();
   const hashDeduped: Finding[] = [];
+  const hashRemovedFindings: Finding[] = [];
 
   for (const f of findings) {
     const hash = generateContentHash(f.title, f.description);
@@ -830,7 +832,10 @@ export async function consolidateBatchFindings(
     const path = f.location?.path ?? '';
     const key = `${path}:${line}:${hash}`;
 
-    if (seen.has(key)) continue;
+    if (seen.has(key)) {
+      hashRemovedFindings.push(f);
+      continue;
+    }
     seen.add(key);
     hashDeduped.push(f);
   }
@@ -846,7 +851,7 @@ export async function consolidateBatchFindings(
 
   // If no proximity clusters, hash-only mode, or no runtime auth, return hash-deduped results.
   if (clusters.length === 0 || options.hashOnly || !canUseRuntimeAuth(options)) {
-    return { findings: hashDeduped, removedCount: hashRemovedCount };
+    return { findings: hashDeduped, removedCount: hashRemovedCount, removedFindings: hashRemovedFindings };
   }
 
   // Phase 3: LLM consolidation for proximity clusters
@@ -884,13 +889,13 @@ Singletons (findings with no duplicates) should not appear in any group.
 
   if (!result.success) {
     console.warn(`LLM batch consolidation failed, keeping all findings: ${result.error}`);
-    return { findings: hashDeduped, removedCount: hashRemovedCount, usage: result.usage };
+    return { findings: hashDeduped, removedCount: hashRemovedCount, removedFindings: hashRemovedFindings, usage: result.usage };
   }
 
   const { absorbed, replacements } = applyMergeGroups(clusteredList, result.data);
 
   if (absorbed.size === 0) {
-    return { findings: hashDeduped, removedCount: hashRemovedCount, usage: result.usage };
+    return { findings: hashDeduped, removedCount: hashRemovedCount, removedFindings: hashRemovedFindings, usage: result.usage };
   }
 
   const consolidated = hashDeduped
@@ -900,7 +905,7 @@ Singletons (findings with no duplicates) should not appear in any group.
 
   console.log(`Consolidate: ${absorbed.size} findings merged by LLM (same root cause)`);
 
-  return { findings: consolidated, removedCount: totalRemoved, usage: result.usage };
+  return { findings: consolidated, removedCount: totalRemoved, removedFindings: [...hashRemovedFindings, ...absorbed], usage: result.usage };
 }
 
 /**

--- a/packages/warden/src/output/dedup.ts
+++ b/packages/warden/src/output/dedup.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { Octokit } from '@octokit/rest';
 import { z } from 'zod';
-import type { Finding, UsageStats } from '../types/index.js';
+import type { Confidence, Finding, Severity, UsageStats } from '../types/index.js';
 import { findingLine } from '../types/index.js';
 import { getRuntime } from '../sdk/runtimes/index.js';
 import { applyMergeGroups, canUseRuntimeAuth } from '../sdk/extract.js';
@@ -41,10 +41,16 @@ export interface ExistingComment {
   isWarden?: boolean;
   /** Skills that have already detected this issue (for Warden comments) */
   skills?: string[];
+  /** Original finding severity, when emitted by a recent Warden comment */
+  severity?: Severity;
+  /** Original finding confidence, when emitted by a recent Warden comment */
+  confidence?: Confidence;
   /** The raw comment body (needed for updating Warden comments) */
   body?: string;
   /** GraphQL node ID for the comment (needed for adding reactions) */
   commentNodeId?: string;
+  /** Login of the actor that authored the comment, when available */
+  actor?: string;
 }
 
 /**
@@ -57,6 +63,8 @@ export type DuplicateActionType = 'update_warden' | 'react_external';
  */
 export interface DuplicateAction {
   type: DuplicateActionType;
+  /** ID produced by the current run before any Warden ID recentering */
+  originalFindingId: string;
   finding: Finding;
   existingComment: ExistingComment;
   /** Whether this was a hash match or semantic match */
@@ -92,6 +100,14 @@ export function generateMarker(path: string, line: number, contentHash: string):
   return `<!-- warden:v1:${path}:${line}:${contentHash} -->`;
 }
 
+export function generateFindingMetadata(finding: Pick<Finding, 'severity' | 'confidence'>): string {
+  const metadata = {
+    severity: finding.severity,
+    confidence: finding.confidence,
+  };
+  return `<!-- warden:finding:v1:${Buffer.from(JSON.stringify(metadata), 'utf8').toString('base64url')} -->`;
+}
+
 /**
  * Parse a Warden marker from a comment body.
  * Returns null if no valid marker is found.
@@ -116,6 +132,32 @@ export function parseMarker(body: string): WardenMarker | null {
     line: parseInt(lineStr, 10),
     contentHash,
   };
+}
+
+export function parseWardenFindingMetadata(body: string): Pick<Finding, 'severity' | 'confidence'> | null {
+  const match = body.match(/<!-- warden:finding:v1:([A-Za-z0-9_-]+) -->/);
+  const encoded = match?.[1];
+  if (!encoded) return null;
+
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as Partial<Finding>;
+    const severity = parsed.severity;
+    if (severity !== 'high' && severity !== 'medium' && severity !== 'low') return null;
+
+    const confidence = parsed.confidence;
+    if (
+      confidence !== undefined &&
+      confidence !== 'high' &&
+      confidence !== 'medium' &&
+      confidence !== 'low'
+    ) {
+      return null;
+    }
+
+    return { severity, confidence };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -333,6 +375,9 @@ interface ReviewThreadNode {
       path: string;
       line: number | null;
       originalLine: number | null;
+      author?: {
+        login: string;
+      } | null;
     }[];
   };
 }
@@ -371,6 +416,9 @@ const REVIEW_THREADS_QUERY = `
                 path
                 line
                 originalLine
+                author {
+                  login
+                }
               }
             }
           }
@@ -422,6 +470,7 @@ export async function fetchExistingComments(
       const isWarden = isWardenComment(firstComment.body);
       const marker = isWarden ? parseMarker(firstComment.body) : null;
       const parsed = parseWardenComment(firstComment.body);
+      const findingMetadata = isWarden ? parseWardenFindingMetadata(firstComment.body) : null;
 
       // For Warden comments, we need parsed title/description
       // For external comments, we extract what we can or use body as description
@@ -440,8 +489,11 @@ export async function fetchExistingComments(
         isResolved: thread.isResolved,
         isWarden,
         skills: isWarden ? parseWardenSkills(firstComment.body) : undefined,
+        severity: findingMetadata?.severity,
+        confidence: findingMetadata?.confidence,
         body: firstComment.body,
         commentNodeId: firstComment.id,
+        actor: firstComment.author?.login,
       });
     }
 
@@ -676,6 +728,8 @@ export function findingToExistingComment(finding: Finding, skill?: string): Exis
     contentHash: generateContentHash(finding.title, finding.description),
     isWarden: true,
     skills: skill ? [skill] : [],
+    severity: finding.severity,
+    ...(finding.confidence ? { confidence: finding.confidence } : {}),
   };
 }
 
@@ -909,9 +963,13 @@ export async function deduplicateFindings(
     }
 
     if (matchingComment) {
+      const duplicateFinding = matchingComment.isWarden && matchingComment.findingId
+        ? { ...finding, id: matchingComment.findingId }
+        : finding;
       duplicateActions.push({
         type: matchingComment.isWarden ? 'update_warden' : 'react_external',
-        finding,
+        originalFindingId: finding.id,
+        finding: duplicateFinding,
         existingComment: matchingComment,
         matchType: 'hash',
       });
@@ -940,9 +998,13 @@ export async function deduplicateFindings(
   for (const finding of hashDedupedFindings) {
     const matchingComment = semanticResult.matches.get(finding.id);
     if (matchingComment) {
+      const duplicateFinding = matchingComment.isWarden && matchingComment.findingId
+        ? { ...finding, id: matchingComment.findingId }
+        : finding;
       duplicateActions.push({
         type: matchingComment.isWarden ? 'update_warden' : 'react_external',
-        finding,
+        originalFindingId: finding.id,
+        finding: duplicateFinding,
         existingComment: matchingComment,
         matchType: 'semantic',
       });

--- a/packages/warden/src/output/renderer.ts
+++ b/packages/warden/src/output/renderer.ts
@@ -2,7 +2,7 @@ import { SEVERITY_ORDER, filterFindings } from '../types/index.js';
 import type { SkillReport, Finding, Severity, SeverityThreshold } from '../types/index.js';
 import type { RenderResult, RenderOptions, GitHubReview, GitHubComment } from './types.js';
 import { capitalize, formatStatsCompact, countBySeverity, pluralize } from '../cli/output/formatters.js';
-import { generateContentHash, generateMarker } from './dedup.js';
+import { generateContentHash, generateFindingMetadata, generateMarker } from './dedup.js';
 import { escapeHtml } from '../utils/index.js';
 
 export function renderSkillReport(report: SkillReport, options: RenderOptions = {}): RenderResult {
@@ -98,6 +98,7 @@ function renderReview(
     const contentHash = generateContentHash(finding.title, finding.description);
     const line = location.endLine ?? location.startLine;
     body += `\n${generateMarker(location.path, line, contentHash)}`;
+    body += `\n${generateFindingMetadata(finding)}`;
 
     const isMultiLine = location.endLine && location.startLine !== location.endLine;
 

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -3,7 +3,7 @@ import { APIError } from '@anthropic-ai/sdk';
 import type { SkillDefinition } from '../config/schema.js';
 import type { HunkWithContext } from '../diff/index.js';
 import type { EventContext, Finding, UsageStats } from '../types/index.js';
-import { analyzeFile, filterOutOfRangeFindings, runSkill } from './analyze.js';
+import { analyzeFile, buildSourceSnippet, filterOutOfRangeFindings, runSkill } from './analyze.js';
 import type { PreparedFile } from './types.js';
 import { getRuntime, type Runtime } from './runtimes/index.js';
 import { ProviderFailureCircuitBreaker } from './circuit-breaker.js';
@@ -224,6 +224,50 @@ describe('filterOutOfRangeFindings', () => {
     const { filtered, dropped } = filterOutOfRangeFindings([], hunkRange);
     expect(filtered).toEqual([]);
     expect(dropped).toEqual([]);
+  });
+});
+
+describe('buildSourceSnippet', () => {
+  it('captures the target line and surrounding reviewed context', () => {
+    const hunk: HunkWithContext = {
+      filename: 'src/example.ts',
+      hunk: {
+        oldStart: 10,
+        oldCount: 3,
+        newStart: 10,
+        newCount: 4,
+        content: '@@ -10,3 +10,4 @@\n const before = true;\n-oldCall();\n+newCall(userInput);\n+audit();\n const after = true;',
+        lines: [
+          ' const before = true;',
+          '-oldCall();',
+          '+newCall(userInput);',
+          '+audit();',
+          ' const after = true;',
+        ],
+      },
+      contextBefore: ['function release() {', '  const userInput = title;'],
+      contextAfter: ['  return true;', '}'],
+      contextStartLine: 8,
+      language: 'typescript',
+    };
+
+    const snippet = buildSourceSnippet(makeFinding(11), hunk, 2);
+
+    expect(snippet).toEqual({
+      path: 'file.ts',
+      language: 'typescript',
+      startLine: 9,
+      endLine: 13,
+      targetStartLine: 11,
+      targetEndLine: 11,
+      lines: [
+        { line: 9, content: '  const userInput = title;', highlighted: false },
+        { line: 10, content: 'const before = true;', highlighted: false },
+        { line: 11, content: 'newCall(userInput);', highlighted: true },
+        { line: 12, content: 'audit();', highlighted: false },
+        { line: 13, content: 'const after = true;', highlighted: false },
+      ],
+    });
   });
 });
 

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -269,6 +269,31 @@ describe('buildSourceSnippet', () => {
       ],
     });
   });
+
+  it('ignores trailing empty diff parser lines when numbering source snippets', () => {
+    const hunk: HunkWithContext = {
+      filename: 'src/example.ts',
+      hunk: {
+        oldStart: 10,
+        oldCount: 1,
+        newStart: 10,
+        newCount: 1,
+        content: '@@ -10,1 +10,1 @@\n+newCall();\n',
+        lines: ['+newCall();', ''],
+      },
+      contextBefore: [],
+      contextAfter: ['after();'],
+      contextStartLine: 10,
+      language: 'typescript',
+    };
+
+    const snippet = buildSourceSnippet(makeFinding(10), hunk, 1);
+
+    expect(snippet?.lines).toEqual([
+      { line: 10, content: 'newCall();', highlighted: true },
+      { line: 11, content: 'after();', highlighted: false },
+    ]);
+  });
 });
 
 describe('analyzeFile', () => {

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -182,9 +182,8 @@ function hunkSourceLines(hunkCtx: HunkWithContext): SourceSnippetLine[] {
   let newLine = hunkCtx.hunk.newStart;
   for (const diffLine of hunkCtx.hunk.lines) {
     if (diffLine.startsWith('-')) continue;
-    const content = diffLine.startsWith('+') || diffLine.startsWith(' ')
-      ? diffLine.slice(1)
-      : diffLine;
+    if (!diffLine.startsWith('+') && !diffLine.startsWith(' ')) continue;
+    const content = diffLine.slice(1);
     lines.push({ line: newLine, content });
     newLine += 1;
   }

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -26,6 +26,7 @@ import {
 } from './types.js';
 import { prepareFiles } from './prepare.js';
 import type { EventContext, SkillReport, UsageStats, HunkFailure } from '../types/index.js';
+import type { SourceSnippet, SourceSnippetLine } from '../types/index.js';
 import { runPool } from '../utils/index.js';
 
 /** Result from parsing hunk output */
@@ -170,6 +171,72 @@ export function filterOutOfRangeFindings(
     }
   }
   return { filtered, dropped };
+}
+
+function hunkSourceLines(hunkCtx: HunkWithContext): SourceSnippetLine[] {
+  const lines: SourceSnippetLine[] = [];
+  for (const [index, content] of hunkCtx.contextBefore.entries()) {
+    lines.push({ line: hunkCtx.contextStartLine + index, content });
+  }
+
+  let newLine = hunkCtx.hunk.newStart;
+  for (const diffLine of hunkCtx.hunk.lines) {
+    if (diffLine.startsWith('-')) continue;
+    const content = diffLine.startsWith('+') || diffLine.startsWith(' ')
+      ? diffLine.slice(1)
+      : diffLine;
+    lines.push({ line: newLine, content });
+    newLine += 1;
+  }
+
+  const afterStart = hunkCtx.hunk.newStart + hunkCtx.hunk.newCount;
+  for (const [index, content] of hunkCtx.contextAfter.entries()) {
+    lines.push({ line: afterStart + index, content });
+  }
+
+  return lines;
+}
+
+export function buildSourceSnippet(
+  finding: Finding,
+  hunkCtx: HunkWithContext,
+  contextLines = 3
+): SourceSnippet | undefined {
+  if (!finding.location) return undefined;
+
+  const targetStartLine = finding.location.startLine;
+  const targetEndLine = finding.location.endLine ?? targetStartLine;
+  const startLine = Math.max(1, targetStartLine - contextLines);
+  const endLine = targetEndLine + contextLines;
+  const lines = hunkSourceLines(hunkCtx)
+    .filter((line) => line.line >= startLine && line.line <= endLine)
+    .map((line) => ({
+      ...line,
+      highlighted: line.line >= targetStartLine && line.line <= targetEndLine,
+    }));
+
+  if (lines.length === 0) return undefined;
+  const firstLine = lines[0];
+  const lastLine = lines.at(-1);
+  if (!firstLine || !lastLine) return undefined;
+
+  return {
+    path: finding.location.path,
+    language: hunkCtx.language,
+    startLine: firstLine.line,
+    endLine: lastLine.line,
+    targetStartLine,
+    targetEndLine,
+    lines,
+  };
+}
+
+function attachSourceSnippets(findings: Finding[], hunkCtx: HunkWithContext): Finding[] {
+  return findings.map((finding) => {
+    if (!finding.location) return finding;
+    const sourceSnippet = buildSourceSnippet(finding, hunkCtx);
+    return sourceSnippet ? { ...finding, sourceSnippet } : finding;
+  });
 }
 
 /**
@@ -334,7 +401,8 @@ async function analyzeHunk(
 
           // Filter findings outside hunk line range (defense-in-depth)
           const hunkRange = getHunkLineRange(hunkCtx.hunk);
-          const { filtered: filteredFindings, dropped } = filterOutOfRangeFindings(parseResult.findings, hunkRange);
+          const { filtered, dropped } = filterOutOfRangeFindings(parseResult.findings, hunkRange);
+          const filteredFindings = attachSourceSnippets(filtered, hunkCtx);
           if (dropped.length > 0) {
             Sentry.addBreadcrumb({
               category: 'finding.out_of_range',

--- a/packages/warden/src/sdk/extract.ts
+++ b/packages/warden/src/sdk/extract.ts
@@ -14,6 +14,8 @@ import {
   joinPromptSections,
 } from './prompt-sections.js';
 
+const ExtractedFindingSchema = FindingSchema.omit({ sourceSnippet: true });
+
 /** Pattern to match the start of findings JSON (allows whitespace after brace) */
 export const FINDINGS_JSON_START = /\{\s*"findings"/;
 
@@ -270,26 +272,34 @@ export function generateShortId(): string {
 
 /**
  * Validate and normalize findings from extracted JSON.
- * Replaces the LLM-provided ID with a short nanoid for stable cross-referencing.
+ * Replaces the LLM-provided ID with a short ID for cross-referencing.
  */
 export function validateFindings(findings: unknown[], filename: string): Finding[] {
   const validated: Finding[] = [];
 
   for (const f of findings) {
+    const candidate = typeof f === 'object' && f !== null
+      ? { ...(f as Record<string, unknown>) }
+      : f;
+
     // Normalize location path before validation
-    if (typeof f === 'object' && f !== null && 'location' in f) {
-      const loc = (f as Record<string, unknown>)['location'];
+    if (typeof candidate === 'object' && candidate !== null && 'location' in candidate) {
+      const loc = (candidate as Record<string, unknown>)['location'];
       if (loc && typeof loc === 'object') {
-        (loc as Record<string, unknown>)['path'] = filename;
+        (candidate as Record<string, unknown>)['location'] = {
+          ...(loc as Record<string, unknown>),
+          path: filename,
+        };
       }
     }
 
-    const result = FindingSchema.safeParse(f);
+    const result = ExtractedFindingSchema.safeParse(candidate);
     if (result.success) {
+      const location = result.data.location ? { ...result.data.location, path: filename } : undefined;
       validated.push({
         ...result.data,
         id: generateShortId(),
-        location: result.data.location ? { ...result.data.location, path: filename } : undefined,
+        location,
       });
     }
   }

--- a/packages/warden/src/sdk/runner.test.ts
+++ b/packages/warden/src/sdk/runner.test.ts
@@ -963,6 +963,29 @@ describe('validateFindings', () => {
     expect(validated[0]!.location!.path).toBe('correct-path.ts');
   });
 
+  it('strips model-provided source snippets during extraction', () => {
+    const rawFindings = [
+      {
+        id: 'id-1',
+        severity: 'medium',
+        title: 'Issue',
+        description: 'Details',
+        sourceSnippet: {
+          path: 'made-up.ts',
+          startLine: 1,
+          endLine: 1,
+          targetStartLine: 1,
+          targetEndLine: 1,
+          lines: [{ line: 1, content: 'hallucinated', highlighted: true }],
+        },
+      },
+    ];
+
+    const validated = validateFindings(rawFindings, 'file.ts');
+    expect(validated).toHaveLength(1);
+    expect(validated[0]!.sourceSnippet).toBeUndefined();
+  });
+
   it('filters out invalid findings', () => {
     const rawFindings = [
       {

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -101,6 +101,24 @@ export const SuggestedFixSchema = z.object({
 });
 export type SuggestedFix = z.infer<typeof SuggestedFixSchema>;
 
+export const SourceSnippetLineSchema = z.object({
+  line: z.number().int().positive(),
+  content: z.string(),
+  highlighted: z.boolean().optional(),
+});
+export type SourceSnippetLine = z.infer<typeof SourceSnippetLineSchema>;
+
+export const SourceSnippetSchema = z.object({
+  path: z.string(),
+  language: z.string().optional(),
+  startLine: z.number().int().positive(),
+  endLine: z.number().int().positive(),
+  targetStartLine: z.number().int().positive(),
+  targetEndLine: z.number().int().positive(),
+  lines: z.array(SourceSnippetLineSchema),
+});
+export type SourceSnippet = z.infer<typeof SourceSnippetSchema>;
+
 // Individual finding from a skill
 export const FindingSchema = z.object({
   id: z.string(),
@@ -112,6 +130,7 @@ export const FindingSchema = z.object({
   location: LocationSchema.optional(),
   additionalLocations: z.array(LocationSchema).optional(),
   suggestedFix: SuggestedFixSchema.optional(),
+  sourceSnippet: SourceSnippetSchema.optional(),
   elapsedMs: z.number().nonnegative().optional(),
 });
 export type Finding = z.infer<typeof FindingSchema>;

--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -186,6 +186,70 @@
         "suggestedFix": {
           "$ref": "#/$defs/SuggestedFix"
         },
+        "sourceSnippet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "language": {
+              "type": "string"
+            },
+            "startLine": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "endLine": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "targetStartLine": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "targetEndLine": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "lines": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "highlighted": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "line",
+                  "content"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "path",
+            "startLine",
+            "endLine",
+            "targetStartLine",
+            "targetEndLine",
+            "lines"
+          ],
+          "additionalProperties": false
+        },
         "elapsedMs": {
           "type": "number",
           "minimum": 0


### PR DESCRIPTION
Add structured reporting data to Warden findings output so downstream reporting can understand what happened to each finding after analysis. The payload now separates analysis results from GitHub review mechanics: findings remain in the skill reports, while observations record posting, dedupe, skip, failure, and resolution outcomes.

**Finding Observations**

Review posting emits per-finding observations with stable outcome identifiers: `posted`, `deduped`, `skipped`, `failed`, and `resolved`. Threshold decisions such as `reportOn`, `minConfidence`, and `maxFindings` stay in the comment/check posting layer; they do not create separate reporting outcomes or duplicate the findings payload.

**Skipped and Deduped Semantics**

Skipped observations are reserved for concrete posting outcomes Warden owns, currently `max_findings` and `duplicate_in_batch`. Deduped observations point at existing Warden comments when a real comment ID is available, and avoid emitting sentinel IDs for newly posted comments in the same run.

**Source and Resolution Context**

Findings now carry Warden-derived source snippets from the analyzed hunk, ignoring model-provided snippet text during extraction. Resolved comments are represented as resolved observations from Warden comment metadata, including stale/fix-evaluation cleanup paths, so resolved findings are not silently dropped from the reporting output.