### PR TITLE
test(evals): Add real-world code review fixtures

### DIFF
--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -191,7 +191,7 @@ positive.
 ## Running Evals
 
 ```bash
-# Run all evals (requires ANTHROPIC_API_KEY)
+# Run all evals (requires ANTHROPIC_API_KEY or WARDEN_ANTHROPIC_API_KEY)
 pnpm evals
 
 # Run evals for a specific skill
@@ -214,6 +214,8 @@ pnpm evals:scaffold https://github.com/getsentry/sentry/pull/12345
 ```
 
 Evals make real API calls and are skipped when `ANTHROPIC_API_KEY` is not set.
+`WARDEN_ANTHROPIC_API_KEY` is bridged into `ANTHROPIC_API_KEY` during eval
+setup, so the usual Warden-prefixed environment works too.
 Suites choose the runtime and model. The checked-in full-pipeline suites
 currently run Pi with `anthropic/claude-sonnet-4-6`.
 

--- a/packages/evals/code-review/async-for-each-invites.json
+++ b/packages/evals/code-review/async-for-each-invites.json
@@ -1,0 +1,15 @@
+{
+  "given": "project invite sending uses forEach with an async callback and returns completed invite results for audit logging",
+  "files": [
+    "fixtures/async-for-each-invites/invites.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "sendProjectInvites returns before the async forEach callbacks finish, so sent is 0, results are empty, and invite failures are detached from the returned promise"
+    }
+  ],
+  "should_not_find": [
+    "style, formatting, or naming issues",
+    "the lack of batching or rate limiting"
+  ]
+}

--- a/packages/evals/code-review/falsey-default-limit.json
+++ b/packages/evals/code-review/falsey-default-limit.json
@@ -1,0 +1,15 @@
+{
+  "given": "search request building supports limit 0 as a metadata-only request but defaults falsey limits with ||",
+  "files": [
+    "fixtures/falsey-default-limit/search.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "buildSearchRequest treats limit: 0 as absent because it uses options.limit || DEFAULT_LIMIT, so metadata-only searches fetch 50 rows instead of zero"
+    }
+  ],
+  "should_not_find": [
+    "style, formatting, or naming issues",
+    "includeArchived defaulting to false"
+  ]
+}

--- a/packages/evals/code-review/ignores-style-issues.json
+++ b/packages/evals/code-review/ignores-style-issues.json
@@ -1,0 +1,18 @@
+{
+  "given": "functionally correct code with style issues, verbose conditionals, and magic numbers",
+  "files": [
+    "fixtures/ignores-style-issues/utils.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "no bugs: the code is functionally correct despite style and readability issues, so zero findings are expected",
+      "required": false
+    }
+  ],
+  "should_not_find": [
+    "inconsistent naming convention",
+    "missing JSDoc comments",
+    "verbose conditional that could be simplified",
+    "magic numbers in discount calculation"
+  ]
+}

--- a/packages/evals/code-review/pagination-floor-total-pages.json
+++ b/packages/evals/code-review/pagination-floor-total-pages.json
@@ -1,0 +1,15 @@
+{
+  "given": "fetchAllItems computes total pages for a paginated API where the final page can be partially full",
+  "files": [
+    "fixtures/pagination-floor-total-pages/paginator.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "fetchAllItems uses Math.floor(totalItems / pageSize), so it skips the final partial page when totalItems is not evenly divisible by pageSize"
+    }
+  ],
+  "should_not_find": [
+    "style, formatting, or naming issues",
+    "missing retry handling"
+  ]
+}

--- a/packages/evals/code-review/permission-level-comparison.json
+++ b/packages/evals/code-review/permission-level-comparison.json
@@ -1,0 +1,15 @@
+{
+  "given": "permission filtering uses a role hierarchy where higher roles include lower-role permissions",
+  "files": [
+    "fixtures/permission-level-comparison/permissions.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "canPerform uses <= instead of >=, so lower roles are granted higher-role actions while owners are denied lower-role actions"
+    }
+  ],
+  "should_not_find": [
+    "style, formatting, or naming issues",
+    "using string literal role names instead of an enum"
+  ]
+}

--- a/packages/evals/code-review/sentry-action-dedup-by-workflow.json
+++ b/packages/evals/code-review/sentry-action-dedup-by-workflow.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry workflow engine evaluates notification actions from different workflows that target the same destination and issue",
+  "files": [
+    "fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_models_action.py",
+    "fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_processors_action.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-action-dedup-by-workflow/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "action deduplication keys include workflow id, so the same notification can be sent multiple times to the same destination for the same issue when different workflows produce it"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/165be911ba388d402993b58f34dc8ad683827e32",
+    "repository": "getsentry/sentry",
+    "source_ref": "1730e13b97865d3ee8943c6f860964388c4987a8",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_models_action.py",
+        "sourcePath": "src/sentry/workflow_engine/models/action.py",
+        "ref": "1730e13b97865d3ee8943c6f860964388c4987a8"
+      },
+      {
+        "fixturePath": "fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_processors_action.py",
+        "sourcePath": "src/sentry/workflow_engine/processors/action.py",
+        "ref": "1730e13b97865d3ee8943c6f860964388c4987a8"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 165be911ba388d402993b58f34dc8ad683827e32. action deduplication keys include workflow id, so the same notification can be sent multiple times to the same destination for the same issue when different workflows produce it"
+  }
+}

--- a/packages/evals/code-review/sentry-ai-conversation-multipart-message.json
+++ b/packages/evals/code-review/sentry-ai-conversation-multipart-message.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry AI conversation rendering receives a message made of multiple content parts",
+  "files": [
+    "fixtures/sentry-ai-conversation-multipart-message/conversationMessages.ts"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-ai-conversation-multipart-message/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "conversation message utilities assume a single-part message shape, so multi-part AI conversation messages are not rendered or parsed correctly"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/ce32ccf8e820cf565c91ba9760c36df87dda353f",
+    "repository": "getsentry/sentry",
+    "source_ref": "8e5104733bdb0d03d2f7148da5869a651c4f23fd",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-ai-conversation-multipart-message/conversationMessages.ts",
+        "sourcePath": "static/app/views/insights/pages/conversations/utils/conversationMessages.ts",
+        "ref": "8e5104733bdb0d03d2f7148da5869a651c4f23fd"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix ce32ccf8e820cf565c91ba9760c36df87dda353f. conversation message utilities assume a single-part message shape, so multi-part AI conversation messages are not rendered or parsed correctly"
+  }
+}

--- a/packages/evals/code-review/sentry-code-review-pr-closed-trigger-filter.json
+++ b/packages/evals/code-review/sentry-code-review-pr-closed-trigger-filter.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry code review webhook receives a pr_closed event for a repo with enabled_code_review true and an empty code_review_triggers list",
+  "files": [
+    "fixtures/sentry-code-review-pr-closed-trigger-filter/pull_request.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-code-review-pr-closed-trigger-filter/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "pr_closed bypasses the trigger gate when code_review_triggers is empty, so repos configured with no code review triggers can still run close handling"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/722441c01309a9487d94bb84c740b6ae1b453735",
+    "repository": "getsentry/sentry",
+    "source_ref": "1d0f212196da9d2c5e2c6bf66ff2e3f6e694e44a",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-code-review-pr-closed-trigger-filter/pull_request.py",
+        "sourcePath": "src/sentry/seer/code_review/webhooks/pull_request.py",
+        "ref": "1d0f212196da9d2c5e2c6bf66ff2e3f6e694e44a"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 722441c01309a9487d94bb84c740b6ae1b453735. pr_closed bypasses the trigger gate when code_review_triggers is empty, so repos configured with no code review triggers can still run close handling"
+  }
+}

--- a/packages/evals/code-review/sentry-cursor-service-account-api-key.json
+++ b/packages/evals/code-review/sentry-cursor-service-account-api-key.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry Cursor integration verifies an API key created for a Cursor service account",
+  "files": [
+    "fixtures/sentry-cursor-service-account-api-key/client.py",
+    "fixtures/sentry-cursor-service-account-api-key/integration.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-cursor-service-account-api-key/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "verify_api_key only relies on the /v0/me endpoint, which fails for Cursor service account keys and prevents valid service accounts from setting up the integration"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/652324b48217e89f4267bfc1bb6e5e390818c277",
+    "repository": "getsentry/sentry",
+    "source_ref": "dd2e7671013b38550048c3c427b5152997e91ab9",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-cursor-service-account-api-key/client.py",
+        "sourcePath": "src/sentry/integrations/cursor/client.py",
+        "ref": "dd2e7671013b38550048c3c427b5152997e91ab9"
+      },
+      {
+        "fixturePath": "fixtures/sentry-cursor-service-account-api-key/integration.py",
+        "sourcePath": "src/sentry/integrations/cursor/integration.py",
+        "ref": "dd2e7671013b38550048c3c427b5152997e91ab9"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 652324b48217e89f4267bfc1bb6e5e390818c277. verify_api_key only relies on the /v0/me endpoint, which fails for Cursor service account keys and prevents valid service accounts from setting up the integration"
+  }
+}

--- a/packages/evals/code-review/sentry-dashboard-axis-range-existing-widget.json
+++ b/packages/evals/code-review/sentry-dashboard-axis-range-existing-widget.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry dashboard widget builder opens an existing widget saved before axisRange was introduced",
+  "files": [
+    "fixtures/sentry-dashboard-axis-range-existing-widget/convertWidgetToBuilderStateParams.ts",
+    "fixtures/sentry-dashboard-axis-range-existing-widget/getDefaultWidget.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-dashboard-axis-range-existing-widget/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "convertWidgetToBuilderStateParams leaves missing widget.axisRange undefined for existing widgets, so the builder applies dataset defaults and shows a different Y-axis range than the saved chart actually renders"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/01217a6efb90cd26f0f8ac8b33c4f255379fe21d",
+    "repository": "getsentry/sentry",
+    "source_ref": "1b2028bb7455b62fba59a1eb3b9d00bdcff27d51",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-dashboard-axis-range-existing-widget/convertWidgetToBuilderStateParams.ts",
+        "sourcePath": "static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts",
+        "ref": "1b2028bb7455b62fba59a1eb3b9d00bdcff27d51"
+      },
+      {
+        "fixturePath": "fixtures/sentry-dashboard-axis-range-existing-widget/getDefaultWidget.tsx",
+        "sourcePath": "static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx",
+        "ref": "1b2028bb7455b62fba59a1eb3b9d00bdcff27d51"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 01217a6efb90cd26f0f8ac8b33c4f255379fe21d. convertWidgetToBuilderStateParams leaves missing widget.axisRange undefined for existing widgets, so the builder applies dataset defaults and shows a different Y-axis range than the saved chart actually renders"
+  }
+}

--- a/packages/evals/code-review/sentry-dashboard-delete-side-nav-stale.json
+++ b/packages/evals/code-review/sentry-dashboard-delete-side-nav-stale.json
@@ -1,0 +1,44 @@
+{
+  "given": "Sentry dashboards landing page deletes a starred dashboard shown in the side navigation",
+  "files": [
+    "fixtures/sentry-dashboard-delete-side-nav-stale/dashboards.tsx",
+    "fixtures/sentry-dashboard-delete-side-nav-stale/detail.tsx",
+    "fixtures/sentry-dashboard-delete-side-nav-stale/useDeleteDashboard.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-dashboard-delete-side-nav-stale/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "deleting a dashboard from the landing page does not update the side navigation, so a starred deleted dashboard remains visible until refresh"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/86872f4f1491c4392a25f4d3fcba31a12726fa63",
+    "repository": "getsentry/sentry",
+    "source_ref": "14170bd6ae28abe4d4f0b5807185b116f777a1a0",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-dashboard-delete-side-nav-stale/dashboards.tsx",
+        "sourcePath": "static/app/actionCreators/dashboards.tsx",
+        "ref": "14170bd6ae28abe4d4f0b5807185b116f777a1a0"
+      },
+      {
+        "fixturePath": "fixtures/sentry-dashboard-delete-side-nav-stale/detail.tsx",
+        "sourcePath": "static/app/views/dashboards/detail.tsx",
+        "ref": "14170bd6ae28abe4d4f0b5807185b116f777a1a0"
+      },
+      {
+        "fixturePath": "fixtures/sentry-dashboard-delete-side-nav-stale/useDeleteDashboard.tsx",
+        "sourcePath": "static/app/views/dashboards/hooks/useDeleteDashboard.tsx",
+        "ref": "14170bd6ae28abe4d4f0b5807185b116f777a1a0"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 86872f4f1491c4392a25f4d3fcba31a12726fa63. deleting a dashboard from the landing page does not update the side navigation, so a starred deleted dashboard remains visible until refresh"
+  }
+}

--- a/packages/evals/code-review/sentry-dashboard-other-series-color.json
+++ b/packages/evals/code-review/sentry-dashboard-other-series-color.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry dashboard new timeseries visualization renders the Other series returned from top-N grouping",
+  "files": [
+    "fixtures/sentry-dashboard-other-series-color/visualizationWidget.tsx",
+    "fixtures/sentry-dashboard-other-series-color/createPlottableFromTimeSeries.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-dashboard-other-series-color/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the new timeseries visualization does not map the Other series to the neutral grey color, so Other renders with the wrong series color instead of matching dashboard conventions"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/de65182e8c3491930779dd88522ea04ee9633314",
+    "repository": "getsentry/sentry",
+    "source_ref": "f945e1ccefd3349392bbc6b7fc4aa9da4d3decc8",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-dashboard-other-series-color/visualizationWidget.tsx",
+        "sourcePath": "static/app/views/dashboards/widgetCard/visualizationWidget.tsx",
+        "ref": "f945e1ccefd3349392bbc6b7fc4aa9da4d3decc8"
+      },
+      {
+        "fixturePath": "fixtures/sentry-dashboard-other-series-color/createPlottableFromTimeSeries.tsx",
+        "sourcePath": "static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx",
+        "ref": "f945e1ccefd3349392bbc6b7fc4aa9da4d3decc8"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix de65182e8c3491930779dd88522ea04ee9633314. the new timeseries visualization does not map the Other series to the neutral grey color, so Other renders with the wrong series color instead of matching dashboard conventions"
+  }
+}

--- a/packages/evals/code-review/sentry-detector-validator-user-context.json
+++ b/packages/evals/code-review/sentry-detector-validator-user-context.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry detector endpoints build validator context for detector type feature flag checks targeted at the requesting actor",
+  "files": [
+    "fixtures/sentry-detector-validator-user-context/organization_detector_details.py",
+    "fixtures/sentry-detector-validator-user-context/organization_detector_index.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-detector-validator-user-context/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "get_detector_validator omits request.user from the validator context, so detector validators that evaluate actor-targeted feature flags cannot see the requesting user and reject or mis-handle enabled detector flows"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/f19882e5a3f81e2d98a05af58c5faa1b406499c8",
+    "repository": "getsentry/sentry",
+    "source_ref": "93b7cee973b5da40d542b5f7d13c639752ee508b",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-detector-validator-user-context/organization_detector_details.py",
+        "sourcePath": "src/sentry/workflow_engine/endpoints/organization_detector_details.py",
+        "ref": "93b7cee973b5da40d542b5f7d13c639752ee508b"
+      },
+      {
+        "fixturePath": "fixtures/sentry-detector-validator-user-context/organization_detector_index.py",
+        "sourcePath": "src/sentry/workflow_engine/endpoints/organization_detector_index.py",
+        "ref": "93b7cee973b5da40d542b5f7d13c639752ee508b"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix f19882e5a3f81e2d98a05af58c5faa1b406499c8. get_detector_validator omits request.user from the validator context, so detector validators that evaluate actor-targeted feature flags cannot see the requesting user and reject or mis-handle enabled detector flows"
+  }
+}

--- a/packages/evals/code-review/sentry-empty-repo-409-cache.json
+++ b/packages/evals/code-review/sentry-empty-repo-409-cache.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry source code integration repeatedly fetches a GitHub tree for an empty repository that returns 409",
+  "files": [
+    "fixtures/sentry-empty-repo-409-cache/repo_trees.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-empty-repo-409-cache/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "get_tree propagates GitHub empty-repository 409 responses without caching the halt result, so every task run refetches the same empty repo and repeats the API failure"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/b53670419ece85ff5a06ef0f3fc21e71579599ba",
+    "repository": "getsentry/sentry",
+    "source_ref": "8e974682bd2f71ae62cf197ac32ccc1a74ae588b",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-empty-repo-409-cache/repo_trees.py",
+        "sourcePath": "src/sentry/integrations/source_code_management/repo_trees.py",
+        "ref": "8e974682bd2f71ae62cf197ac32ccc1a74ae588b"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix b53670419ece85ff5a06ef0f3fc21e71579599ba. get_tree propagates GitHub empty-repository 409 responses without caching the halt result, so every task run refetches the same empty repo and repeats the API failure"
+  }
+}

--- a/packages/evals/code-review/sentry-event-grouping-info-mutates-class-context.json
+++ b/packages/evals/code-review/sentry-event-grouping-info-mutates-class-context.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry grouping info endpoint builds per-request grouping context from a class-level initial_context template",
+  "files": [
+    "fixtures/sentry-event-grouping-info-mutates-class-context/event_grouping_info.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-event-grouping-info-mutates-class-context/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the grouping info endpoint mutates the class-level initial_context template, so request-specific context can leak across later grouping-info requests"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/267604be196501908e72f0e9fd2d2b1c7dbfe627",
+    "repository": "getsentry/sentry",
+    "source_ref": "8e9805a67b95be03d9700ac66dd8a65a7df5fb6c",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-event-grouping-info-mutates-class-context/event_grouping_info.py",
+        "sourcePath": "src/sentry/issues/endpoints/event_grouping_info.py",
+        "ref": "8e9805a67b95be03d9700ac66dd8a65a7df5fb6c"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 267604be196501908e72f0e9fd2d2b1c7dbfe627. the grouping info endpoint mutates the class-level initial_context template, so request-specific context can leak across later grouping-info requests"
+  }
+}

--- a/packages/evals/code-review/sentry-explorer-autofix-missing-group-id.json
+++ b/packages/evals/code-review/sentry-explorer-autofix-missing-group-id.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry explorer autofix metadata is used by Slack integration to continue an issue-specific flow",
+  "files": [
+    "fixtures/sentry-explorer-autofix-missing-group-id/autofix_agent.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-explorer-autofix-missing-group-id/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "explorer autofix metadata can omit group_id, so the Slack integration lacks the issue identifier needed to continue the expected autofix flow"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/c9772d7047ef78d03dbedcb87a1214a9af30ef07",
+    "repository": "getsentry/sentry",
+    "source_ref": "bf9c244d0341de6ad77ed57e7b1479a1320f9871",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-explorer-autofix-missing-group-id/autofix_agent.py",
+        "sourcePath": "src/sentry/seer/autofix/autofix_agent.py",
+        "ref": "bf9c244d0341de6ad77ed57e7b1479a1320f9871"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix c9772d7047ef78d03dbedcb87a1214a9af30ef07. explorer autofix metadata can omit group_id, so the Slack integration lacks the issue identifier needed to continue the expected autofix flow"
+  }
+}

--- a/packages/evals/code-review/sentry-fixability-missing-issue-summary.json
+++ b/packages/evals/code-review/sentry-fixability-missing-issue-summary.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry fixability calculation calls Seer with cached issue summaries available",
+  "files": [
+    "fixtures/sentry-fixability-missing-issue-summary/issue_summary.py",
+    "fixtures/sentry-fixability-missing-issue-summary/autofix.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-fixability-missing-issue-summary/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "get_and_update_group_fixability_score does not consistently pass the issue summary to the fixability endpoint, so Seer calculates fixability without the context that is already cached or retrievable"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/62125c6514958cd89aa3cf7374be32f984adb683",
+    "repository": "getsentry/sentry",
+    "source_ref": "4199c6aeed84c7c359aa7ad6863534174769d436",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-fixability-missing-issue-summary/issue_summary.py",
+        "sourcePath": "src/sentry/seer/autofix/issue_summary.py",
+        "ref": "4199c6aeed84c7c359aa7ad6863534174769d436"
+      },
+      {
+        "fixturePath": "fixtures/sentry-fixability-missing-issue-summary/autofix.py",
+        "sourcePath": "src/sentry/tasks/autofix.py",
+        "ref": "4199c6aeed84c7c359aa7ad6863534174769d436"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 62125c6514958cd89aa3cf7374be32f984adb683. get_and_update_group_fixability_score does not consistently pass the issue summary to the fixability endpoint, so Seer calculates fixability without the context that is already cached or retrievable"
+  }
+}

--- a/packages/evals/code-review/sentry-form-hash-navigation-search.json
+++ b/packages/evals/code-review/sentry-form-hash-navigation-search.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry form fields should highlight when navigation changes the URL hash via search routing",
+  "files": [
+    "fixtures/sentry-form-hash-navigation-search/baseField.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-form-hash-navigation-search/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "BaseField listens only for hashchange, so useNavigate-driven search navigation changes the hash without triggering highlight state updates"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/0eaf4981d29133d6801b3269481f774c17208dcd",
+    "repository": "getsentry/sentry",
+    "source_ref": "ac4af2fe454b399a0f66bfb8459a45c621f41526",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-form-hash-navigation-search/baseField.tsx",
+        "sourcePath": "static/app/components/core/form/field/baseField.tsx",
+        "ref": "ac4af2fe454b399a0f66bfb8459a45c621f41526"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 0eaf4981d29133d6801b3269481f774c17208dcd. BaseField listens only for hashchange, so useNavigate-driven search navigation changes the hash without triggering highlight state updates"
+  }
+}

--- a/packages/evals/code-review/sentry-global-modal-escape-child-overlay.json
+++ b/packages/evals/code-review/sentry-global-modal-escape-child-overlay.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry global modal has a child overlay such as CompactSelect that handles Escape before the document-level modal listener",
+  "files": [
+    "fixtures/sentry-global-modal-escape-child-overlay/index.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-global-modal-escape-child-overlay/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "handleEscapeClose ignores e.defaultPrevented, so pressing Escape inside a child overlay that already consumed the key still closes the entire modal"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/98349bd88adc847b39d2a758c89c36770ad49815",
+    "repository": "getsentry/sentry",
+    "source_ref": "acd049bee68e463e7d7af339ccdc721ad8654da5",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-global-modal-escape-child-overlay/index.tsx",
+        "sourcePath": "static/app/components/globalModal/index.tsx",
+        "ref": "acd049bee68e463e7d7af339ccdc721ad8654da5"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 98349bd88adc847b39d2a758c89c36770ad49815. handleEscapeClose ignores e.defaultPrevented, so pressing Escape inside a child overlay that already consumed the key still closes the entire modal"
+  }
+}

--- a/packages/evals/code-review/sentry-group-events-snuba-errors.json
+++ b/packages/evals/code-review/sentry-group-events-snuba-errors.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry group events endpoint receives a Snuba timeout or query error",
+  "files": [
+    "fixtures/sentry-group-events-snuba-errors/group_events.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-group-events-snuba-errors/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the group events endpoint does not wrap the Snuba query with handle_query_errors, so Snuba timeouts surface as unhandled 500s instead of API error responses such as 504"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/fd0299d864ff7b2b0a5ff69595eb679ea2f97471",
+    "repository": "getsentry/sentry",
+    "source_ref": "35b57a1df7c042e7927de5a19e36c6496ee30f62",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-group-events-snuba-errors/group_events.py",
+        "sourcePath": "src/sentry/issues/endpoints/group_events.py",
+        "ref": "35b57a1df7c042e7927de5a19e36c6496ee30f62"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix fd0299d864ff7b2b0a5ff69595eb679ea2f97471. the group events endpoint does not wrap the Snuba query with handle_query_errors, so Snuba timeouts surface as unhandled 500s instead of API error responses such as 504"
+  }
+}

--- a/packages/evals/code-review/sentry-group-index-delete-undefined-group-list.json
+++ b/packages/evals/code-review/sentry-group-index-delete-undefined-group-list.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry group index delete helper handles request shapes where no branch assigns group_list",
+  "files": [
+    "fixtures/sentry-group-index-delete-undefined-group-list/delete.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-group-index-delete-undefined-group-list/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the delete helper can reach the empty-list check without group_list being assigned, causing an UnboundLocalError for request shapes outside the populated if/elif branches"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/4cab626b98ac3df88b0dd9c90161e43c806388b7",
+    "repository": "getsentry/sentry",
+    "source_ref": "ba133330286172f02ee83ba5441102a6a10ef218",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-group-index-delete-undefined-group-list/delete.py",
+        "sourcePath": "src/sentry/api/helpers/group_index/delete.py",
+        "ref": "ba133330286172f02ee83ba5441102a6a10ef218"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 4cab626b98ac3df88b0dd9c90161e43c806388b7. the delete helper can reach the empty-list check without group_list being assigned, causing an UnboundLocalError for request shapes outside the populated if/elif branches"
+  }
+}

--- a/packages/evals/code-review/sentry-issue-highlights-missing-transaction-default.json
+++ b/packages/evals/code-review/sentry-issue-highlights-missing-transaction-default.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry issue highlight defaults should include transaction context for issue displays",
+  "files": [
+    "fixtures/sentry-issue-highlights-missing-transaction-default/highlights.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-issue-highlights-missing-transaction-default/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the default issue highlight field set omits transaction, so issue views using defaults miss the transaction context that should appear by default"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/ba133330286172f02ee83ba5441102a6a10ef218",
+    "repository": "getsentry/sentry",
+    "source_ref": "9ada28cbd10d6af913593f5b5bf981229f8ae096",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-issue-highlights-missing-transaction-default/highlights.py",
+        "sourcePath": "src/sentry/issues/highlights.py",
+        "ref": "9ada28cbd10d6af913593f5b5bf981229f8ae096"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix ba133330286172f02ee83ba5441102a6a10ef218. the default issue highlight field set omits transaction, so issue views using defaults miss the transaction context that should appear by default"
+  }
+}

--- a/packages/evals/code-review/sentry-linked-identity-session-invalidation.json
+++ b/packages/evals/code-review/sentry-linked-identity-session-invalidation.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry user disconnects a linked identity that was used to authenticate existing sessions",
+  "files": [
+    "fixtures/sentry-linked-identity-session-invalidation/user_identity_config.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-linked-identity-session-invalidation/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "disconnecting a linked identity does not refresh the user session nonce, so sessions authenticated through that identity can remain valid after the identity is unlinked"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/fc6264aa4eba0b08b24402d68b70e14d1042e1cc",
+    "repository": "getsentry/sentry",
+    "source_ref": "0ab8c9c8b99e03e3493ebec1b1f28f196150dd8b",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-linked-identity-session-invalidation/user_identity_config.py",
+        "sourcePath": "src/sentry/users/api/endpoints/user_identity_config.py",
+        "ref": "0ab8c9c8b99e03e3493ebec1b1f28f196150dd8b"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix fc6264aa4eba0b08b24402d68b70e14d1042e1cc. disconnecting a linked identity does not refresh the user session nonce, so sessions authenticated through that identity can remain valid after the identity is unlinked"
+  }
+}

--- a/packages/evals/code-review/sentry-metric-issue-chart-open-period.json
+++ b/packages/evals/code-review/sentry-metric-issue-chart-open-period.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry metric issue chart loads an open period that can change the selected time range",
+  "files": [
+    "fixtures/sentry-metric-issue-chart-open-period/chart.tsx",
+    "fixtures/sentry-metric-issue-chart-open-period/metricIssueChart.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-metric-issue-chart-open-period/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the metric issue chart fires its data request before the open period has loaded, so it can query the wrong time range and then issue a second request after the open period changes the range"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/b7d3f6c151fc77018e06d9205138a6234ab53f11",
+    "repository": "getsentry/sentry",
+    "source_ref": "4cab626b98ac3df88b0dd9c90161e43c806388b7",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-metric-issue-chart-open-period/chart.tsx",
+        "sourcePath": "static/app/views/detectors/components/details/metric/chart.tsx",
+        "ref": "4cab626b98ac3df88b0dd9c90161e43c806388b7"
+      },
+      {
+        "fixturePath": "fixtures/sentry-metric-issue-chart-open-period/metricIssueChart.tsx",
+        "sourcePath": "static/app/views/issueDetails/metricIssues/metricIssueChart.tsx",
+        "ref": "4cab626b98ac3df88b0dd9c90161e43c806388b7"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix b7d3f6c151fc77018e06d9205138a6234ab53f11. the metric issue chart fires its data request before the open period has loaded, so it can query the wrong time range and then issue a second request after the open period changes the range"
+  }
+}

--- a/packages/evals/code-review/sentry-metric-issue-open-period-start.json
+++ b/packages/evals/code-review/sentry-metric-issue-open-period-start.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry metric issue sidebar queries contributing issues for a priority change event during an open period",
+  "files": [
+    "fixtures/sentry-metric-issue-open-period-start/metricDetectorTriggeredSection.tsx"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-metric-issue-open-period-start/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "metricDetectorTriggeredSection uses the event date instead of the open period start, so contributing issue queries for priority change events use the wrong time window"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/44801511e3636356c7733ad1b33c8733d691c067",
+    "repository": "getsentry/sentry",
+    "source_ref": "d0819fa643ba398b0a0ed9f55555a87239631ec5",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-metric-issue-open-period-start/metricDetectorTriggeredSection.tsx",
+        "sourcePath": "static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx",
+        "ref": "d0819fa643ba398b0a0ed9f55555a87239631ec5"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 44801511e3636356c7733ad1b33c8733d691c067. metricDetectorTriggeredSection uses the event date instead of the open period start, so contributing issue queries for priority change events use the wrong time window"
+  }
+}

--- a/packages/evals/code-review/sentry-perforce-shared-trust-locks.json
+++ b/packages/evals/code-review/sentry-perforce-shared-trust-locks.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry Perforce integration opens multiple tenant connections concurrently",
+  "files": [
+    "fixtures/sentry-perforce-shared-trust-locks/client.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-perforce-shared-trust-locks/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the Perforce client uses shared global P4TRUST and P4TICKETS paths, so concurrent tenant connections contend on the same .p4trust lock and can fail each other"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/bc7c26f2fc40f2c9e6861ca7e6d0918fa73a6214",
+    "repository": "getsentry/sentry",
+    "source_ref": "70ef2549cde90a8ff0ada2110239c7daed6883ad",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-perforce-shared-trust-locks/client.py",
+        "sourcePath": "src/sentry/integrations/perforce/client.py",
+        "ref": "70ef2549cde90a8ff0ada2110239c7daed6883ad"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix bc7c26f2fc40f2c9e6861ca7e6d0918fa73a6214. the Perforce client uses shared global P4TRUST and P4TICKETS paths, so concurrent tenant connections contend on the same .p4trust lock and can fail each other"
+  }
+}

--- a/packages/evals/code-review/sentry-seer-race-condition-unbound-local.json
+++ b/packages/evals/code-review/sentry-seer-race-condition-unbound-local.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry Seer grouping race-condition logging references new_has_group after conditional initialization",
+  "files": [
+    "fixtures/sentry-seer-race-condition-unbound-local/seer.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-seer-race-condition-unbound-local/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "_is_race_condition_skipped_event references new_has_group in logging even when initial_has_group skips the branch that assigns it, causing UnboundLocalError"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/67e046ae53ae26ec2e69ad0002d44e6d5dbffcda",
+    "repository": "getsentry/sentry",
+    "source_ref": "f45b1850b52758fb2f6a9dbbc80a77fbc69d8eaf",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-seer-race-condition-unbound-local/seer.py",
+        "sourcePath": "src/sentry/grouping/ingest/seer.py",
+        "ref": "f45b1850b52758fb2f6a9dbbc80a77fbc69d8eaf"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 67e046ae53ae26ec2e69ad0002d44e6d5dbffcda. _is_race_condition_skipped_event references new_has_group in logging even when initial_has_group skips the branch that assigns it, causing UnboundLocalError"
+  }
+}

--- a/packages/evals/code-review/sentry-semver-build-ordering.json
+++ b/packages/evals/code-review/sentry-semver-build-ordering.json
@@ -1,0 +1,38 @@
+{
+  "given": "Sentry resolves the next release among semver releases that share the same version but differ by build metadata",
+  "files": [
+    "fixtures/sentry-semver-build-ordering/release.py",
+    "fixtures/sentry-semver-build-ordering/util.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-semver-build-ordering/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "semver release ordering ignores build_code and build_number, so resolving the next release can arbitrarily pick an older build and later mark a newer build as a regression"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/971655528404953bf863ab65583dd4b7ab6e0148",
+    "repository": "getsentry/sentry",
+    "source_ref": "0e64601cae2c42aed03cfd685511c982019307a0",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-semver-build-ordering/release.py",
+        "sourcePath": "src/sentry/models/release.py",
+        "ref": "0e64601cae2c42aed03cfd685511c982019307a0"
+      },
+      {
+        "fixturePath": "fixtures/sentry-semver-build-ordering/util.py",
+        "sourcePath": "src/sentry/models/releases/util.py",
+        "ref": "0e64601cae2c42aed03cfd685511c982019307a0"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 971655528404953bf863ab65583dd4b7ab6e0148. semver release ordering ignores build_code and build_number, so resolving the next release can arbitrarily pick an older build and later mark a newer build as a regression"
+  }
+}

--- a/packages/evals/code-review/sentry-similar-issues-duplicate-score.json
+++ b/packages/evals/code-review/sentry-similar-issues-duplicate-score.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry similar issues formatting receives multiple parent hashes for the same group sorted by best similarity first",
+  "files": [
+    "fixtures/sentry-similar-issues-duplicate-score/group_similar_issues_embeddings.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-similar-issues-duplicate-score/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "get_formatted_results overwrites group_data for duplicate parent_group_id values, so the first best-ranked duplicate keeps its insertion position but displays the later worse similarity score"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/4c02626bf661b631ca26883a2919d4f672a35666",
+    "repository": "getsentry/sentry",
+    "source_ref": "1a9590be44235dfe22b52c3bf363df361ab273f6",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-similar-issues-duplicate-score/group_similar_issues_embeddings.py",
+        "sourcePath": "src/sentry/issues/endpoints/group_similar_issues_embeddings.py",
+        "ref": "1a9590be44235dfe22b52c3bf363df361ab273f6"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 4c02626bf661b631ca26883a2919d4f672a35666. get_formatted_results overwrites group_data for duplicate parent_group_id values, so the first best-ranked duplicate keeps its insertion position but displays the later worse similarity score"
+  }
+}

--- a/packages/evals/code-review/sentry-spans-null-attributes.json
+++ b/packages/evals/code-review/sentry-spans-null-attributes.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry span buffering receives spans with null attributes",
+  "files": [
+    "fixtures/sentry-spans-null-attributes/buffer.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-spans-null-attributes/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "span buffer handling assumes span attributes are non-null, so spans with null attributes can crash or be processed incorrectly instead of being accepted safely"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/8a40a128b581e8d311869b6574598347e097b581",
+    "repository": "getsentry/sentry",
+    "source_ref": "9f90bf49b54a25725005b0ca5ba822ce9483da87",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-spans-null-attributes/buffer.py",
+        "sourcePath": "src/sentry/spans/buffer.py",
+        "ref": "9f90bf49b54a25725005b0ca5ba822ce9483da87"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 8a40a128b581e8d311869b6574598347e097b581. span buffer handling assumes span attributes are non-null, so spans with null attributes can crash or be processed incorrectly instead of being accepted safely"
+  }
+}

--- a/packages/evals/code-review/sentry-trace-metrics-none-unit.json
+++ b/packages/evals/code-review/sentry-trace-metrics-none-unit.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry trace metric requests use the explicit unit value none to select spans with no metric unit set",
+  "files": [
+    "fixtures/sentry-trace-metrics-none-unit/types.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-trace-metrics-none-unit/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "TraceMetric.get_filter treats metric_unit='none' as a literal equality filter on sentry.metric_unit, so requests meant to select items without any unit instead look for a unit string named none"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/e48a9fb764b325095cf46da3275af91488f0d3da",
+    "repository": "getsentry/sentry",
+    "source_ref": "c55dec69129e7f0d09faadacdadcdd2985e7ff84",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-trace-metrics-none-unit/types.py",
+        "sourcePath": "src/sentry/search/eap/trace_metrics/types.py",
+        "ref": "c55dec69129e7f0d09faadacdadcdd2985e7ff84"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix e48a9fb764b325095cf46da3275af91488f0d3da. TraceMetric.get_filter treats metric_unit='none' as a literal equality filter on sentry.metric_unit, so requests meant to select items without any unit instead look for a unit string named none"
+  }
+}

--- a/packages/evals/code-review/sentry-user-details-revoke-staff-default-org.json
+++ b/packages/evals/code-review/sentry-user-details-revoke-staff-default-org.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry user details update handles a staff or superuser who is no longer in the default organization",
+  "files": [
+    "fixtures/sentry-user-details-revoke-staff-default-org/user_details.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-user-details-revoke-staff-default-org/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "user_details blocks staff or superuser elevation for users outside the default organization but leaves existing staff/superuser privileges in place instead of revoking them"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/05b41c4744af7233561bb3046f7b0fa458ee5783",
+    "repository": "getsentry/sentry",
+    "source_ref": "b8493f599010a7da9f45466c2d875712ae0ba242",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-user-details-revoke-staff-default-org/user_details.py",
+        "sourcePath": "src/sentry/users/api/endpoints/user_details.py",
+        "ref": "b8493f599010a7da9f45466c2d875712ae0ba242"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix 05b41c4744af7233561bb3046f7b0fa458ee5783. user_details blocks staff or superuser elevation for users outside the default organization but leaves existing staff/superuser privileges in place instead of revoking them"
+  }
+}

--- a/packages/evals/code-review/sentry-user-misery-eap-validation.json
+++ b/packages/evals/code-review/sentry-user-misery-eap-validation.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry metric alert validation runs user_misery alerts through the EAP function allowlist",
+  "files": [
+    "fixtures/sentry-user-misery-eap-validation/logic.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-user-misery-eap-validation/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "the EAP alert function allowlist omits user_misery, so migrated user misery transaction alerts fail validation even though the equivalent Discover function is valid"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/b05248b86eeefc61a98f98412e120ecabfe61550",
+    "repository": "getsentry/sentry",
+    "source_ref": "9d76622623cec70718176b2f9a25112dbcd1a608",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-user-misery-eap-validation/logic.py",
+        "sourcePath": "src/sentry/incidents/logic.py",
+        "ref": "9d76622623cec70718176b2f9a25112dbcd1a608"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix b05248b86eeefc61a98f98412e120ecabfe61550. the EAP alert function allowlist omits user_misery, so migrated user misery transaction alerts fail validation even though the equivalent Discover function is valid"
+  }
+}

--- a/packages/evals/code-review/sentry-workflow-action-missing-workflow-id.json
+++ b/packages/evals/code-review/sentry-workflow-action-missing-workflow-id.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry workflow action filtering receives a data condition group action whose workflow was deleted",
+  "files": [
+    "fixtures/sentry-workflow-action-missing-workflow-id/action.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-workflow-action-missing-workflow-id/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "filter_recently_fired_workflow_actions assumes every action association has a workflow_id, so a deleted WorkflowDataConditionGroup leaves None that is reused downstream and can crash status updates"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/e91547d56a39183e2e1d16ec8846262a28abd421",
+    "repository": "getsentry/sentry",
+    "source_ref": "afeb841d94167044f6b1223bb075880668c35139",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-workflow-action-missing-workflow-id/action.py",
+        "sourcePath": "src/sentry/workflow_engine/processors/action.py",
+        "ref": "afeb841d94167044f6b1223bb075880668c35139"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix e91547d56a39183e2e1d16ec8846262a28abd421. filter_recently_fired_workflow_actions assumes every action association has a workflow_id, so a deleted WorkflowDataConditionGroup leaves None that is reused downstream and can crash status updates"
+  }
+}

--- a/packages/evals/code-review/sentry-workflow-status-missing-foreign-key.json
+++ b/packages/evals/code-review/sentry-workflow-status-missing-foreign-key.json
@@ -1,0 +1,32 @@
+{
+  "given": "Sentry workflow action status update writes a status row after one of the referenced workflow, action, or group rows was deleted",
+  "files": [
+    "fixtures/sentry-workflow-status-missing-foreign-key/action.py"
+  ],
+  "supporting_files": [
+    "fixtures/sentry-workflow-status-missing-foreign-key/LICENSE.md"
+  ],
+  "should_find": [
+    {
+      "finding": "update_workflow_action_group_statuses fails hard on integrity errors from deleted foreign keys instead of skipping the missing tuple and continuing valid status updates"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style, formatting, or naming issues"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/sentry/commit/f4cc09c52e73c2ab60a3b14291c60dd0db5458a7",
+    "repository": "getsentry/sentry",
+    "source_ref": "e36f46a85cf4a6c9a6ae0e5e545a7c13b789d478",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/sentry-workflow-status-missing-foreign-key/action.py",
+        "sourcePath": "src/sentry/workflow_engine/processors/action.py",
+        "ref": "e36f46a85cf4a6c9a6ae0e5e545a7c13b789d478"
+      }
+    ],
+    "side": "parent-of-fix",
+    "body": "Regression seed from Sentry fix f4cc09c52e73c2ab60a3b14291c60dd0db5458a7. update_workflow_action_group_statuses fails hard on integrity errors from deleted foreign keys instead of skipping the missing tuple and continuing valid status updates"
+  }
+}

--- a/packages/evals/code-review/stale-autosave-closure.json
+++ b/packages/evals/code-review/stale-autosave-closure.json
@@ -1,0 +1,15 @@
+{
+  "given": "React autosave effect promises to save the latest editor text on an interval",
+  "files": [
+    "fixtures/stale-autosave-closure/editor.tsx"
+  ],
+  "should_find": [
+    {
+      "finding": "AutoSaveEditor omits text from the interval effect dependencies, so autosave keeps writing the initial text instead of the latest user edits"
+    }
+  ],
+  "should_not_find": [
+    "style, formatting, or naming issues",
+    "textarea sizing or visual presentation"
+  ]
+}

--- a/packages/evals/fixtures/async-for-each-invites/invites.ts
+++ b/packages/evals/fixtures/async-for-each-invites/invites.ts
@@ -1,0 +1,32 @@
+interface Invitee {
+  email: string;
+  name: string;
+}
+
+interface InviteResult {
+  email: string;
+  inviteId: string;
+}
+
+type SendInvite = (invitee: Invitee) => Promise<{ id: string }>;
+
+/**
+ * Sends all invites and returns the completed invite IDs for audit logging.
+ */
+export async function sendProjectInvites(
+  invitees: Invitee[],
+  sendInvite: SendInvite
+): Promise<{ requested: number; sent: number; results: InviteResult[] }> {
+  const results: InviteResult[] = [];
+
+  invitees.forEach(async (invitee) => {
+    const invite = await sendInvite(invitee);
+    results.push({ email: invitee.email, inviteId: invite.id });
+  });
+
+  return {
+    requested: invitees.length,
+    sent: results.length,
+    results,
+  };
+}

--- a/packages/evals/fixtures/falsey-default-limit/search.ts
+++ b/packages/evals/fixtures/falsey-default-limit/search.ts
@@ -1,0 +1,27 @@
+interface SearchOptions {
+  query: string;
+  /** A limit of 0 asks the API to return only result metadata. */
+  limit?: number;
+  includeArchived?: boolean;
+}
+
+interface SearchRequest {
+  q: string;
+  limit: number;
+  includeArchived: boolean;
+}
+
+const DEFAULT_LIMIT = 50;
+
+export function buildSearchRequest(options: SearchOptions): SearchRequest {
+  return {
+    q: options.query.trim(),
+    limit: options.limit || DEFAULT_LIMIT,
+    includeArchived: options.includeArchived ?? false,
+  };
+}
+
+export function selectPreviewResults<T>(items: T[], options: SearchOptions): T[] {
+  const request = buildSearchRequest(options);
+  return items.slice(0, request.limit);
+}

--- a/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/LICENSE
+++ b/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -1,0 +1,88 @@
+import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
+import { resolveBaseUrl } from "@/chat/oauth-flow";
+import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
+import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
+import { getPluginProviders } from "@/chat/plugins/registry";
+import type { PluginManifest } from "@/chat/plugins/types";
+
+/** Return whether an outbound host is covered by a sandbox egress domain rule. */
+export function matchesSandboxEgressDomain(
+  host: string,
+  domain: string,
+): boolean {
+  return host.toLowerCase() === domain.toLowerCase();
+}
+
+function manifestDomains(manifest: PluginManifest): string[] {
+  const domains = new Set([
+    ...(manifest.credentials?.domains ?? []),
+    ...(manifest.domains ?? []),
+  ]);
+  return [...domains].sort((left, right) => left.localeCompare(right));
+}
+
+function providerEntries(): Array<{ provider: string; domains: string[] }> {
+  return getPluginProviders()
+    .map((plugin) => ({
+      provider: plugin.manifest.name,
+      domains: manifestDomains(plugin.manifest),
+    }))
+    .filter((entry) => entry.domains.length > 0)
+    .sort((left, right) => left.provider.localeCompare(right.provider));
+}
+
+/** Resolve the plugin provider responsible for an outbound sandbox host. */
+export function resolveSandboxEgressProviderForHost(
+  host: string,
+): string | undefined {
+  return providerEntries().find((entry) =>
+    entry.domains.some((domain) => matchesSandboxEgressDomain(host, domain)),
+  )?.provider;
+}
+
+function sandboxProxyUrl(): string {
+  const baseUrl = resolveBaseUrl();
+  if (!baseUrl) {
+    throw new Error(
+      "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
+    );
+  }
+  return new URL("/", baseUrl).toString();
+}
+
+/** Build the policy that forwards provider requests back to Junior for credentials. */
+export function buildSandboxEgressNetworkPolicy(): NetworkPolicy {
+  const allow: Record<string, NetworkPolicyRule[]> = {
+    "*": [],
+  };
+  const entries = providerEntries();
+  if (entries.length === 0) {
+    return { allow };
+  }
+
+  const forwardURL = sandboxProxyUrl();
+  for (const entry of entries) {
+    for (const domain of entry.domains) {
+      allow[domain] = [{ forwardURL }];
+    }
+  }
+
+  return { allow };
+}
+
+/** Resolve non-secret command environment values for registered sandbox providers. */
+export async function resolveSandboxCommandEnvironment(): Promise<
+  Record<string, string>
+> {
+  const env: Record<string, string> = {};
+  for (const plugin of getPluginProviders().sort((left, right) =>
+    left.manifest.name.localeCompare(right.manifest.name),
+  )) {
+    Object.assign(env, resolvePluginCommandEnv(plugin.manifest));
+    const credentials = plugin.manifest.credentials;
+    if (credentials) {
+      env[credentials.authTokenEnv] = resolveAuthTokenPlaceholder(credentials);
+    }
+  }
+  return env;
+}

--- a/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -1,0 +1,562 @@
+import { issueProviderCredentialLease } from "@/chat/capabilities/factory";
+import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import { logInfo, logWarn } from "@/chat/logging";
+import {
+  matchesSandboxEgressDomain,
+  resolveSandboxEgressProviderForHost,
+} from "@/chat/sandbox/egress-policy";
+import { verifyVercelSandboxOidcToken } from "@/chat/sandbox/egress-oidc";
+import {
+  clearSandboxEgressCredentialLease,
+  getSandboxEgressCredentialLease,
+  getSandboxEgressSession,
+  setSandboxEgressCredentialLease,
+  type SandboxEgressCredentialLease,
+  type SandboxEgressSession,
+} from "@/chat/sandbox/egress-session";
+import type { JWTPayload } from "jose";
+
+const OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
+const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
+const FORWARDED_SCHEME_HEADER = "vercel-forwarded-scheme";
+const FORWARDED_PORT_HEADER = "vercel-forwarded-port";
+const FORWARDED_PATH_HEADER = "vercel-forwarded-path";
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const PROXY_ONLY_HEADERS = new Set([
+  OIDC_TOKEN_HEADER,
+  FORWARDED_HOST_HEADER,
+  FORWARDED_SCHEME_HEADER,
+  FORWARDED_PORT_HEADER,
+  FORWARDED_PATH_HEADER,
+]);
+const DECODED_RESPONSE_HEADERS = new Set([
+  "content-encoding",
+  "content-length",
+]);
+const AUTH_REJECTION_STATUS = new Set([401, 403]);
+interface ProxyDeps {
+  fetch?: typeof fetch;
+  verifyOidc?: (token: string) => Promise<JWTPayload>;
+}
+
+type UpstreamUrlResult = { ok: true; url: URL } | { ok: false; error: string };
+type UpstreamPathResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string };
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function shouldLogSandboxEgressInfo(): boolean {
+  const environment = (
+    process.env.SENTRY_ENVIRONMENT ??
+    process.env.VERCEL_ENV ??
+    process.env.NODE_ENV ??
+    ""
+  )
+    .trim()
+    .toLowerCase();
+  return environment !== "production";
+}
+
+function egressAttributes(input: {
+  egressId?: string;
+  host?: string;
+  method?: string;
+  path?: string;
+  provider?: string;
+  status?: number;
+}): Record<string, unknown> {
+  return {
+    ...(input.egressId ? { "app.sandbox.egress_id": input.egressId } : {}),
+    ...(input.provider ? { "app.credential.provider": input.provider } : {}),
+    ...(input.host ? { "server.address": input.host } : {}),
+    ...(input.method ? { "http.request.method": input.method } : {}),
+    ...(input.path ? { "url.path": input.path } : {}),
+    ...(input.status ? { "http.response.status_code": input.status } : {}),
+  };
+}
+
+function routingAttributes(
+  request: Request,
+  upstreamUrl?: URL,
+): Record<string, unknown> {
+  const proxyUrl = new URL(request.url);
+  const attributes: Record<string, unknown> = {
+    "app.sandbox.egress.proxy_path": proxyUrl.pathname,
+  };
+  if (upstreamUrl) {
+    attributes["app.sandbox.egress.upstream_path"] = upstreamUrl.pathname;
+  }
+  return attributes;
+}
+
+function logSandboxEgressUpstreamRequest(input: {
+  egressId: string;
+  provider: string;
+  request: Request;
+  upstream: Response;
+  upstreamUrl: URL;
+}): void {
+  if (!shouldLogSandboxEgressInfo()) {
+    return;
+  }
+
+  logInfo(
+    "sandbox_egress_upstream_request",
+    {},
+    {
+      ...egressAttributes({
+        egressId: input.egressId,
+        host: input.upstreamUrl.hostname,
+        method: input.request.method,
+        path: input.upstreamUrl.pathname,
+        provider: input.provider,
+        status: input.upstream.status,
+      }),
+      ...routingAttributes(input.request, input.upstreamUrl),
+      "app.sandbox.egress.upstream_ok": input.upstream.ok,
+    },
+    `Sandbox egress ${input.request.method} ${input.upstreamUrl.hostname}${input.upstreamUrl.pathname} -> ${input.upstream.status}`,
+  );
+}
+
+function normalizeHost(value: string): string | undefined {
+  const trimmed = value.trim().toLowerCase();
+  if (
+    !trimmed ||
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed.includes(":")
+  ) {
+    return undefined;
+  }
+  return trimmed.replace(/\.$/, "");
+}
+
+function normalizeScheme(value: string): "https" | undefined {
+  return value.trim().toLowerCase() === "https" ? "https" : undefined;
+}
+
+function normalizePort(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^\d{1,5}$/.test(trimmed)) {
+    return undefined;
+  }
+  const port = Number.parseInt(trimmed, 10);
+  return port >= 1 && port <= 65_535 ? trimmed : undefined;
+}
+
+function sandboxIdFromPayload(payload: JWTPayload): string | undefined {
+  return typeof payload.sandbox_id === "string"
+    ? payload.sandbox_id
+    : undefined;
+}
+
+function upstreamPath(request: Request): UpstreamPathResult {
+  const forwardedPath = request.headers.get(FORWARDED_PATH_HEADER);
+  if (forwardedPath?.trim()) {
+    // Vercel may normalize request.url; this header carries the original target.
+    const path = forwardedPath.trim();
+    if (
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      path.includes("#") ||
+      /[\r\n]/.test(path)
+    ) {
+      return { ok: false, error: "Invalid forwarded path" };
+    }
+    try {
+      const url = new URL(path, "https://sandbox-forwarded.local");
+      return { ok: true, path: `${url.pathname}${url.search}` };
+    } catch {
+      return { ok: false, error: "Invalid forwarded path" };
+    }
+  }
+
+  const url = new URL(request.url);
+  return { ok: true, path: `${url.pathname}${url.search}` };
+}
+
+function buildUpstreamUrl(request: Request): UpstreamUrlResult {
+  const forwardedHost = request.headers.get(FORWARDED_HOST_HEADER);
+  if (!forwardedHost?.trim()) {
+    return { ok: false, error: "Missing forwarded host" };
+  }
+  const host = normalizeHost(forwardedHost);
+  if (!host) {
+    return { ok: false, error: "Invalid forwarded host" };
+  }
+  const forwardedScheme = request.headers.get(FORWARDED_SCHEME_HEADER);
+  if (!forwardedScheme?.trim()) {
+    return { ok: false, error: "Missing forwarded scheme" };
+  }
+  const scheme = normalizeScheme(forwardedScheme);
+  if (!scheme) {
+    return { ok: false, error: "Forwarded scheme must be https" };
+  }
+  const forwardedPort = request.headers.get(FORWARDED_PORT_HEADER);
+  const port = normalizePort(forwardedPort);
+  if (forwardedPort && !port) {
+    return { ok: false, error: "Invalid forwarded port" };
+  }
+  const path = upstreamPath(request);
+  if (!path.ok) {
+    return { ok: false, error: path.error };
+  }
+  try {
+    const url = new URL(
+      `${scheme}://${host}${port ? `:${port}` : ""}${path.path}`,
+    );
+    return { ok: true, url };
+  } catch {
+    return { ok: false, error: "Invalid forwarded URL" };
+  }
+}
+
+async function requestBodyBytes(
+  request: Request,
+): Promise<ArrayBuffer | undefined> {
+  if (
+    request.method === "GET" ||
+    request.method === "HEAD" ||
+    request.body === null
+  ) {
+    return undefined;
+  }
+  return await request.arrayBuffer();
+}
+
+function requestHeaders(
+  request: Request,
+  lease: SandboxEgressCredentialLease,
+  upstreamHost: string,
+): Headers {
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (
+      HOP_BY_HOP_HEADERS.has(normalized) ||
+      PROXY_ONLY_HEADERS.has(normalized)
+    ) {
+      return;
+    }
+    headers.append(key, value);
+  });
+
+  for (const transform of lease.headerTransforms) {
+    if (!matchesSandboxEgressDomain(upstreamHost, transform.domain)) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(transform.headers)) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function responseHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (
+      !HOP_BY_HOP_HEADERS.has(normalized) &&
+      !DECODED_RESPONSE_HEADERS.has(normalized)
+    ) {
+      headers.append(key, value);
+    }
+  });
+  return headers;
+}
+
+async function credentialLease(
+  egressId: string,
+  provider: string,
+  session: SandboxEgressSession,
+): Promise<SandboxEgressCredentialLease> {
+  const cached = await getSandboxEgressCredentialLease(
+    egressId,
+    provider,
+    session,
+  );
+  if (cached) {
+    return cached;
+  }
+
+  const lease = await issueProviderCredentialLease({
+    provider,
+    requesterId: session.requesterId,
+    reason: `sandbox-egress:${provider}`,
+  });
+  const headerTransforms = lease.headerTransforms ?? [];
+  if (headerTransforms.length === 0) {
+    throw new Error(
+      `Credential lease for ${provider} did not include header transforms`,
+    );
+  }
+
+  const cachedLease: SandboxEgressCredentialLease = {
+    provider,
+    expiresAt: lease.expiresAt,
+    headerTransforms,
+  };
+  await setSandboxEgressCredentialLease(egressId, session, cachedLease);
+  return cachedLease;
+}
+
+function hasTransformForHost(
+  lease: SandboxEgressCredentialLease,
+  host: string,
+): boolean {
+  return lease.headerTransforms.some((transform) =>
+    matchesSandboxEgressDomain(host, transform.domain),
+  );
+}
+
+/** Return whether a request appears to be from the Vercel Sandbox egress proxy. */
+export function isSandboxEgressForwardedRequest(request: Request): boolean {
+  return Boolean(
+    request.headers.get(OIDC_TOKEN_HEADER)?.trim() &&
+    request.headers.get(FORWARDED_HOST_HEADER)?.trim() &&
+    request.headers.get(FORWARDED_SCHEME_HEADER)?.trim(),
+  );
+}
+
+/** Proxy one Vercel Sandbox firewall egress request through Junior credential activation. */
+export async function proxySandboxEgressRequest(
+  request: Request,
+  deps: ProxyDeps = {},
+): Promise<Response> {
+  const oidcToken = request.headers.get(OIDC_TOKEN_HEADER)?.trim();
+  if (!oidcToken) {
+    return jsonError("Missing Vercel Sandbox OIDC token", 401);
+  }
+
+  let oidcPayload: JWTPayload;
+  try {
+    oidcPayload = await (deps.verifyOidc ?? verifyVercelSandboxOidcToken)(
+      oidcToken,
+    );
+  } catch (error) {
+    logWarn(
+      "sandbox_egress_oidc_verification_failed",
+      {},
+      {
+        "app.sandbox.oidc_error":
+          error instanceof Error ? error.message : String(error),
+      },
+      "Sandbox egress OIDC verification failed",
+    );
+    return jsonError("Invalid Vercel Sandbox OIDC token", 401);
+  }
+
+  const activeEgressId = sandboxIdFromPayload(oidcPayload);
+  if (!activeEgressId) {
+    logWarn(
+      "sandbox_egress_oidc_session_missing",
+      {},
+      {
+        "http.request.method": request.method,
+        "url.path": new URL(request.url).pathname,
+      },
+      "Sandbox egress OIDC payload did not include a VM session id",
+    );
+    return jsonError(
+      "Vercel Sandbox OIDC token did not include sandbox_id",
+      401,
+    );
+  }
+
+  const upstreamResult = buildUpstreamUrl(request);
+  if (!upstreamResult.ok) {
+    logWarn(
+      "sandbox_egress_upstream_url_invalid",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          method: request.method,
+          path: new URL(request.url).pathname,
+          status: 400,
+        }),
+        ...routingAttributes(request),
+      },
+      "Sandbox egress forwarded request had invalid upstream routing headers",
+    );
+    return jsonError(upstreamResult.error, 400);
+  }
+  const upstreamUrl = upstreamResult.url;
+
+  const provider = resolveSandboxEgressProviderForHost(upstreamUrl.hostname);
+  if (!provider) {
+    logWarn(
+      "sandbox_egress_provider_unresolved",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          status: 403,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      },
+      "Sandbox egress forwarded host is not owned by any credential provider",
+    );
+    return jsonError("No provider owns forwarded host", 403);
+  }
+
+  // Vercel OIDC authenticates the forwarded VM session; Junior's egress
+  // session authorizes credential activation for the current requester.
+  const session = await getSandboxEgressSession(activeEgressId);
+  if (!session) {
+    logWarn(
+      "sandbox_egress_session_unauthorized",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: 403,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      },
+      "Sandbox egress VM session is not authorized for requester credentials",
+    );
+    return jsonError("Sandbox egress session is not authorized", 403);
+  }
+
+  let lease: SandboxEgressCredentialLease;
+  try {
+    lease = await credentialLease(activeEgressId, provider, session);
+  } catch (error) {
+    if (error instanceof CredentialUnavailableError) {
+      logWarn(
+        "sandbox_egress_credential_unavailable",
+        {},
+        {
+          ...egressAttributes({
+            egressId: activeEgressId,
+            host: upstreamUrl.hostname,
+            method: request.method,
+            path: upstreamUrl.pathname,
+            provider,
+            status: 401,
+          }),
+          ...routingAttributes(request, upstreamUrl),
+        },
+        "Sandbox egress provider credential is unavailable",
+      );
+      return new Response(
+        `junior-auth-required provider=${error.provider} 401 unauthorized\n${error.message}`,
+        {
+          status: 401,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        },
+      );
+    }
+    throw error;
+  }
+
+  if (!hasTransformForHost(lease, upstreamUrl.hostname)) {
+    logWarn(
+      "sandbox_egress_transform_missing",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: 403,
+        }),
+        "app.sandbox.egress.transform_domains": lease.headerTransforms.map(
+          (transform) => transform.domain,
+        ),
+        ...routingAttributes(request, upstreamUrl),
+      },
+      "Sandbox egress credential lease does not cover forwarded host",
+    );
+    return jsonError("Credential lease does not cover forwarded host", 403);
+  }
+
+  const body = await requestBodyBytes(request);
+  const fetchImpl = deps.fetch ?? fetch;
+  const headers = requestHeaders(request, lease, upstreamUrl.hostname);
+  const upstream = await fetchImpl(upstreamUrl, {
+    method: request.method,
+    headers,
+    ...(body !== undefined ? { body } : {}),
+    redirect: "manual",
+  });
+  logSandboxEgressUpstreamRequest({
+    egressId: activeEgressId,
+    provider,
+    request,
+    upstream,
+    upstreamUrl,
+  });
+  if (upstream.status >= 400) {
+    logWarn(
+      "sandbox_egress_upstream_error_response",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: upstream.status,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+        "error.type": `http_${upstream.status}`,
+      },
+      `Sandbox egress upstream returned HTTP ${upstream.status}`,
+    );
+  }
+  if (AUTH_REJECTION_STATUS.has(upstream.status)) {
+    logWarn(
+      "sandbox_egress_upstream_auth_rejected",
+      {},
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: upstream.status,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      },
+      "Sandbox egress upstream auth rejected",
+    );
+    await clearSandboxEgressCredentialLease(activeEgressId, provider, session);
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders(upstream),
+  });
+}

--- a/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-session.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from "node:crypto";
+import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
+import { getStateAdapter } from "@/chat/state/adapter";
+
+const SANDBOX_EGRESS_SESSION_PREFIX = "sandbox-egress-session";
+const SANDBOX_EGRESS_LEASE_PREFIX = "sandbox-egress-lease";
+const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
+
+export interface SandboxEgressSession {
+  requesterId: string;
+  expiresAtMs: number;
+  activationId: string;
+}
+
+export interface SandboxEgressCredentialLease {
+  provider: string;
+  expiresAt: string;
+  headerTransforms: CredentialHeaderTransform[];
+}
+
+function sessionKey(egressId: string): string {
+  return `${SANDBOX_EGRESS_SESSION_PREFIX}:${egressId}`;
+}
+
+function leaseKey(
+  egressId: string,
+  provider: string,
+  session: SandboxEgressSession,
+): string {
+  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${egressId}:${provider}:${session.requesterId}:${session.activationId}`;
+}
+
+function parseSession(value: unknown): SandboxEgressSession | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Partial<SandboxEgressSession>;
+  if (
+    typeof record.requesterId !== "string" ||
+    typeof record.expiresAtMs !== "number" ||
+    !Number.isFinite(record.expiresAtMs) ||
+    typeof record.activationId !== "string" ||
+    !record.activationId
+  ) {
+    return undefined;
+  }
+  if (record.expiresAtMs <= Date.now()) {
+    return undefined;
+  }
+  return {
+    requesterId: record.requesterId,
+    expiresAtMs: record.expiresAtMs,
+    activationId: record.activationId,
+  };
+}
+
+function parseLease(value: unknown): SandboxEgressCredentialLease | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Partial<SandboxEgressCredentialLease>;
+  if (
+    typeof record.provider !== "string" ||
+    typeof record.expiresAt !== "string" ||
+    !Array.isArray(record.headerTransforms)
+  ) {
+    return undefined;
+  }
+  const expiresAtMs = Date.parse(record.expiresAt);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+    return undefined;
+  }
+  const headerTransforms = record.headerTransforms.filter(
+    (transform): transform is CredentialHeaderTransform =>
+      Boolean(
+        transform &&
+        typeof transform.domain === "string" &&
+        transform.headers &&
+        typeof transform.headers === "object",
+      ),
+  );
+  if (headerTransforms.length === 0) {
+    return undefined;
+  }
+  return {
+    provider: record.provider,
+    expiresAt: record.expiresAt,
+    headerTransforms,
+  };
+}
+
+/** Persist requester authorization for credential activation by one forwarded VM session. */
+export async function upsertSandboxEgressSession(input: {
+  egressId: string;
+  requesterId: string;
+  ttlMs?: number;
+}): Promise<void> {
+  const state = getStateAdapter();
+  await state.connect();
+  const ttlMs = Math.max(1, input.ttlMs ?? DEFAULT_SESSION_TTL_MS);
+  const now = Date.now();
+  const session: SandboxEgressSession = {
+    requesterId: input.requesterId,
+    expiresAtMs: now + ttlMs,
+    activationId: randomUUID(),
+  };
+  await state.set(sessionKey(input.egressId), session, ttlMs);
+}
+
+/** Clear the active requester-bound authorization context for a forwarded VM session. */
+export async function clearSandboxEgressSession(
+  egressId: string,
+): Promise<void> {
+  const state = getStateAdapter();
+  await state.connect();
+  await state.delete(sessionKey(egressId));
+}
+
+/** Load the active egress authorization session for a forwarded VM session. */
+export async function getSandboxEgressSession(
+  egressId: string,
+): Promise<SandboxEgressSession | undefined> {
+  const state = getStateAdapter();
+  await state.connect();
+  return parseSession(await state.get(sessionKey(egressId)));
+}
+
+/** Cache a short-lived credential lease for repeated requests from one forwarded VM session. */
+export async function setSandboxEgressCredentialLease(
+  egressId: string,
+  session: SandboxEgressSession,
+  lease: SandboxEgressCredentialLease,
+): Promise<void> {
+  const leaseExpiresAtMs = Date.parse(lease.expiresAt);
+  if (!Number.isFinite(leaseExpiresAtMs) || leaseExpiresAtMs <= Date.now()) {
+    return;
+  }
+  const ttlMs = Math.max(
+    1,
+    Math.min(leaseExpiresAtMs, session.expiresAtMs) - Date.now(),
+  );
+  const state = getStateAdapter();
+  await state.connect();
+  await state.set(leaseKey(egressId, lease.provider, session), lease, ttlMs);
+}
+
+/** Load a cached egress credential lease for a forwarded session/provider pair. */
+export async function getSandboxEgressCredentialLease(
+  egressId: string,
+  provider: string,
+  session: SandboxEgressSession,
+): Promise<SandboxEgressCredentialLease | undefined> {
+  const state = getStateAdapter();
+  await state.connect();
+  return parseLease(await state.get(leaseKey(egressId, provider, session)));
+}
+
+/** Clear a cached egress credential lease after the provider rejects its headers. */
+export async function clearSandboxEgressCredentialLease(
+  egressId: string,
+  provider: string,
+  session: SandboxEgressSession,
+): Promise<void> {
+  const state = getStateAdapter();
+  await state.connect();
+  await state.delete(leaseKey(egressId, provider, session));
+}

--- a/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/evals/fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/sandbox.ts
@@ -1,0 +1,577 @@
+import fs from "node:fs/promises";
+import {
+  logInfo,
+  setSpanAttributes,
+  setSpanStatus,
+  withSpan,
+  type LogContext,
+} from "@/chat/logging";
+import {
+  buildSandboxEgressNetworkPolicy,
+  resolveSandboxCommandEnvironment,
+} from "@/chat/sandbox/egress-policy";
+import {
+  clearSandboxEgressSession,
+  upsertSandboxEgressSession,
+} from "@/chat/sandbox/egress-session";
+import { throwSandboxOperationError } from "@/chat/sandbox/errors";
+import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
+import { createSandboxSessionManager } from "@/chat/sandbox/session";
+import {
+  isHostFileMissingError,
+  resolveHostDataPath,
+  resolveHostSkillPath,
+} from "@/chat/sandbox/skill-sync";
+import type { SandboxInstance } from "@/chat/sandbox/workspace";
+import type { SkillMetadata } from "@/chat/skills";
+import { editFile } from "@/chat/tools/sandbox/edit-file";
+import { findFiles } from "@/chat/tools/sandbox/find-files";
+import {
+  isMissingPathError,
+  positiveInteger,
+} from "@/chat/tools/sandbox/file-utils";
+import { grepFiles } from "@/chat/tools/sandbox/grep";
+import { listDir } from "@/chat/tools/sandbox/list-dir";
+import {
+  missingFileResult,
+  sliceFileContent,
+} from "@/chat/tools/sandbox/read-file";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+
+// Spec: specs/security-policy.md (sandbox isolation, network policy, credential lifecycle)
+// Spec: specs/logging/tracing-spec.md (required sandbox span semantics)
+interface SandboxExecutionInput {
+  toolName: string;
+  input: unknown;
+}
+
+export interface SandboxExecutionEnvelope<T = unknown> {
+  result: T;
+}
+
+export interface BashCustomCommandResult {
+  ok: boolean;
+  command: string;
+  cwd: string;
+  exit_code: number;
+  signal: null;
+  timed_out: boolean;
+  stdout: string;
+  stderr: string;
+  stdout_truncated: boolean;
+  stderr_truncated: boolean;
+}
+
+export interface SandboxAcquiredState {
+  sandboxId: string;
+  sandboxDependencyProfileHash?: string;
+}
+
+export interface SandboxExecutor {
+  configureSkills(skills: SkillMetadata[]): void;
+  configureReferenceFiles(files: string[]): void;
+  getSandboxId(): string | undefined;
+  getDependencyProfileHash(): string | undefined;
+  canExecute(toolName: string): boolean;
+  createSandbox(): Promise<SandboxInstance>;
+  execute<T>(
+    params: SandboxExecutionInput,
+  ): Promise<SandboxExecutionEnvelope<T>>;
+  dispose(): Promise<void>;
+}
+
+const SANDBOX_TOOL_NAMES = new Set([
+  "bash",
+  "readFile",
+  "editFile",
+  "grep",
+  "findFiles",
+  "listDir",
+  "writeFile",
+]);
+
+function parseEnv(raw: unknown): Record<string, string> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>)
+      .filter(([, value]) => typeof value === "string")
+      .map(([key, value]) => [key, value as string]),
+  );
+}
+
+/** Create one sandbox-backed tool executor facade for the current turn. */
+export function createSandboxExecutor(options?: {
+  sandboxId?: string;
+  sandboxDependencyProfileHash?: string;
+  timeoutMs?: number;
+  traceContext?: LogContext;
+  credentialEgress?: {
+    requesterId: string;
+  };
+  onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
+  runBashCustomCommand?: (
+    command: string,
+  ) => Promise<{ handled: boolean; result?: BashCustomCommandResult }>;
+}): SandboxExecutor {
+  let availableSkills: SkillMetadata[] = [];
+  let referenceFiles: string[] = [];
+  const traceContext = options?.traceContext ?? {};
+  const credentialEgress = options?.credentialEgress;
+  const authorizeSandboxEgressForCommand = credentialEgress
+    ? async (egressId: string): Promise<void> => {
+        await upsertSandboxEgressSession({
+          egressId,
+          requesterId: credentialEgress.requesterId,
+          ttlMs: options?.timeoutMs,
+        });
+      }
+    : undefined;
+  const clearSandboxEgressForCommand = credentialEgress
+    ? async (egressId: string): Promise<void> => {
+        await clearSandboxEgressSession(egressId);
+      }
+    : undefined;
+  const sessionManager = createSandboxSessionManager({
+    sandboxId: options?.sandboxId,
+    sandboxDependencyProfileHash: options?.sandboxDependencyProfileHash,
+    timeoutMs: options?.timeoutMs,
+    traceContext,
+    commandEnv: credentialEgress
+      ? async () => await resolveSandboxCommandEnvironment()
+      : undefined,
+    createNetworkPolicy: credentialEgress
+      ? buildSandboxEgressNetworkPolicy
+      : undefined,
+    beforeCommand: authorizeSandboxEgressForCommand,
+    afterCommand: clearSandboxEgressForCommand,
+    onSandboxAcquired: async (sandbox) => {
+      await options?.onSandboxAcquired?.(sandbox);
+    },
+  });
+
+  const withSandboxSpan = <T>(
+    name: string,
+    op: string,
+    attributes: Record<string, unknown>,
+    callback: () => Promise<T>,
+  ): Promise<T> => withSpan(name, op, traceContext, callback, attributes);
+
+  const logSandboxBootRequest = (
+    trigger: string,
+    details: Record<string, string | number> = {},
+  ): void => {
+    if (sessionManager.getSandboxId()) {
+      return;
+    }
+
+    logInfo(
+      "sandbox_boot_requested",
+      traceContext,
+      {
+        "app.sandbox.boot.trigger": trigger,
+        ...details,
+      },
+      "Sandbox boot requested",
+    );
+  };
+
+  const executeBashTool = async <T>(
+    rawInput: Record<string, unknown>,
+    command: string,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const env = parseEnv(rawInput.env);
+    const timeoutMs = positiveInteger(rawInput.timeoutMs);
+    logSandboxBootRequest("tool.bash", {
+      "app.sandbox.command_length": command.length,
+    });
+    const executeBash = (await sessionManager.ensureToolExecutors()).bash;
+    const result = await withSandboxSpan(
+      "bash",
+      "process.exec",
+      {
+        "process.executable.name": "bash",
+      },
+      async () => {
+        try {
+          const response = await executeBash({
+            command,
+            ...(env ? { env } : {}),
+            ...(timeoutMs ? { timeoutMs } : {}),
+          });
+          setSpanAttributes({
+            "process.exit.code": response.exitCode,
+            "app.sandbox.stdout_bytes": Buffer.byteLength(
+              response.stdout ?? "",
+              "utf8",
+            ),
+            "app.sandbox.stderr_bytes": Buffer.byteLength(
+              response.stderr ?? "",
+              "utf8",
+            ),
+            ...(response.exitCode !== 0
+              ? { "error.type": "nonzero_exit" }
+              : {}),
+          });
+          setSpanStatus(response.exitCode === 0 ? "ok" : "error");
+          return response;
+        } catch (error) {
+          setSpanAttributes({
+            "error.type":
+              error instanceof Error ? error.name : "sandbox_execute_error",
+          });
+          setSpanStatus("error");
+          throw error;
+        }
+      },
+    );
+
+    return {
+      result: {
+        ok: result.exitCode === 0,
+        command,
+        cwd: SANDBOX_WORKSPACE_ROOT,
+        exit_code: result.exitCode,
+        signal: null,
+        timed_out: Boolean(result.timedOut),
+        stdout: result.stdout,
+        stderr: result.stderr,
+        stdout_truncated: result.stdoutTruncated,
+        stderr_truncated: result.stderrTruncated,
+      } as T,
+    };
+  };
+
+  const executeReadFileTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const filePath = String(rawInput.path ?? "").trim();
+    if (!filePath) {
+      throw new ToolInputError("path is required");
+    }
+    const offset = positiveInteger(rawInput.offset);
+    const limit = positiveInteger(rawInput.limit);
+
+    if (!sessionManager.getSandboxId()) {
+      const hostPath =
+        resolveHostSkillPath(availableSkills, filePath) ??
+        resolveHostDataPath(referenceFiles, filePath);
+      if (hostPath) {
+        try {
+          const content = await fs.readFile(hostPath, "utf8");
+          setSpanAttributes({
+            "app.sandbox.path.length": filePath.length,
+            "app.sandbox.read.bytes": Buffer.byteLength(content, "utf8"),
+            "app.sandbox.read.chars": content.length,
+            "app.skill.virtual_read": true,
+          });
+          setSpanStatus("ok");
+          return {
+            result: sliceFileContent({
+              content,
+              path: filePath,
+              offset,
+              limit,
+            }) as T,
+          };
+        } catch (error) {
+          if (!isHostFileMissingError(error)) {
+            throw error;
+          }
+        }
+      }
+    }
+
+    logSandboxBootRequest("tool.readFile", {
+      "file.path": filePath,
+    });
+    const executeReadFile = (await sessionManager.ensureToolExecutors())
+      .readFile;
+    const result = await withSandboxSpan(
+      "sandbox.readFile",
+      "sandbox.fs.read",
+      {
+        "app.sandbox.path.length": filePath.length,
+      },
+      async () => {
+        let response: { content: string };
+        try {
+          response = await executeReadFile({ path: filePath });
+        } catch (error) {
+          if (isMissingPathError(error)) {
+            setSpanStatus("ok");
+            return missingFileResult(filePath);
+          }
+          throw error;
+        }
+        const content = String(response.content ?? "");
+        setSpanAttributes({
+          "app.sandbox.read.bytes": Buffer.byteLength(content, "utf8"),
+          "app.sandbox.read.chars": content.length,
+        });
+        setSpanStatus("ok");
+        return {
+          ...sliceFileContent({
+            content,
+            path: filePath,
+            offset,
+            limit,
+          }),
+        };
+      },
+    );
+
+    return { result: result as T };
+  };
+
+  const executeWriteFileTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const filePath = String(rawInput.path ?? "").trim();
+    if (!filePath) {
+      throw new ToolInputError("path is required");
+    }
+
+    const content = String(rawInput.content ?? "");
+    logSandboxBootRequest("tool.writeFile", {
+      "file.path": filePath,
+    });
+    const executeWriteFile = (await sessionManager.ensureToolExecutors())
+      .writeFile;
+    await withSandboxSpan(
+      "sandbox.writeFile",
+      "sandbox.fs.write",
+      {
+        "app.sandbox.path.length": filePath.length,
+        "app.sandbox.write.bytes": Buffer.byteLength(content, "utf8"),
+      },
+      async () => {
+        try {
+          await executeWriteFile({ path: filePath, content });
+        } catch (error) {
+          throwSandboxOperationError("sandbox writeFile", error);
+        }
+        setSpanStatus("ok");
+      },
+    );
+
+    return {
+      result: {
+        ok: true,
+        path: filePath,
+        bytes_written: Buffer.byteLength(content, "utf8"),
+      } as T,
+    };
+  };
+
+  const executeEditFileTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const filePath = String(rawInput.path ?? "").trim();
+    if (!filePath) {
+      throw new ToolInputError("path is required");
+    }
+    if (!Array.isArray(rawInput.edits)) {
+      throw new ToolInputError("edits is required");
+    }
+
+    logSandboxBootRequest("tool.editFile", {
+      "file.path": filePath,
+    });
+    const executors = await sessionManager.ensureToolExecutors();
+    const result = await withSandboxSpan(
+      "sandbox.editFile",
+      "sandbox.fs.edit",
+      {
+        "app.sandbox.path.length": filePath.length,
+        "app.sandbox.edit.count": rawInput.edits.length,
+      },
+      async () => {
+        const response = await editFile({
+          fs: executors.fs,
+          path: filePath,
+          edits: rawInput.edits as Array<{ oldText: string; newText: string }>,
+        });
+        setSpanStatus("ok");
+        return response;
+      },
+    );
+
+    return { result: result as T };
+  };
+
+  const executeGrepTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const pattern = String(rawInput.pattern ?? "");
+    if (!pattern) {
+      throw new ToolInputError("pattern is required");
+    }
+
+    logSandboxBootRequest("tool.grep");
+    const contextLines = positiveInteger(rawInput.context);
+    const limit = positiveInteger(rawInput.limit);
+    const executors = await sessionManager.ensureToolExecutors();
+    const result = await withSandboxSpan(
+      "sandbox.grep",
+      "sandbox.fs.search",
+      {
+        "app.sandbox.pattern.length": pattern.length,
+      },
+      async () => {
+        const response = await grepFiles({
+          fs: executors.fs,
+          pattern,
+          ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
+          ...(typeof rawInput.glob === "string" ? { glob: rawInput.glob } : {}),
+          ...(typeof rawInput.ignoreCase === "boolean"
+            ? { ignoreCase: rawInput.ignoreCase }
+            : {}),
+          ...(typeof rawInput.literal === "boolean"
+            ? { literal: rawInput.literal }
+            : {}),
+          ...(contextLines ? { context: contextLines } : {}),
+          ...(limit ? { limit } : {}),
+        });
+        setSpanStatus("ok");
+        return response;
+      },
+    );
+
+    return { result: result as T };
+  };
+
+  const executeFindFilesTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const pattern = String(rawInput.pattern ?? "");
+    if (!pattern) {
+      throw new ToolInputError("pattern is required");
+    }
+
+    logSandboxBootRequest("tool.findFiles");
+    const limit = positiveInteger(rawInput.limit);
+    const executors = await sessionManager.ensureToolExecutors();
+    const result = await withSandboxSpan(
+      "sandbox.findFiles",
+      "sandbox.fs.find",
+      {
+        "app.sandbox.pattern.length": pattern.length,
+      },
+      async () => {
+        const response = await findFiles({
+          fs: executors.fs,
+          pattern,
+          ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
+          ...(limit ? { limit } : {}),
+        });
+        setSpanStatus("ok");
+        return response;
+      },
+    );
+
+    return { result: result as T };
+  };
+
+  const executeListDirTool = async <T>(
+    rawInput: Record<string, unknown>,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    logSandboxBootRequest("tool.listDir");
+    const limit = positiveInteger(rawInput.limit);
+    const executors = await sessionManager.ensureToolExecutors();
+    const result = await withSandboxSpan(
+      "sandbox.listDir",
+      "sandbox.fs.list",
+      {},
+      async () => {
+        const response = await listDir({
+          fs: executors.fs,
+          ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
+          ...(limit ? { limit } : {}),
+        });
+        setSpanStatus("ok");
+        return response;
+      },
+    );
+
+    return { result: result as T };
+  };
+
+  const execute = async <T>(
+    params: SandboxExecutionInput,
+  ): Promise<SandboxExecutionEnvelope<T>> => {
+    const rawInput = (params.input ?? {}) as Record<string, unknown>;
+    const bashCommand =
+      params.toolName === "bash"
+        ? String(rawInput.command ?? "").trim()
+        : undefined;
+
+    if (params.toolName === "bash") {
+      if (!bashCommand) {
+        throw new ToolInputError("command is required");
+      }
+      if (options?.runBashCustomCommand) {
+        const custom = await options.runBashCustomCommand(bashCommand);
+        if (custom.handled) {
+          return { result: custom.result as T };
+        }
+      }
+      return await executeBashTool(rawInput, bashCommand);
+    }
+
+    if (params.toolName === "readFile") {
+      return await executeReadFileTool(rawInput);
+    }
+
+    if (params.toolName === "editFile") {
+      return await executeEditFileTool(rawInput);
+    }
+
+    if (params.toolName === "grep") {
+      return await executeGrepTool(rawInput);
+    }
+
+    if (params.toolName === "findFiles") {
+      return await executeFindFilesTool(rawInput);
+    }
+
+    if (params.toolName === "listDir") {
+      return await executeListDirTool(rawInput);
+    }
+
+    if (params.toolName === "writeFile") {
+      return await executeWriteFileTool(rawInput);
+    }
+
+    throw new Error(`unsupported sandbox tool: ${params.toolName}`);
+  };
+
+  return {
+    configureSkills(skills: SkillMetadata[]) {
+      availableSkills = [...skills];
+      sessionManager.configureSkills(skills);
+    },
+    configureReferenceFiles(files: string[]) {
+      referenceFiles = [...files];
+      sessionManager.configureReferenceFiles(files);
+    },
+    getSandboxId() {
+      return sessionManager.getSandboxId();
+    },
+    getDependencyProfileHash() {
+      return sessionManager.getDependencyProfileHash();
+    },
+    canExecute(toolName: string) {
+      return SANDBOX_TOOL_NAMES.has(toolName);
+    },
+    async createSandbox() {
+      return await sessionManager.createSandbox();
+    },
+    execute,
+    async dispose() {
+      await sessionManager.dispose();
+    },
+  };
+}

--- a/packages/evals/fixtures/pagination-floor-total-pages/paginator.ts
+++ b/packages/evals/fixtures/pagination-floor-total-pages/paginator.ts
@@ -1,0 +1,24 @@
+interface Page<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+}
+
+type FetchPage<T> = (page: number) => Promise<Page<T>>;
+
+/**
+ * Fetches every item from a one-indexed paginated API.
+ */
+export async function fetchAllItems<T>(fetchPage: FetchPage<T>): Promise<T[]> {
+  const firstPage = await fetchPage(1);
+  const totalPages = Math.floor(firstPage.totalItems / firstPage.pageSize);
+  const items = [...firstPage.items];
+
+  for (let page = 2; page <= totalPages; page++) {
+    const nextPage = await fetchPage(page);
+    items.push(...nextPage.items);
+  }
+
+  return items;
+}

--- a/packages/evals/fixtures/permission-level-comparison/permissions.ts
+++ b/packages/evals/fixtures/permission-level-comparison/permissions.ts
@@ -1,0 +1,28 @@
+type Role = 'viewer' | 'editor' | 'admin' | 'owner';
+
+interface Permission {
+  action: string;
+  minimumRole: Role;
+}
+
+const ROLE_LEVEL: Record<Role, number> = {
+  viewer: 0,
+  editor: 1,
+  admin: 2,
+  owner: 3,
+};
+
+/**
+ * Higher roles include the permissions granted to lower roles.
+ */
+export function canPerform(userRole: Role, minimumRole: Role): boolean {
+  const userLevel = ROLE_LEVEL[userRole];
+  const requiredLevel = ROLE_LEVEL[minimumRole];
+  return userLevel <= requiredLevel;
+}
+
+export function allowedActions(userRole: Role, permissions: Permission[]): string[] {
+  return permissions
+    .filter((permission) => canPerform(userRole, permission.minimumRole))
+    .map((permission) => permission.action);
+}

--- a/packages/evals/fixtures/sentry-action-dedup-by-workflow/LICENSE.md
+++ b/packages/evals/fixtures/sentry-action-dedup-by-workflow/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_models_action.py
+++ b/packages/evals/fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_models_action.py
@@ -1,0 +1,31 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/models/action.py@1730e13b97865d3ee8943c6f860964388c4987a8.
+# Unrelated class fields and trigger code omitted; captured around fix 165be911ba388d402993b58f34dc8ad683827e32.
+
+
+class Action:
+    type: str
+    integration_id: int | None
+    config: dict | None
+    data: dict | None
+
+    def get_dedup_key(self, workflow_id: int | None) -> str:
+        key_parts = [self.type]
+        if workflow_id is not None:
+            key_parts.append(str(workflow_id))
+
+        if self.integration_id:
+            key_parts.append(str(self.integration_id))
+
+        if self.config:
+            config = self.config.copy()
+            config.pop("target_display", None)
+            key_parts.append(str(config))
+
+        if self.data:
+            data = self.data.copy()
+            if "dynamic_form_fields" in data:
+                data = data["dynamic_form_fields"]
+
+            key_parts.append(str(data))
+
+        return ":".join(key_parts)

--- a/packages/evals/fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_processors_action.py
+++ b/packages/evals/fixtures/sentry-action-dedup-by-workflow/src_sentry_workflow_engine_processors_action.py
@@ -1,0 +1,44 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/processors/action.py@1730e13b97865d3ee8943c6f860964388c4987a8.
+# Unrelated status and task dispatch code omitted; captured around fix 165be911ba388d402993b58f34dc8ad683827e32.
+
+from collections import defaultdict
+
+
+def get_unique_active_actions(actions_queryset, group):
+    """
+    Returns a queryset of unique active actions based on their handler's dedup_key method.
+    Group is used for logging only.
+    """
+    dedup_key_to_action_id: dict[str, int] = {}
+    dropped = defaultdict[str, set[int]](set)
+
+    for action in actions_queryset:
+        # We only want to fire active actions
+        if action.status != ObjectStatus.ACTIVE:
+            continue
+
+        # workflow_id is annotated in the queryset
+        workflow_id = getattr(action, "workflow_id")
+        dedup_key = action.get_dedup_key(workflow_id)
+        previous_action_id = dedup_key_to_action_id.get(dedup_key)
+        if previous_action_id is not None:
+            dropped[dedup_key].add(previous_action_id)
+        dedup_key_to_action_id[dedup_key] = action.id
+
+    for dedup_key, action_ids in dropped.items():
+        group_type = group.issue_type.slug
+        logger.info(
+            "workflow_engine.action.dedup.dropped",
+            extra={
+                "dedup_key": dedup_key,
+                "dropped_action_ids": sorted(action_ids),
+                "replacement_action_id": dedup_key_to_action_id[dedup_key],
+                "group_id": group.id,
+                "group_type": group_type,
+            },
+        )
+        metrics.incr(
+            "workflow_engine.action.dedup.dropped", len(action_ids), tags={"group_type": group_type}
+        )
+
+    return actions_queryset.filter(id__in=dedup_key_to_action_id.values())

--- a/packages/evals/fixtures/sentry-ai-conversation-multipart-message/LICENSE.md
+++ b/packages/evals/fixtures/sentry-ai-conversation-multipart-message/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-ai-conversation-multipart-message/conversationMessages.ts
+++ b/packages/evals/fixtures/sentry-ai-conversation-multipart-message/conversationMessages.ts
@@ -1,0 +1,53 @@
+// Source excerpt from getsentry/sentry static/app/views/insights/pages/conversations/utils/conversationMessages.ts@8e5104733bdb0d03d2f7148da5869a651c4f23fd.
+// Unrelated context omitted; captured around the fix diff for ce32ccf8e820cf565c91ba9760c36df87dda353f.
+
+        msg => msg.role === 'assistant' && (msg.content || msg.parts)
+      );
+      if (assistantMessage) {
+        const content = extractTextFromMessage(assistantMessage);
+        if (content) {
+          return content;
+        }
+      }
+    } catch {
+      // Invalid JSON, fall through to legacy attributes
+    }
+  }
+
+  const responseText = getStringAttr(node, SpanFields.GEN_AI_RESPONSE_TEXT);
+  if (responseText) {
+    return responseText;
+  }
+
+  return getStringAttr(node, SpanFields.GEN_AI_RESPONSE_OBJECT) ?? null;
+}
+
+export function getNodeTimestamp(node: AITraceSpanNode): number {
+  return 'start_timestamp' in node.value ? node.value.start_timestamp : 0;
+}
+
+function getGenAiOpType(node: AITraceSpanNode): string | undefined {
+  return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
+}
+
+export function extractTextFromMessage(msg: RequestMessage): string | null {
+  if (Array.isArray(msg.parts)) {
+    const textParts = msg.parts
+      .filter(p => p.type === 'text')
+      .map(p => p.content || p.text)
+      .filter(Boolean);
+    if (textParts.length > 0) {
+      return textParts.join('\n');
+    }
+  }
+
+  if (typeof msg.content === 'string') {
+    return msg.content;
+  }
+
+  if (Array.isArray(msg.content)) {
+    return msg.content[0]?.text ?? null;
+  }
+
+  return null;
+}

--- a/packages/evals/fixtures/sentry-code-review-pr-closed-trigger-filter/LICENSE.md
+++ b/packages/evals/fixtures/sentry-code-review-pr-closed-trigger-filter/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-code-review-pr-closed-trigger-filter/pull_request.py
+++ b/packages/evals/fixtures/sentry-code-review-pr-closed-trigger-filter/pull_request.py
@@ -1,0 +1,40 @@
+# Source excerpt from getsentry/sentry src/sentry/seer/code_review/webhooks/pull_request.py@1d0f212196da9d2c5e2c6bf66ff2e3f6e694e44a.
+# Unrelated context omitted; captured around the fix diff for 722441c01309a9487d94bb84c740b6ae1b453735.
+
+            github_event, action_value, WebhookFilteredReason.UNSUPPORTED_ACTION
+        )
+        return
+
+    if action not in WHITELISTED_ACTIONS:
+        logger.warning(Log.UNSUPPORTED_ACTION.value)
+        record_webhook_filtered(
+            github_event, action_value, WebhookFilteredReason.UNSUPPORTED_ACTION
+        )
+        return
+
+    action_requires_trigger_permission = ACTIONS_REQUIRING_TRIGGER_CHECK.get(action)
+    if action_requires_trigger_permission is not None and (
+        org_code_review_settings is None
+        or action_requires_trigger_permission not in org_code_review_settings.triggers
+    ):
+        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
+        return
+
+    # Skip draft check for CLOSED actions to ensure Seer receives cleanup notifications
+    # even if the PR was converted to draft before closing
+    if action != PullRequestAction.CLOSED and pull_request.get("draft") is True:
+        return
+
+    pr_number = pull_request.get("number")
+    if pr_number and action in ACTIONS_ELIGIBLE_FOR_EYES_REACTION:
+        # We don't ever need to delete :eyes: since we later add it back to the PR description idempotently.
+        reactions_to_delete = [GitHubReaction.HOORAY]
+        if is_github_rate_limit_sensitive(organization.slug):
+            reactions_to_delete = []
+
+        delete_existing_reactions_and_add_reaction(
+            github_event=github_event,
+            github_event_action=action_value,
+            integration=integration,
+            organization_id=organization.id,
+            repo=repo,

--- a/packages/evals/fixtures/sentry-cursor-service-account-api-key/LICENSE.md
+++ b/packages/evals/fixtures/sentry-cursor-service-account-api-key/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-cursor-service-account-api-key/client.py
+++ b/packages/evals/fixtures/sentry-cursor-service-account-api-key/client.py
@@ -1,0 +1,109 @@
+# Source excerpt from getsentry/sentry src/sentry/integrations/cursor/client.py@dd2e7671013b38550048c3c427b5152997e91ab9.
+# Unrelated context omitted; captured around the fix diff for 652324b48217e89f4267bfc1bb6e5e390818c277.
+
+        message = error_json["error"]
+        match = _MODEL_NAME_PATTERN.search(message)
+    except (AttributeError, KeyError, TypeError) as e:
+        logger.warning(
+            "coding_agent.cursor.extract_model_from_error_failed", extra={"error": str(e)}
+        )
+        return None
+    return match.group(1) if match else None
+
+
+def _get_model_family(model_name: str) -> str:
+    """Extract the alphabetic family prefix from a model name.
+
+    Examples: 'gpt-4' -> 'gpt', 'claude-4.6-opus-high-thinking' -> 'claude'
+    """
+    match = _MODEL_FAMILY_PATTERN.match(model_name)
+    return match.group(1).lower() if match else model_name.lower()
+
+
+def _prioritize_models_by_family(models: list[str], failed_model: str | None) -> list[str]:
+    """Reorder models so same-family models come first, then GPT models, then the rest."""
+    if failed_model is None:
+        return models
+    family = _get_model_family(failed_model)
+    same_family = [m for m in models if _get_model_family(m) == family]
+    gpt_fallback = [
+        m for m in models if _get_model_family(m) != family and _get_model_family(m) == "gpt"
+    ]
+    other = [m for m in models if _get_model_family(m) != family and _get_model_family(m) != "gpt"]
+    return same_family + gpt_fallback + other
+
+
+class CursorAgentClient(CodingAgentClient):
+    integration_name = "cursor"
+    base_url = "https://api.cursor.com"
+    api_key: str
+
+    def __init__(self, api_key: str, webhook_secret: str):
+        super().__init__()
+        self.api_key = api_key
+        self.webhook_secret = webhook_secret
+
+    def _get_auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def get_api_key_metadata(self) -> CursorApiKeyMetadata:
+        """Fetch metadata about the API key from Cursor's /v0/me endpoint."""
+        logger.info(
+            "coding_agent.cursor.get_api_key_metadata",
+            extra={"agent_type": self.__class__.__name__},
+        )
+
+        api_response = self.get(
+            "/v0/me",
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **self._get_auth_headers(),
+            },
+            timeout=30,
+        )
+
+        return CursorApiKeyMetadata.validate(api_response.json)
+
+    def get_available_models(self) -> list[str]:
+        """Fetch available models from Cursor's /v0/models endpoint."""
+        api_response = self.get(
+            "/v0/models",
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **self._get_auth_headers(),
+            },
+            timeout=30,
+        )
+
+        return CursorModelsResponse.validate(api_response.json).models
+
+    def _post_launch(
+        self,
+        payload: CursorAgentLaunchRequestBody,
+        request: CodingAgentLaunchRequest,
+    ) -> CodingAgentState:
+        """Post a launch request and parse the response into a CodingAgentState."""
+        api_response = self.post(
+            "/v0/agents",
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **self._get_auth_headers(),
+            },
+            data=payload.dict(exclude_none=True),
+            json=True,
+            timeout=60,
+        )
+
+        launch_response = CursorAgentLaunchResponse.validate(api_response.json)
+
+        return CodingAgentState(
+            id=launch_response.id,
+            status=CodingAgentStatus.RUNNING,
+            provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
+            name=f"{request.repository.owner}/{request.repository.name}: {launch_response.name or f'Cursor Agent {launch_response.id}'}",
+            started_at=launch_response.createdAt,
+            agent_url=launch_response.target.url,
+        )
+
+    def launch(self, webhook_url: str, request: CodingAgentLaunchRequest) -> CodingAgentState:
+        """Launch coding agent with webhook callback.

--- a/packages/evals/fixtures/sentry-cursor-service-account-api-key/integration.py
+++ b/packages/evals/fixtures/sentry-cursor-service-account-api-key/integration.py
@@ -1,0 +1,179 @@
+# Source excerpt from getsentry/sentry src/sentry/integrations/cursor/integration.py@dd2e7671013b38550048c3c427b5152997e91ab9.
+# Unrelated context omitted; captured around the fix diff for 652324b48217e89f4267bfc1bb6e5e390818c277.
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Literal
+
+from django import forms
+from django.http.request import HttpRequest
+from django.http.response import HttpResponseBase
+from django.utils.translation import gettext_lazy as _
+from pydantic import BaseModel, ValidationError
+from requests import HTTPError
+
+from sentry.integrations.base import (
+    FeatureDescription,
+    IntegrationData,
+    IntegrationFeatures,
+    IntegrationMetadata,
+)
+from sentry.integrations.coding_agent.integration import (
+    CodingAgentIntegration,
+    CodingAgentIntegrationProvider,
+)
+from sentry.integrations.cursor.client import CursorAgentClient
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.models.apitoken import generate_token
+
+# ... source context omitted ...
+
+        [
+            IntegrationFeatures.CODING_AGENT,
+        ]
+    )
+
+    def get_pipeline_views(self):
+        return [CursorPipelineView()]
+
+    def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
+        config = state.get("config", {})
+        if not config:
+            raise IntegrationConfigurationError("Missing configuration data")
+
+        webhook_secret = generate_token()
+        api_key = config["api_key"]
+
+        try:
+            client = CursorAgentClient(api_key=api_key, webhook_secret=webhook_secret)
+            cursor_metadata = client.get_api_key_metadata()
+            api_key_name = cursor_metadata.apiKeyName
+            user_email = cursor_metadata.userEmail
+        except (HTTPError, ApiError) as e:
+            self.get_logger().exception("cursor.build_integration.metadata_fetch_failed")
+            status_code: int | None = None
+            if isinstance(e, ApiError):
+                status_code = e.code
+            elif isinstance(e, HTTPError) and e.response is not None:
+                status_code = e.response.status_code
+            if status_code in (401, 403):
+                raise IntegrationConfigurationError(
+                    "Invalid Cursor API key. Please verify that your API key is correct and has not been revoked."
+                )
+            raise IntegrationConfigurationError(
+                "Unable to validate Cursor API key. Please try again or contact support if the issue persists."
+            )
+        except ValidationError:
+            self.get_logger().exception("cursor.build_integration.metadata_validation_failed")
+            raise IntegrationConfigurationError(
+                "Received unexpected response from Cursor API. Please try again."
+            )
+
+        integration_name = (
+            f"Cursor Cloud Agent - {user_email}/{api_key_name}"
+            if user_email and api_key_name
+            else "Cursor Cloud Agent"
+        )
+
+        metadata = CursorIntegrationMetadata(
+            domain_name="cursor.sh",
+            api_key=api_key,
+            webhook_secret=webhook_secret,
+            api_key_name=api_key_name,
+            user_email=user_email,
+        )
+
+        return {
+            # NOTE(jennmueng): We need to create a unique ID for each integration installation. Because of this, new installations will yield a unique external_id and integration.
+            # Why UUIDs? We use UUIDs here for each integration installation because we don't know how many times this USER-LEVEL API key will be used, or if the same org can have multiple cursor agents (in the near future)
+            # or if the same user can have multiple installations across multiple orgs. So just a UUID per installation is the best approach. Re-configuring an existing installation will still maintain this external id
+            "external_id": uuid.uuid4().hex,
+            "name": integration_name,
+            "metadata": metadata.dict(),
+        }
+
+    def get_agent_name(self) -> str:
+        return "Cursor Agent"
+
+    def get_agent_key(self) -> str:
+        return "cursor"
+
+    @classmethod
+    def get_installation(
+        cls, model: RpcIntegration | Integration, organization_id: int, **kwargs: Any
+    ) -> CursorAgentIntegration:
+        return CursorAgentIntegration(model, organization_id)
+
+
+class CursorAgentIntegration(CodingAgentIntegration):
+    def get_organization_config(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "api_key",
+                "type": "secret",
+                "label": _("Cursor API Key"),
+                "help": _("Update the API key used by Cursor Cloud Agents."),
+                "required": True,
+                "placeholder": "***********************",
+                "formatMessageValue": False,
+            }
+        ]
+
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+        api_key = data.get("api_key")
+        if not api_key:
+            raise IntegrationConfigurationError("API key is required")
+
+        metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})
+
+        try:
+            client = CursorAgentClient(api_key=api_key, webhook_secret=metadata.webhook_secret)
+            cursor_metadata = client.get_api_key_metadata()
+            metadata.api_key = api_key
+            metadata.api_key_name = cursor_metadata.apiKeyName
+            metadata.user_email = cursor_metadata.userEmail
+        except (HTTPError, ApiError) as e:
+            status_code: int | None = None
+            if isinstance(e, ApiError):
+                status_code = e.code
+            elif isinstance(e, HTTPError) and e.response is not None:
+                status_code = e.response.status_code
+            if status_code in (401, 403):
+                raise IntegrationConfigurationError(
+                    "Invalid Cursor API key. Please verify that your API key is correct and has not been revoked."
+                )
+            raise IntegrationConfigurationError(
+                "Unable to validate Cursor API key. Please try again or contact support if the issue persists."
+            )
+        except ValidationError:
+            raise IntegrationConfigurationError(
+                "Received unexpected response from Cursor API. Please try again."
+            )
+
+        integration_name = (
+            f"Cursor Cloud Agent - {metadata.user_email}/{metadata.api_key_name}"
+            if metadata.user_email and metadata.api_key_name
+            else "Cursor Cloud Agent"
+        )
+
+        integration_service.update_integration(
+            integration_id=self.model.id, name=integration_name, metadata=metadata.dict()
+        )
+        self.model.metadata = metadata.dict()
+
+        super().update_organization_config({})
+
+    def get_client(self):
+        return CursorAgentClient(
+            api_key=self.api_key,
+            webhook_secret=self.webhook_secret,
+        )
+
+    def get_dynamic_display_information(self) -> Mapping[str, Any] | None:
+        """Return metadata to display in the configurations list."""
+        metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})

--- a/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/LICENSE.md
+++ b/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/convertWidgetToBuilderStateParams.ts
+++ b/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/convertWidgetToBuilderStateParams.ts
@@ -1,0 +1,81 @@
+import {explodeField} from 'sentry/utils/discover/fields';
+import {
+  DisplayType,
+  WidgetType,
+  type Widget,
+  type WidgetQuery,
+} from 'sentry/views/dashboards/types';
+import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
+import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
+import {
+  serializeFields,
+  serializeThresholds,
+  serializeTraceMetric,
+  type WidgetBuilderStateQueryParams,
+} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+
+function stringifyFields(
+  query: WidgetQuery,
+  fieldKey: 'fields' | 'columns' | 'aggregates'
+) {
+  const fields = query[fieldKey]?.map((field, index) =>
+    explodeField({field, alias: query.fieldAliases?.[index]})
+  );
+  return fields ? serializeFields(fields) : [];
+}
+
+/**
+ * Converts a widget to a set of query params that can be used to
+ * restore the widget builder state.
+ */
+export function convertWidgetToBuilderStateParams(
+  widget: Widget
+): WidgetBuilderStateQueryParams {
+  const query = widget.queries.flatMap(q => q.conditions);
+  const sort = widget.queries.flatMap(q => q.orderby);
+  let legendAlias = widget.queries.flatMap(q => q.name);
+
+  // y-axes and fields are shared across all queries
+  // so we can just use the first query
+  const firstWidgetQuery = widget.queries[0];
+  let yAxis = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'aggregates') : [];
+  let field: string[] = [];
+  if (usesTimeSeriesData(widget.displayType)) {
+    field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'columns') : [];
+  } else {
+    // For TRACEMETRICS table/big_number widgets, use raw field strings directly
+    // because stringifyFields loses the 4th argument (unit: "-")
+    if (widget.widgetType === WidgetType.TRACEMETRICS && firstWidgetQuery?.fields) {
+      field = firstWidgetQuery.fields;
+    } else {
+      field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'fields') : [];
+    }
+
+    yAxis = [];
+    legendAlias = [];
+  }
+
+  let traceMetric: TraceMetric | null = null;
+  if (widget.widgetType === WidgetType.TRACEMETRICS) {
+    traceMetric = extractTraceMetricFromWidget(widget);
+  }
+
+  return {
+    title: widget.title,
+    description: widget.description ?? '',
+    dataset: widget.widgetType ?? WidgetType.ERRORS,
+    displayType: widget.displayType ?? DisplayType.TABLE,
+    limit: widget.limit,
+    field,
+    yAxis,
+    query,
+    sort,
+    legendAlias,
+    selectedAggregate: firstWidgetQuery?.selectedAggregate,
+    thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
+    traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
+    axisRange: getAxisRange(widget.axisRange),
+  };
+}

--- a/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/getDefaultWidget.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-axis-range-existing-widget/getDefaultWidget.tsx
@@ -1,0 +1,13 @@
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+
+export function getDefaultWidget(widgetType: WidgetType): Widget {
+  const config = getDatasetConfig(widgetType);
+  return {
+    displayType: widgetType === WidgetType.ISSUE ? DisplayType.TABLE : DisplayType.LINE,
+    interval: '',
+    title: 'Custom Widget',
+    widgetType,
+    queries: [config.defaultWidgetQuery],
+  };
+}

--- a/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/LICENSE.md
+++ b/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/dashboards.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/dashboards.tsx
@@ -1,0 +1,103 @@
+// Source excerpt from getsentry/sentry static/app/actionCreators/dashboards.tsx@14170bd6ae28abe4d4f0b5807185b116f777a1a0.
+// Unrelated context omitted; captured around the fix diff for 86872f4f1491c4392a25f4d3fcba31a12726fa63.
+
+  const {title, widgets, projects, environment, period, start, end, filters, utc} =
+    dashboard;
+  const data = {
+    title,
+    widgets: widgets.map(widget => omit(widget, ['tempId'])).map(_enforceWidgetLimit),
+    projects,
+    environment,
+    period,
+    start,
+    end,
+    filters,
+    utc,
+  };
+
+  const promise: Promise<DashboardDetails> = api.requestPromise(
+    `/organizations/${orgId}/dashboards/${dashboard.id}/`,
+    {
+      method: 'PUT',
+      data,
+      query: {
+        project: projects,
+        environment,
+      },
+    }
+  );
+
+  // We let the callers of `updateDashboard` handle adding a success message, so
+  // that it can be more specific than just "Dashboard updated," but do the
+  // error-handling here, since it doesn't depend on the caller's context
+  promise.catch(response => {
+    const errorResponse = response?.responseJSON ?? null;
+
+    if (errorResponse) {
+      const errors = flattenErrors(errorResponse, {});
+      addErrorMessage(errors[Object.keys(errors)[0]!] as string);
+    } else {
+      addErrorMessage(t('Unable to update dashboard'));
+    }
+  });
+
+  return promise;
+}
+
+export function deleteDashboard(
+  api: Client,
+  orgId: string,
+  dashboardId: string
+): Promise<undefined> {
+  const promise: Promise<undefined> = api.requestPromise(
+    `/organizations/${orgId}/dashboards/${dashboardId}/`,
+    {
+      method: 'DELETE',
+    }
+  );
+
+  promise.catch(response => {
+    const errorResponse = response?.responseJSON ?? null;
+
+    if (errorResponse) {
+      const errors = flattenErrors(errorResponse, {});
+      addErrorMessage(errors[Object.keys(errors)[0]!] as string);
+    } else {
+      addErrorMessage(t('Unable to delete dashboard'));
+    }
+  });
+
+  return promise;
+}
+
+export function validateWidgetRequest(
+  orgId: string,
+  widget: Widget,
+  selection: PageFilters
+) {
+  return [
+    getApiUrl('/organizations/$organizationIdOrSlug/dashboards/widgets/', {
+      path: {organizationIdOrSlug: orgId},
+    }),
+    {
+      method: 'POST',
+      data: widget,
+      query: {
+        // TODO: This should be replaced in the future with projects
+        // when we save Dashboard page filters. This is being sent to
+        // bypass validation when creating or updating dashboards
+        project: [ALL_ACCESS_PROJECTS],
+        environment: selection.environments,
+      },
+    },
+  ] as const;
+}
+
+export function updateDashboardPermissions(
+  api: Client,
+  orgId: string,
+  dashboard: DashboardDetails | DashboardListItem
+): Promise<DashboardDetails> {
+  const {permissions} = dashboard;
+  const data = {
+    permissions,

--- a/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/detail.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/detail.tsx
@@ -1,0 +1,187 @@
+// Source excerpt from getsentry/sentry static/app/views/dashboards/detail.tsx@14170bd6ae28abe4d4f0b5807185b116f777a1a0.
+// Unrelated context omitted; captured around the fix diff for 86872f4f1491c4392a25f4d3fcba31a12726fa63.
+
+  WidgetViewerQueryField,
+} from 'sentry/components/modals/widgetViewerModal/utils';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFiltersContainer from 'sentry/components/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {browserHistory} from 'sentry/utils/browserHistory';
+import EventView from 'sentry/utils/discover/eventView';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
+import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
+import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
+import {decodeBoolean} from 'sentry/utils/queryString';
+import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useApi from 'sentry/utils/useApi';
+import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
+import {
+  cloneDashboard,
+  getCurrentPageFilters,
+  getDashboardFiltersFromURL,
+  hasUnsavedFilterChanges,
+
+// ... source context omitted ...
+
+};
+
+type RouteParams = {
+  dashboardId?: string;
+  templateId?: string;
+  widgetId?: string;
+  widgetIndex?: string;
+};
+
+type Props = {
+  api: Client;
+  dashboard: DashboardDetails;
+  dashboards: DashboardListItem[];
+  initialState: DashboardState;
+  location: Location;
+  navigate: ReactRouter3Navigate;
+  organization: Organization;
+  params: RouteParams;
+  projects: Project[];
+  router: InjectedRouter;
+  theme: Theme;
+  children?: React.ReactNode;
+  onDashboardUpdate?: (updatedDashboard: DashboardDetails) => void;
+  storageNamespace?: string;
+  useTimeseriesVisualization?: boolean;
+  widgetInterval?: string;
+};
+
+type State = {
+  dashboardState: DashboardState;
+  isCommittingChanges: boolean;
+  isSavingDashboardFilters: boolean;
+  isWidgetBuilderOpen: boolean;
+  modifiedDashboard: DashboardDetails | null;
+  widgetLegendState: WidgetLegendSelectionState;
+  widgetLimitReached: boolean;
+  newlyAddedWidget?: Widget;
+
+// ... source context omitted ...
+
+        ]
+      );
+    }
+
+    return widgetBuilderRoutes.includes(path ?? location.pathname);
+  };
+
+  onEdit = () => {
+    const {dashboard, organization} = this.props;
+    trackAnalytics('dashboards2.edit.start', {organization});
+
+    this.setState({
+      dashboardState: DashboardState.EDIT,
+      modifiedDashboard: cloneDashboard(dashboard),
+    });
+  };
+
+  onDelete = (dashboard: State['modifiedDashboard']) => () => {
+    const {api, organization, location} = this.props;
+    if (!dashboard?.id) {
+      return;
+    }
+
+    const previousDashboardState = this.state.dashboardState;
+
+    this.setState({dashboardState: DashboardState.PENDING_DELETE}, () => {
+      deleteDashboard(api, organization.slug, dashboard.id)
+        .then(() => {
+          addSuccessMessage(t('Dashboard deleted'));
+          trackAnalytics('dashboards2.delete', {organization});
+          browserHistory.replace({
+            pathname: `/organizations/${organization.slug}/dashboards/`,
+            query: location.query,
+          });
+        })
+        .catch(() => {
+          this.setState({
+            dashboardState: previousDashboardState,
+          });
+        });
+    });
+  };
+
+  onCancel = () => {
+    const {organization, dashboard, location, params} = this.props;
+
+// ... source context omitted ...
+
+  margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    grid-template-columns: minmax(0, 1fr) max-content;
+    grid-column-gap: ${space(2)};
+    height: 40px;
+  }
+`;
+
+interface DashboardDetailWithInjectedPropsProps extends Omit<
+  Props,
+  | 'theme'
+  | 'navigate'
+  | 'api'
+  | 'organization'
+  | 'projects'
+  | 'location'
+  | 'params'
+  | 'router'
+> {}
+
+export default function DashboardDetailWithInjectedProps(
+  props: DashboardDetailWithInjectedPropsProps
+) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const api = useApi();
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const location = useLocation();
+  const params = useParams<RouteParams>();
+  const router = useRouter();
+  const [chartInterval] = useChartInterval();
+
+  // Always use the validated chart interval so the UI dropdown and widget
+  // requests stay in sync. chartInterval is validated against the current page
+  // filter period (e.g. won't return 1m for a 30d range) and always has a value.
+  const widgetInterval = organization.features.includes('dashboards-interval-selection')
+    ? chartInterval
+    : undefined;
+
+  return (
+    <DashboardDetail
+      {...props}
+      theme={theme}
+      navigate={navigate}
+      api={api}
+      organization={organization}
+      projects={projects}
+      location={location}
+      params={params}
+      router={router}
+      widgetInterval={widgetInterval}
+    />
+  );
+}

--- a/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/useDeleteDashboard.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-delete-side-nav-stale/useDeleteDashboard.tsx
@@ -1,0 +1,39 @@
+import {useCallback} from 'react';
+
+import {deleteDashboard as deleteDashboardAction} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+
+interface UseDeleteDashboardProps {
+  onSuccess: () => void;
+}
+
+export function useDeleteDashboard({onSuccess}: UseDeleteDashboardProps) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const deleteDashboard = useCallback(
+    (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
+      deleteDashboardAction(api, organization.slug, dashboard.id)
+        .then(() => {
+          trackAnalytics('dashboards_manage.delete', {
+            organization,
+            dashboard_id: parseInt(dashboard.id, 10),
+            view_type: viewType,
+          });
+          onSuccess();
+          addSuccessMessage(t('Dashboard deleted'));
+        })
+        .catch(() => {
+          addErrorMessage(t('Error deleting Dashboard'));
+        });
+    },
+    [api, organization, onSuccess]
+  );
+
+  return deleteDashboard;
+}

--- a/packages/evals/fixtures/sentry-dashboard-other-series-color/LICENSE.md
+++ b/packages/evals/fixtures/sentry-dashboard-other-series-color/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-dashboard-other-series-color/createPlottableFromTimeSeries.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-other-series-color/createPlottableFromTimeSeries.tsx
@@ -1,0 +1,28 @@
+import type {Widget} from 'sentry/views/dashboards/types';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
+
+export function createPlottableFromTimeSeries(
+  timeSeries: TimeSeries,
+  widget: Widget,
+  alias?: string,
+  name?: string
+): Plottable | null {
+  const shouldStack = widget.queries[0]?.columns.length! > 0;
+
+  const {displayType, title} = widget;
+  switch (displayType) {
+    case DisplayType.LINE:
+      return new Line(timeSeries, {alias, name});
+    case DisplayType.AREA:
+      return new Area(timeSeries, {alias, name});
+    case DisplayType.BAR:
+      return new Bars(timeSeries, {stack: shouldStack ? title : undefined, alias, name});
+    default:
+      return null;
+  }
+}

--- a/packages/evals/fixtures/sentry-dashboard-other-series-color/visualizationWidget.tsx
+++ b/packages/evals/fixtures/sentry-dashboard-other-series-color/visualizationWidget.tsx
@@ -1,0 +1,93 @@
+// Source excerpt from getsentry/sentry static/app/views/dashboards/widgetCard/visualizationWidget.tsx@f945e1ccefd3349392bbc6b7fc4aa9da4d3decc8.
+// Unrelated context omitted; captured around the fix diff for de65182e8c3491930779dd88522ea04ee9633314.
+
+}: VisualizationWidgetContentProps) {
+  const theme = useTheme();
+  const organization = useOrganization();
+  const location = useLocation();
+  const {selection} = usePageFilters();
+
+  const firstWidgetQuery = widget.queries[0];
+  const aggregates = firstWidgetQuery?.aggregates ?? []; // All widget queries have the same aggregates
+  const columns = firstWidgetQuery?.columns ?? []; // All widget queries have the same columns
+
+  const timeSeriesWithPlottable: Array<[TimeSeries, Plottable]> = timeseriesResults
+    .map(series => {
+      const seriesName = series.seriesName ?? aggregates[0] ?? '';
+      const splitSeriesName = seriesName.split(SERIES_NAME_PART_DELIMITER);
+
+      const yAxis =
+        aggregates.find(aggregate => splitSeriesName.includes(aggregate)) ??
+        aggregates[0];
+
+      const alias =
+        widget?.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ||
+        undefined;
+
+      const timeSeries = transformLegacySeriesToTimeSeries(
+        series,
+        timeseriesResultsTypes,
+        timeseriesResultsUnits,
+        columns,
+        yAxis,
+        alias
+      );
+
+      if (!timeSeries) {
+        return null;
+      }
+
+      const labelParts = [alias, formatTimeSeriesLabel(timeSeries)];
+      // If there are multiple aggregates and columns, add the yAxis to the label for uniqueness
+      if (aggregates.length > 1 && columns.length > 1) {
+        labelParts.push(timeSeries.yAxis);
+      }
+      const plottable = createPlottableFromTimeSeries(
+        timeSeries,
+        widget,
+        labelParts.filter(defined).join(SERIES_NAME_PART_DELIMITER),
+        seriesName
+      );
+      if (!plottable) {
+        return null;
+      }
+      return [timeSeries, plottable] satisfies [TimeSeries, Plottable];
+    })
+    .filter(defined);
+
+  const errorDisplay =
+    renderErrorMessage && errorMessage ? renderErrorMessage(errorMessage) : null;
+
+  const plottableWithNeedsColor = timeSeriesWithPlottable.filter(
+    ([_, plottable]) => plottable.needsColor
+  ).length;
+
+  const colorPalette =
+    plottableWithNeedsColor > 0
+      ? theme.chart.getColorPalette(plottableWithNeedsColor - 1)
+      : [];
+
+  const showBreakdownData =
+    widget.legendType === 'breakdown' &&
+    usesTimeSeriesData(widget.displayType) &&
+    tableResults &&
+    tableResults.length > 0;
+
+  const tableDataRows = tableResults?.[0]?.data;
+
+  // We only support one column for legend breakdown right now
+  const firstColumn = columns[0];
+  const linkedDashboard = findLinkedDashboardForField(firstWidgetQuery, firstColumn);
+
+  const footerTable = showBreakdownData ? (
+    <WidgetFooterTable>
+      {timeSeriesWithPlottable.map(([timeSeries, plottable], index) => {
+        if (timeSeries.meta.isOther) {
+          return null;
+        }
+
+        let value: number | null = null;
+        const yAxis = timeSeries.yAxis;
+        const firstColumnGroupByValue = timeSeries.groupBy?.find(
+          groupBy => groupBy.key === firstColumn
+        )?.value;

--- a/packages/evals/fixtures/sentry-detector-validator-user-context/LICENSE.md
+++ b/packages/evals/fixtures/sentry-detector-validator-user-context/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-detector-validator-user-context/organization_detector_details.py
+++ b/packages/evals/fixtures/sentry-detector-validator-user-context/organization_detector_details.py
@@ -1,0 +1,94 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/endpoints/organization_detector_details.py@93b7cee973b5da40d542b5f7d13c639752ee508b.
+# Unrelated context omitted; captured around the fix diff for f19882e5a3f81e2d98a05af58c5faa1b406499c8.
+
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
+from sentry.apidocs.parameters import DetectorParams, GlobalParams
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
+from sentry.incidents.grouptype import MetricIssue
+from sentry.incidents.metric_issue_detector import schedule_update_project_config
+from sentry.issues import grouptype
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
+from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
+from sentry.workflow_engine.endpoints.validators.detector_workflow import (
+    BulkDetectorWorkflowsValidator,
+    can_delete_detector,
+    can_edit_detector,
+)
+from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
+from sentry.workflow_engine.models import Detector
+
+
+def get_detector_validator(
+    request: Request,
+    project: Project,
+    detector_type_slug: str,
+    instance: Detector | None = None,
+    partial: bool = False,
+) -> BaseDetectorTypeValidator:
+    type = grouptype.registry.get_by_slug(detector_type_slug)
+    if type is None:
+        error_message = get_unknown_detector_type_error(detector_type_slug, project.organization)
+        raise ValidationError({"type": [error_message]})
+
+    if type.detector_settings is None or type.detector_settings.validator is None:
+        raise ValidationError({"type": ["Detector type not compatible with detectors"]})
+
+    return type.detector_settings.validator(
+        instance=instance,
+        context={
+            "project": project,
+            "organization": project.organization,
+            "request": request,
+            "access": request.access,
+        },
+        data=request.data,
+        partial=partial,
+    )
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Monitors"])
+class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
+    def convert_args(
+        self, request: Request, detector_id: str, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Organization | Detector]]:
+        args, kwargs = super().convert_args(request, *args, **kwargs)
+        validated_detector_id = to_valid_int_id("detector_id", detector_id, raise_404=True)
+        try:
+            detector = (
+                Detector.objects.with_type_filters()
+                .select_related("project")
+                .get(
+                    id=validated_detector_id,
+                    project__organization_id=kwargs["organization"].id,
+                )
+            )
+            kwargs["detector"] = detector
+        except Detector.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        # Verify user has access to the detector's project (respects Open Membership setting)
+        if not request.access.has_project_access(detector.project):
+            raise PermissionDenied
+
+        return args, kwargs
+
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
+    }
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    permission_classes = (OrganizationDetectorPermission,)
+
+    @extend_schema(
+        operation_id="Fetch a Monitor",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,

--- a/packages/evals/fixtures/sentry-detector-validator-user-context/organization_detector_index.py
+++ b/packages/evals/fixtures/sentry-detector-validator-user-context/organization_detector_index.py
@@ -1,0 +1,94 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/endpoints/organization_detector_index.py@93b7cee973b5da40d542b5f7d13c639752ee508b.
+# Unrelated context omitted; captured around the fix diff for f19882e5a3f81e2d98a05af58c5faa1b406499c8.
+
+        else:
+            assert_never(actor)
+    return assignee_query
+
+
+# Maps API field name to database ordering expressions
+SORT_MAP = {
+    "name": "name",
+    "-name": "-name",
+    "id": "id",
+    "-id": "-id",
+    "type": "type",
+    "-type": "-type",
+    "connectedWorkflows": "connected_workflows",
+    "-connectedWorkflows": "-connected_workflows",
+    "latestGroup": F("latest_group_date_added").asc(nulls_first=True),
+    "-latestGroup": F("latest_group_date_added").desc(nulls_last=True),
+    "openIssues": F("open_issues_count").asc(nulls_first=True),
+    "-openIssues": F("open_issues_count").desc(nulls_last=True),
+}
+
+DETECTOR_TYPE_ALIASES = {
+    "metric": MetricIssue.slug,
+    "uptime": UptimeDomainCheckFailure.slug,
+    "cron": MonitorIncidentType.slug,
+}
+
+
+def get_detector_validator(
+    request: Request, project: Project, detector_type_slug: str, instance: Any = None
+) -> BaseDetectorTypeValidator:
+    type = grouptype.registry.get_by_slug(detector_type_slug)
+    if type is None:
+        error_message = get_unknown_detector_type_error(detector_type_slug, project.organization)
+        raise ValidationError({"type": [error_message]})
+
+    if type.detector_settings is None or type.detector_settings.validator is None:
+        raise ValidationError({"type": ["Detector type not compatible with detectors"]})
+
+    return type.detector_settings.validator(
+        instance=instance,
+        context={
+            "project": project,
+            "organization": project.organization,
+            "request": request,
+            "access": request.access,
+        },
+        data=request.data,
+    )
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Monitors"])
+class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
+    }
+    owner = ApiOwner.ISSUES
+
+    permission_classes = (OrganizationDetectorPermission,)
+
+    def filter_detectors(self, request: Request, organization: Any) -> QuerySet[Detector]:
+        """
+        Filter detectors based on the request parameters.
+        """
+
+        if not request.user.is_authenticated:
+            return Detector.objects.none()
+
+        if raw_idlist := request.GET.getlist("id"):
+            ids = to_valid_int_id_list("id", raw_idlist)
+            # If filtering by IDs, we must search across all accessible projects
+            projects = self.get_projects(
+                request,
+                organization,
+                include_all_accessible=True,
+            )
+            return Detector.objects.with_type_filters().filter(
+                project_id__in=projects,
+                id__in=ids,
+            )
+
+        projects = self.get_projects(
+            request,
+            organization,
+        )
+
+        queryset: QuerySet[Detector] = Detector.objects.with_type_filters().filter(

--- a/packages/evals/fixtures/sentry-empty-repo-409-cache/LICENSE.md
+++ b/packages/evals/fixtures/sentry-empty-repo-409-cache/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-empty-repo-409-cache/repo_trees.py
+++ b/packages/evals/fixtures/sentry-empty-repo-409-cache/repo_trees.py
@@ -1,0 +1,71 @@
+# Source excerpt from getsentry/sentry src/sentry/integrations/source_code_management/repo_trees.py@8e974682bd2f71ae62cf197ac32ccc1a74ae588b.
+# Unrelated context omitted; captured around the fix diff for b53670419ece85ff5a06ef0f3fc21e71579599ba.
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Any, NamedTuple
+
+from sentry.integrations.services.integration import RpcOrganizationIntegration
+from sentry.issues.auto_source_code_config.utils.platform import get_supported_extensions
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+METRICS_KEY_PREFIX = "integrations.source_code_management"
+EXCLUDED_EXTENSIONS = ["spec.jsx"]
+EXCLUDED_PATHS = ["tests/"]
+
+
+class RepoAndBranch(NamedTuple):
+    name: str
+    branch: str
+
+
+class RepoTree(NamedTuple):
+    repo: RepoAndBranch
+    files: Sequence[str]
+
+# ... source context omitted ...
+
+        shifted_seconds: int,
+        only_source_code_files: bool = True,
+        only_use_cache: bool = False,
+    ) -> list[str]:
+        """It returns all files for a repo or just source code files.
+
+        repo_full_name: e.g. getsentry/sentry
+        tree_sha: A branch or a commit sha
+        only_source_code_files: Include all files or just the source code files
+        only_use_cache: Do not hit the network but use the value from the cache
+            if any. This is useful if the remaining API requests are low
+        """
+        key = f"{self.integration_name}:repo:{repo_full_name}:{'source-code' if only_source_code_files else 'all'}"
+        cache_hit = cache.has_key(key)
+        use_api = not cache_hit and not only_use_cache
+        repo_files: list[str] = cache.get(key, [])
+        if use_api:
+            # Cache miss – fetch from API
+            tree = self.get_client().get_tree(repo_full_name, tree_sha)
+            if tree:
+                # Keep files; discard directories
+                repo_files = [node["path"] for node in tree if node["type"] == "blob"]
+                if only_source_code_files:
+                    repo_files = filter_source_code_files(files=repo_files)
+                # The backend's caching will skip silently if the object size greater than 5MB
+                # (due to Memcached's max value size limit).
+                # The trees API does not return structures larger than 7MB
+                # As an example, all file paths in Sentry is about 1.3MB
+                # Larger customers may have larger repositories, however,
+                # the cost of not having the files cached
+                # repositories is a single API network request, thus,
+                # being acceptable to sometimes not having everything cached
+                cache.set(key, repo_files, self.CACHE_SECONDS + shifted_seconds)
+
+            metrics.incr(
+                f"{METRICS_KEY_PREFIX}.get_tree",
+                tags={"fetched": tree is not None, "integration": self.integration_name},

--- a/packages/evals/fixtures/sentry-event-grouping-info-mutates-class-context/LICENSE.md
+++ b/packages/evals/fixtures/sentry-event-grouping-info-mutates-class-context/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-event-grouping-info-mutates-class-context/event_grouping_info.py
+++ b/packages/evals/fixtures/sentry-event-grouping-info-mutates-class-context/event_grouping_info.py
@@ -1,0 +1,55 @@
+import orjson
+from django.http import HttpRequest, HttpResponse
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.grouping.api import load_grouping_config
+from sentry.grouping.grouping_info import get_grouping_info
+from sentry.interfaces.stacktrace import StacktraceOrder
+from sentry.services import eventstore
+from sentry.users.services.user_option import user_option_service
+from sentry.users.services.user_option.service import get_option_from_list
+
+
+@region_silo_endpoint
+class EventGroupingInfoEndpoint(ProjectEndpoint):
+    owner = ApiOwner.ISSUES
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: HttpRequest, project, event_id) -> HttpResponse:
+        """
+        Returns the grouping information for an event
+        `````````````````````````````````````````````
+
+        This endpoint returns a JSON dump of the metadata that went into the
+        grouping algorithm.
+        """
+        event = eventstore.backend.get_event_by_id(project.id, event_id)
+        if event is None:
+            raise ResourceDoesNotExist
+
+        grouping_config = load_grouping_config(event.get_grouping_config())
+
+        # We want the stacktraces in the grouping info to match the issue details page's main
+        # stacktrace, which by default is upside down compared to the event JSON. Therefore, unless
+        # user has set a preference to prevent it, we want to flip the grouping info stacktraces,
+        # too.
+        should_reverse_stacktraces = (
+            get_option_from_list(
+                user_option_service.get_many(filter={"user_ids": [request.user.id]}),
+                key="stacktrace_order",
+            )
+            != StacktraceOrder.MOST_RECENT_LAST
+        )
+        grouping_config.initial_context["reverse_stacktraces"] = should_reverse_stacktraces
+
+        grouping_info = get_grouping_info(grouping_config, project, event)
+
+        return HttpResponse(
+            orjson.dumps(grouping_info, option=orjson.OPT_UTC_Z), content_type="application/json"
+        )

--- a/packages/evals/fixtures/sentry-explorer-autofix-missing-group-id/LICENSE.md
+++ b/packages/evals/fixtures/sentry-explorer-autofix-missing-group-id/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-explorer-autofix-missing-group-id/autofix_agent.py
+++ b/packages/evals/fixtures/sentry-explorer-autofix-missing-group-id/autofix_agent.py
@@ -1,0 +1,96 @@
+# Source excerpt from getsentry/sentry src/sentry/seer/autofix/autofix_agent.py@bf9c244d0341de6ad77ed57e7b1479a1320f9871.
+# Unrelated context omitted; captured around the fix diff for c9772d7047ef78d03dbedcb87a1214a9af30ef07.
+
+    }
+    return step_to_action_type[step][is_completed]
+
+
+def trigger_autofix_explorer(
+    group: Group,
+    step: AutofixStep,
+    run_id: int | None = None,
+    stopping_point: AutofixStoppingPoint | None = None,
+    intelligence_level: Literal["low", "medium", "high"] = "low",
+) -> int:
+    """
+    Start or continue an Explorer-based autofix run.
+
+    Args:
+        group: The Sentry group (issue) to analyze
+        step: Which autofix step to run
+        run_id: Existing run ID to continue, or None for new run
+        stopping_point: Where to stop the automated pipeline (only used for new runs)
+
+    Returns:
+        The run ID
+    """
+    from sentry.seer.autofix.on_completion_hook import (
+        AutofixOnCompletionHook,  # nested to avoid circular import
+    )
+
+    config = STEP_CONFIGS[step]
+    client = SeerExplorerClient(
+        organization=group.organization,
+        project=group.project,
+        user=None,  # No user personalization for autofix
+        category_key="autofix",
+        category_value=str(group.id),
+        intelligence_level=intelligence_level,
+        on_completion_hook=AutofixOnCompletionHook,
+        enable_coding=config.enable_coding,
+    )
+
+    prompt = build_step_prompt(step, group)
+    prompt_metadata = {"step": step.value}
+    artifact_key = step.value if config.artifact_schema else None
+    artifact_schema = config.artifact_schema
+
+    if run_id is None:
+        metadata = None
+        if stopping_point:
+            metadata = {"stopping_point": stopping_point.value, "group_id": group.id}
+        run_id = client.start_run(
+            prompt=prompt,
+            prompt_metadata=prompt_metadata,
+            artifact_key=artifact_key,
+            artifact_schema=artifact_schema,
+            metadata=metadata,
+        )
+    else:
+        client.continue_run(
+            run_id=run_id,
+            prompt=prompt,
+            prompt_metadata=prompt_metadata,
+            artifact_key=artifact_key,
+            artifact_schema=artifact_schema,
+        )
+
+    group.update(seer_autofix_last_triggered=timezone.now())
+
+    payload = {
+        "run_id": run_id,
+        "group_id": group.id,
+    }
+
+    webhook_action_type = get_step_webhook_action_type(step, is_completed=False)
+    event_name = webhook_action_type.value
+
+    event_type = f"seer.{event_name}"
+    try:
+        sentry_app_event_type = SentryAppEventType(event_type)
+        if SeerOperator.has_access(organization=group.organization):
+            process_autofix_updates.apply_async(
+                kwargs={
+                    "event_type": sentry_app_event_type,
+                    "event_payload": payload,
+                    "organization_id": group.organization.id,
+                }
+            )
+    except ValueError:
+        logger.exception(
+            "autofix.trigger.webhook_invalid_event_type",
+            extra={"event_type": event_type},
+        )
+
+    # Send "started" webhook after we have the run_id
+    try:

--- a/packages/evals/fixtures/sentry-fixability-missing-issue-summary/LICENSE.md
+++ b/packages/evals/fixtures/sentry-fixability-missing-issue-summary/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-fixability-missing-issue-summary/autofix.py
+++ b/packages/evals/fixtures/sentry-fixability-missing-issue-summary/autofix.py
@@ -1,0 +1,134 @@
+# Source excerpt from getsentry/sentry src/sentry/tasks/autofix.py@4199c6aeed84c7c359aa7ad6863534174769d436.
+# Unrelated context omitted; captured around the fix diff for 62125c6514958cd89aa3cf7374be32f984adb683.
+
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.generate_summary_and_run_automation",
+    namespace=ingest_errors_tasks,
+    processing_deadline_duration=35,
+    retry=Retry(times=1),
+)
+def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
+    from sentry.seer.autofix.issue_summary import get_issue_summary
+
+    trigger_path = kwargs.get("trigger_path", "unknown")
+    sentry_sdk.set_tag("trigger_path", trigger_path)
+
+    group = Group.objects.get(id=group_id)
+    organization = group.project.organization
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.generate_summary_and_run_automation", sample_rate=1.0)
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="generate_summary_and_run_automation",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
+
+    get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS)
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.generate_issue_summary_only",
+    namespace=ingest_errors_tasks,
+    processing_deadline_duration=35,
+    retry=Retry(times=3, delay=3, on=(Exception,)),
+)
+def generate_issue_summary_only(group_id: int) -> None:
+    """
+    Generate issue summary WITHOUT triggering automation.
+    Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
+    """
+    from sentry.api.serializers.rest_framework.base import (
+        camel_to_snake_case,
+        convert_dict_key_case,
+    )
+    from sentry.seer.autofix.issue_summary import (
+        get_and_update_group_fixability_score,
+        get_issue_summary,
+    )
+
+    group = Group.objects.get(id=group_id)
+    organization = group.project.organization
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.generate_issue_summary_only", sample_rate=1.0)
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="generate_issue_summary_only",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
+
+    summary_data, status_code = get_issue_summary(
+        group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
+    )
+
+    summary_payload = None
+    if status_code == 200:
+        summary_snake = convert_dict_key_case(summary_data, camel_to_snake_case)
+        required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
+        if all(summary_snake.get(k) is not None for k in required_fields):
+            summary_payload = {
+                "group_id": group.id,
+                **{k: summary_snake[k] for k in required_fields},
+            }
+
+    get_and_update_group_fixability_score(group, force_generate=True, summary=summary_payload)
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.run_automation_only_task",
+    namespace=ingest_errors_tasks,
+    processing_deadline_duration=35,
+    retry=Retry(times=1),
+)
+def run_automation_only_task(group_id: int) -> None:
+    """
+    Run automation directly for a group (assumes summary and fixability already exist).
+    Used for triage signals flow when event count >= 10 and summary exists.
+    """
+    from django.contrib.auth.models import AnonymousUser
+
+    from sentry.seer.autofix.issue_summary import run_automation
+
+    group = Group.objects.get(id=group_id)
+    organization = group.project.organization
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.run_automation_only_task", sample_rate=1.0)
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="run_automation_only",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
+
+    event = group.get_latest_event()
+
+    if not event:
+        logger.warning("run_automation_only_task.no_event_found", extra={"group_id": group_id})
+        return
+
+    # Track issue age when running automation
+    issue_age_days = int((timezone.now() - group.first_seen).total_seconds() / (60 * 60 * 24))
+    metrics.distribution(
+        "seer.automation.issue_age_since_first_seen", issue_age_days, unit="day", sample_rate=1.0
+    )

--- a/packages/evals/fixtures/sentry-fixability-missing-issue-summary/issue_summary.py
+++ b/packages/evals/fixtures/sentry-fixability-missing-issue-summary/issue_summary.py
@@ -1,0 +1,129 @@
+# Source excerpt from getsentry/sentry src/sentry/seer/autofix/issue_summary.py@4199c6aeed84c7c359aa7ad6863534174769d436.
+# Unrelated context omitted; captured around the fix diff for 62125c6514958cd89aa3cf7374be32f984adb683.
+
+    summary: dict[str, Any] | None = None,
+) -> SummarizeIssueResponse:
+    payload: dict[str, Any] = {
+        "group_id": group.id,
+        "organization_slug": group.organization.slug,
+        "organization_id": group.organization.id,
+        "project_id": group.project.id,
+    }
+    if summary is not None:
+        payload["summary"] = summary
+    response = make_signed_seer_api_request(
+        fixability_connection_pool_gpu,
+        "/v1/automation/summarize/fixability",
+        body=orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS),
+        timeout=settings.SEER_FIXABILITY_TIMEOUT,
+    )
+    if response.status >= 400:
+        raise Exception(f"Seer API error: {response.status}")
+    response_data = orjson.loads(response.data)
+    return SummarizeIssueResponse.validate(response_data)
+
+
+def get_and_update_group_fixability_score(
+    group: Group,
+    force_generate: bool = False,
+    summary: dict[str, Any] | None = None,
+) -> float:
+    """
+    Get the fixability score for a group and update the group with the score.
+    If the fixability score is already set, return it without generating a new one.
+    """
+    if not force_generate and group.seer_fixability_score is not None:
+        return group.seer_fixability_score
+
+    with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
+        issue_summary = _generate_fixability_score(group, summary=summary)
+
+    if not issue_summary.scores:
+        raise ValueError("Issue summary scores is None or empty.")
+    if issue_summary.scores.fixability_score is None:
+        raise ValueError("Issue summary fixability score is None.")
+
+    fixability_score = issue_summary.scores.fixability_score
+    group.update(seer_fixability_score=fixability_score)
+    return fixability_score
+
+
+def _is_issue_fixable(group: Group, fixability_score: float) -> bool:
+    project = group.project
+    option = project.get_option("sentry:autofix_automation_tuning")
+    if option == AutofixAutomationTuningSettings.OFF:
+        return False
+    elif option == AutofixAutomationTuningSettings.SUPER_LOW:
+        return fixability_score >= FixabilityScoreThresholds.SUPER_HIGH.value
+    elif option == AutofixAutomationTuningSettings.LOW:
+        return fixability_score >= FixabilityScoreThresholds.HIGH.value
+    elif option == AutofixAutomationTuningSettings.MEDIUM:
+        return fixability_score >= FixabilityScoreThresholds.MEDIUM.value
+    elif option == AutofixAutomationTuningSettings.HIGH:
+
+# ... source context omitted ...
+
+    cache_key: str,
+    should_run_automation: bool = True,
+) -> tuple[dict[str, Any], int]:
+    """Core logic to generate and cache the issue summary."""
+    serialized_event, event = _get_event(group, user, provided_event_id=force_event_id)
+
+    if not serialized_event or not event:
+        return {"detail": "Could not find an event for the issue"}, 400
+
+    trace_tree = None
+    if event:
+        try:
+            trace_tree = _get_trace_tree_for_event(event, group.project, timeout=3)
+        except Exception:
+            logger.warning(
+                "Failed to get trace for event in issue summary",
+                extra={"group_id": group.id},
+                exc_info=True,
+            )
+
+    issue_summary = _call_seer(
+        group,
+        serialized_event,
+        trace_tree,
+    )
+
+    if should_run_automation:
+        try:
+            run_automation(group, user, event, source)
+        except Exception:
+            logger.exception(
+                "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
+            )
+
+    summary_dict = issue_summary.dict()
+    summary_dict["event_id"] = event.event_id
+
+    cache.set(cache_key, summary_dict, timeout=int(timedelta(days=7).total_seconds()))
+
+    return summary_dict, 200
+
+
+def _log_seer_scanner_billing_event(group: Group, source: SeerAutomationSource):
+    if source == SeerAutomationSource.ISSUE_DETAILS:
+        return
+
+    quotas.backend.record_seer_run(
+        group.organization.id, group.project.id, DataCategory.SEER_SCANNER
+    )
+
+
+def get_issue_summary_cache_key(group_id: int) -> str:
+    return f"ai-group-summary-v2:{group_id}"
+
+
+def get_issue_summary_lock_key(group_id: int) -> tuple[str, str]:
+    return (f"ai-group-summary-v2-lock:{group_id}", "get_issue_summary")
+
+
+def get_issue_summary(
+    group: Group,
+    user: User | RpcUser | AnonymousUser | None = None,
+    force_event_id: str | None = None,
+    source: SeerAutomationSource = SeerAutomationSource.ISSUE_DETAILS,

--- a/packages/evals/fixtures/sentry-form-hash-navigation-search/LICENSE.md
+++ b/packages/evals/fixtures/sentry-form-hash-navigation-search/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-form-hash-navigation-search/baseField.tsx
+++ b/packages/evals/fixtures/sentry-form-hash-navigation-search/baseField.tsx
@@ -1,0 +1,127 @@
+import {useEffect, useRef, type Ref} from 'react';
+import {mergeRefs} from '@react-aria/utils';
+
+import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
+import {useFieldContext} from '@sentry/scraps/form/formContext';
+import {Checkmark, Spinner} from '@sentry/scraps/form/icons';
+import {Flex} from '@sentry/scraps/layout';
+
+import {FieldMeta} from './meta';
+
+export type BaseFieldProps<T extends HTMLElement> = {
+  disabled?: boolean | string;
+  ref?: Ref<T>;
+};
+type FieldChildrenProps<T extends HTMLElement> = {
+  'aria-describedby': string;
+  'aria-invalid': boolean;
+  disabled: boolean;
+  id: string;
+  name: string;
+  onBlur: () => void;
+  ref: Ref<T>;
+};
+
+export const useAutoSaveIndicator = () => {
+  const field = useFieldContext();
+  const status = useAutoSaveContext()?.status;
+
+  if (status === 'pending') {
+    return (
+      <Spinner role="status" aria-label={`Saving ${field.name}`} aria-live="polite" />
+    );
+  }
+
+  if (status === 'success') {
+    return <Checkmark variant="success" size="sm" />;
+  }
+
+  return null;
+};
+
+export const useFieldId = () => {
+  const field = useFieldContext();
+
+  return field.form.formId + field.name;
+};
+
+export const useHintTextId = () => {
+  const fieldId = useFieldId();
+
+  return `${fieldId}-hint`;
+};
+
+export const useLabelId = () => {
+  const fieldId = useFieldId();
+
+  return `${fieldId}-label`;
+};
+
+function useScrollToHash(fieldName: string, ref: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    function handleHashChange() {
+      try {
+        const hash = decodeURIComponent(window.location.hash.slice(1));
+        if (hash !== fieldName) {
+          return;
+        }
+      } catch {
+        return;
+      }
+      ref.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
+      ref.current?.focus({focusVisible: true});
+      animateRowHighlight(ref.current);
+    }
+    // Check on mount (page loaded with hash already in URL)
+    handleHashChange();
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, [fieldName, ref]);
+}
+
+type FieldState = {indicator: React.ReactNode};
+
+export function BaseField<T extends HTMLElement>(
+  props: BaseFieldProps<T> & {
+    children: (props: FieldChildrenProps<T>, state: FieldState) => React.ReactNode;
+  }
+) {
+  const autoSaveContext = useAutoSaveContext();
+  const indicator = useAutoSaveIndicator();
+  const field = useFieldContext();
+  const ref = useRef<T>(null);
+  const fieldId = useFieldId();
+  const hintTextId = useHintTextId();
+  useScrollToHash(field.name, ref);
+
+  return (
+    <Flex gap="sm" align="center">
+      {props.children(
+        {
+          ref: mergeRefs(ref, props.ref),
+          disabled: !!props.disabled || autoSaveContext?.status === 'pending',
+          'aria-invalid': !field.state.meta.isValid,
+          'aria-describedby': hintTextId,
+          onBlur: field.handleBlur,
+          name: field.name,
+          id: fieldId,
+        },
+        {indicator}
+      )}
+      <FieldMeta.Status disabled={props.disabled} />
+    </Flex>
+  );
+}
+
+function animateRowHighlight(node: HTMLElement | null) {
+  if (!node) return;
+  const name = node.getAttribute('name');
+  if (!name) return;
+  const fieldRow = node.closest<HTMLElement>(`#${CSS.escape(name)}`);
+  if (fieldRow) {
+    fieldRow.dataset.highlight = '';
+    fieldRow.addEventListener('animationend', () => delete fieldRow.dataset.highlight, {
+      once: true,
+    });
+  }
+}

--- a/packages/evals/fixtures/sentry-global-modal-escape-child-overlay/LICENSE.md
+++ b/packages/evals/fixtures/sentry-global-modal-escape-child-overlay/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-global-modal-escape-child-overlay/index.tsx
+++ b/packages/evals/fixtures/sentry-global-modal-escape-child-overlay/index.tsx
@@ -1,0 +1,94 @@
+// Source excerpt from getsentry/sentry static/app/components/globalModal/index.tsx@acd049bee68e463e7d7af339ccdc721ad8654da5.
+// Unrelated context omitted; captured around the fix diff for 98349bd88adc847b39d2a758c89c36770ad49815.
+
+
+/**
+ * Meta-type to make re-exporting these in the action creator easy without
+ * polluting the global API namespace with duplicate type names.
+ *
+ * eg. you won't accidentally import ModalRenderProps from here.
+ */
+export type ModalTypes = {
+  options: ModalOptions;
+  renderProps: ModalRenderProps;
+};
+
+type Props = {
+  /**
+   * Note this is the callback for the main App container and NOT the calling
+   * component. GlobalModal is never used directly, but is controlled via
+   * stores. To access the onClose callback from the component, you must
+   * specify it when using the action creator.
+   */
+  onClose?: () => void;
+};
+
+function GlobalModal({onClose}: Props) {
+  const {renderer, options, visible} = useGlobalModal();
+  const location = useLocation();
+
+  const closeEvents = options.closeEvents ?? 'all';
+
+  const closeModal = useCallback(
+    (reason?: 'close-button' | 'backdrop-click' | 'escape-key') => {
+      // Option close callback, from the thing which opened the modal
+      options.onClose?.(reason);
+
+      // actually closes the modal
+      ModalStore.closeModal();
+
+      // GlobalModal onClose prop callback
+      onClose?.();
+    },
+    [options, onClose]
+  );
+
+  const handleEscapeClose = useCallback(
+    (e: KeyboardEvent) => {
+      if (
+        e.key !== 'Escape' ||
+        closeEvents === 'none' ||
+        closeEvents === 'backdrop-click'
+      ) {
+        return;
+      }
+
+      closeModal('escape-key');
+    },
+    [closeModal, closeEvents]
+  );
+
+  const scrollLock = useScrollLock(document.documentElement);
+  const portal = getModalPortal();
+  const focusTrap = useRef<FocusTrap | null>(null);
+  // SentryApp might be missing on tests
+  if (window.SentryApp) {
+    window.SentryApp.modalFocusTrap = focusTrap;
+  }
+
+  useEffect(() => {
+    focusTrap.current = createFocusTrap(portal, {
+      preventScroll: true,
+      escapeDeactivates: false,
+      fallbackFocus: portal,
+      allowOutsideClick: true,
+    });
+    ModalStore.setFocusTrap(focusTrap.current);
+  }, [portal]);
+
+  useEffect(() => {
+    const root = document.getElementById(ROOT_ELEMENT);
+
+    const reset = () => {
+      scrollLock.release();
+      root?.removeAttribute('aria-hidden');
+      focusTrap.current?.deactivate();
+      document.removeEventListener('keydown', handleEscapeClose);
+    };
+
+    if (visible) {
+      scrollLock.acquire();
+      root?.setAttribute('aria-hidden', 'true');
+      focusTrap.current?.activate();
+
+      document.addEventListener('keydown', handleEscapeClose);

--- a/packages/evals/fixtures/sentry-group-events-snuba-errors/LICENSE.md
+++ b/packages/evals/fixtures/sentry-group-events-snuba-errors/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-group-events-snuba-errors/group_events.py
+++ b/packages/evals/fixtures/sentry-group-events-snuba-errors/group_events.py
@@ -1,0 +1,105 @@
+# Source excerpt from getsentry/sentry src/sentry/issues/endpoints/group_events.py@35b57a1df7c042e7927de5a19e36c6496ee30f62.
+# Unrelated context omitted; captured around the fix diff for fd0299d864ff7b2b0a5ff69595eb679ea2f97471.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from django.utils import timezone
+from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
+from sentry.api.helpers.environments import get_environments
+from sentry.api.helpers.events import get_direct_hit_response, run_group_events_query
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.api.serializers.models.event import SimpleEventSerializerResponse
+from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.examples.event_examples import EventExamples
+from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
+from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.search.events.types import SnubaParams
+from sentry.search.utils import InvalidQuery, parse_query
+from sentry.services import eventstore
+from sentry.services.eventstore.models import Event
+
+if TYPE_CHECKING:
+    from sentry.models.environment import Environment
+    from sentry.models.group import Group
+
+
+class NoResults(Exception):
+    pass
+
+
+# ... source context omitted ...
+
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=EventExamples.GROUP_EVENTS_SIMPLE,
+    )
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-events"])
+    def get(self, request: Request, group: Group) -> Response:
+        """
+        Return a list of error events bound to an issue
+        """
+
+        try:
+            environments = get_environments(request, group.project.organization)
+            query = self._get_search_query(request, group, environments)
+        except InvalidQuery as exc:
+            return Response({"detail": str(exc)}, status=400)
+        except (NoResults, ResourceDoesNotExist):
+            return Response([])
+
+        try:
+            start, end = get_date_range_from_params(request.GET, optional=True)
+        except InvalidParams as e:
+            raise ParseError(detail=str(e))
+
+        try:
+            return self._get_events_snuba(request, group, environments, query, start, end)
+        except GroupEventsError as exc:
+            raise ParseError(detail=str(exc))
+
+    def _get_events_snuba(
+        self,
+        request: Request,
+        group: Group,
+        environments: Sequence[Environment],
+        query: str | None,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> Response:
+        default_end = timezone.now()
+        default_start = default_end - timedelta(days=90)
+        referrer = f"api.group-events.{group.issue_category.name.lower()}"
+
+        direct_hit_snuba_params = SnubaParams(
+            start=start if start else default_start,
+            end=end if end else default_end,
+            projects=[group.project],
+            organization=group.project.organization,
+        )
+        direct_hit_resp = get_direct_hit_response(
+            request, query, direct_hit_snuba_params, f"{referrer}.direct-hit", group
+        )

--- a/packages/evals/fixtures/sentry-group-index-delete-undefined-group-list/LICENSE.md
+++ b/packages/evals/fixtures/sentry-group-index-delete-undefined-group-list/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-group-index-delete-undefined-group-list/delete.py
+++ b/packages/evals/fixtures/sentry-group-index-delete-undefined-group-list/delete.py
@@ -1,0 +1,54 @@
+# Source excerpt from getsentry/sentry src/sentry/api/helpers/group_index/delete.py@ba133330286172f02ee83ba5441102a6a10ef218.
+# Unrelated context omitted; captured around the fix diff for 4cab626b98ac3df88b0dd9c90161e43c806388b7.
+
+            logger=audit_logger,
+            organization_id=project.organization_id,
+            target_object=group.id,
+            event=audit_log.get_event_id("ISSUE_DELETE"),
+            data={
+                "issue_id": group.id,
+                "project_slug": project.slug,
+            },
+        )
+
+        issue_deleted.send_robust(
+            group=group, user=request.user, delete_type=delete_type, sender=delete_group_list
+        )
+
+
+def schedule_tasks_to_delete_groups(
+    request: Request,
+    projects: Sequence[Project],
+    organization_id: int,
+    search_fn: SearchFunction | None = None,
+) -> Response:
+    """
+    `search_fn` refers to the `search.query` method with the appropriate
+    project, org, environment, and search params already bound
+    """
+    group_ids = request.GET.getlist("id")
+    if group_ids:
+        group_list = list(
+            Group.objects.filter(
+                project__in=projects,
+                project__organization_id=organization_id,
+                id__in=set(group_ids),
+            ).exclude(status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS])
+        )
+    elif search_fn:
+        try:
+            cursor_result, _ = search_fn(
+                {
+                    "limit": BULK_MUTATION_LIMIT,
+                    "paginator_options": {"max_limit": BULK_MUTATION_LIMIT},
+                }
+            )
+        except ValidationError as exc:
+            return Response({"detail": str(exc)}, status=400)
+
+        group_list = list(cursor_result)
+
+    if not group_list:
+        return Response(status=204)
+
+    groups_by_project_id = defaultdict(list)

--- a/packages/evals/fixtures/sentry-issue-highlights-missing-transaction-default/LICENSE.md
+++ b/packages/evals/fixtures/sentry-issue-highlights-missing-transaction-default/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-issue-highlights-missing-transaction-default/highlights.py
+++ b/packages/evals/fixtures/sentry-issue-highlights-missing-transaction-default/highlights.py
@@ -1,0 +1,56 @@
+import re
+from typing import TypedDict
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from sentry.models.project import Project
+from sentry.utils.platform_categories import MOBILE
+
+VALID_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_.: -]+$")
+
+
+@extend_schema_field(field=OpenApiTypes.OBJECT)
+class HighlightContextField(serializers.Field):
+    def to_internal_value(self, data: object) -> dict[str, list[str]]:
+        if not isinstance(data, dict):
+            raise serializers.ValidationError("Expected a dictionary.")
+        for key, value in data.items():
+            if not VALID_KEY_PATTERN.match(key):
+                raise serializers.ValidationError(f"Key '{key}' is invalid.")
+            if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                raise serializers.ValidationError(f"Value for '{key}' must be a list of strings.")
+            # Remove duplicates
+            data[key] = list(set(value))
+
+        return data
+
+    def to_representation(self, value):
+        return value
+
+
+class HighlightPreset(TypedDict):
+    tags: list[str]
+    context: dict[str, list[str]]
+
+
+DEFAULT_HIGHLIGHT_TAGS = ["handled", "level"]
+DEFAULT_HIGHLIGHT_CTX = {"trace": ["trace_id"]}
+
+MOBILE_HIGHLIGHTS: HighlightPreset = {
+    "tags": DEFAULT_HIGHLIGHT_TAGS + ["mobile", "main_thread"],
+    "context": {**DEFAULT_HIGHLIGHT_CTX, "profile": ["profile_id"], "app": ["name"]},
+}
+FALLBACK_HIGHLIGHTS: HighlightPreset = {
+    "tags": DEFAULT_HIGHLIGHT_TAGS + ["url"],
+    "context": {**DEFAULT_HIGHLIGHT_CTX},
+}
+
+
+def get_highlight_preset_for_project(project: Project) -> HighlightPreset:
+    if not project.platform or project.platform == "other":
+        return FALLBACK_HIGHLIGHTS
+    elif project.platform in MOBILE:
+        return MOBILE_HIGHLIGHTS
+    return FALLBACK_HIGHLIGHTS

--- a/packages/evals/fixtures/sentry-linked-identity-session-invalidation/LICENSE.md
+++ b/packages/evals/fixtures/sentry-linked-identity-session-invalidation/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-linked-identity-session-invalidation/user_identity_config.py
+++ b/packages/evals/fixtures/sentry-linked-identity-session-invalidation/user_identity_config.py
@@ -1,0 +1,45 @@
+# Source excerpt from getsentry/sentry src/sentry/users/api/endpoints/user_identity_config.py@0ab8c9c8b99e03e3493ebec1b1f28f196150dd8b.
+# Unrelated context omitted; captured around the fix diff for fc6264aa4eba0b08b24402d68b70e14d1042e1cc.
+
+        # Identity objects in order to correctly set the status.
+        for identity in get_identities(user):
+            if identity.category == category and identity.id == identity_int:
+                return identity
+        return None
+
+    def get(self, request: Request, user: User, category: str, identity_id: str) -> Response:
+        identity = self._get_identity(user, category, identity_id)
+        if identity:
+            return Response(serialize(identity, serializer=UserIdentityConfigSerializer()))
+        else:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def delete(self, request: Request, user: User, category: str, identity_id: str) -> Response:
+        if category == GITHUB_COPILOT_IDENTITY:
+            identity = self._get_identity(user, category, identity_id)
+            if not identity:
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            if identity.status != Status.CAN_DISCONNECT:
+                return Response(status=status.HTTP_403_FORBIDDEN)
+
+            deleted = github_copilot_identity_service.delete(
+                identity_id=int(identity_id), user_id=user.id
+            )
+            if not deleted:
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        with transaction.atomic(using=router.db_for_write(Identity)):
+            identity = self._get_identity(user, category, identity_id)
+            if not identity:
+                # Returns 404 even if the ID exists but belongs to
+                # another user. In that case, 403 would also be
+                # appropriate, but 404 is fine or even preferable.
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            if identity.status != Status.CAN_DISCONNECT:
+                return Response(status=status.HTTP_403_FORBIDDEN)
+
+            model_type = identity.get_model_type_for_category()
+            model_type.objects.get(id=int(identity_id)).delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/packages/evals/fixtures/sentry-metric-issue-chart-open-period/LICENSE.md
+++ b/packages/evals/fixtures/sentry-metric-issue-chart-open-period/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-metric-issue-chart-open-period/chart.tsx
+++ b/packages/evals/fixtures/sentry-metric-issue-chart-open-period/chart.tsx
@@ -1,0 +1,135 @@
+// Source excerpt from getsentry/sentry static/app/views/detectors/components/details/metric/chart.tsx@4cab626b98ac3df88b0dd9c90161e43c806388b7.
+// Unrelated context omitted; captured around the fix diff for b7d3f6c151fc77018e06d9205138a6234ab53f11.
+
+function incidentMarklineTooltip(ctx: IncidentTooltipContext) {
+  const time = defaultFormatAxisLabel(ctx.period.start, true, false, true, false);
+  const color =
+    ctx.period.priority === 'high' ? ctx.theme.colors.red400 : ctx.theme.colors.yellow400;
+  const priorityLabel = ctx.period.priority === 'high' ? t('Critical') : t('Warning');
+  const priorityDot = `<span style="display:inline-block;width:10px;height:8px;border-radius:100%;background:${color};margin-right:6px;vertical-align:middle;"></span>`;
+  return [
+    '<div class="tooltip-series">',
+    `<div><span class="tooltip-label"><strong>${t('#%s Triggered', ctx.period.id)}</strong></span></div>`,
+    `<div><span class="tooltip-label">${t('Started')}</span> ${time}</div>`,
+    `<div><span class="tooltip-label">${t('Priority')}</span> ${priorityDot} ${priorityLabel}</div>`,
+    '</div>',
+    '<div class="tooltip-arrow arrow-top"></div>',
+  ].join('');
+}
+
+interface MetricDetectorDetailsChartProps {
+  detector: MetricDetector;
+  // Passing snubaQuery separately to avoid checking null in all places
+  snubaQuery: SnubaQuery;
+}
+const CHART_HEIGHT = 180;
+
+interface UseMetricDetectorChartProps {
+  detector: MetricDetector;
+  openPeriods: GroupOpenPeriod[];
+  /**
+   * Relative time period (e.g., '7d'). Use either statsPeriod or absolute start/end.
+   */
+  end?: string | null;
+  height?: number;
+  /**
+   * Display a persistent highlight area for the open period with the given ID.
+   */
+  highlightedOpenPeriodId?: string;
+  start?: string | null;
+  statsPeriod?: string | null;
+}
+
+function createTriggerIntervalMarkerData({
+  period,
+  intervalMs,
+}: {
+  intervalMs: number;
+  period: GroupOpenPeriod;
+}): IncidentPeriod {
+  return {
+    id: period.id,
+    end: new Date(period.start).getTime(),
+    priority: period.activities[0]?.value ?? 'high',
+    start: new Date(period.start).getTime() - intervalMs,
+
+// ... source context omitted ...
+
+    name: t('Open Periods'),
+    priority: segment.priority ?? 'high',
+    start: segment.start,
+  }));
+}
+
+type UseMetricDetectorChartResult =
+  | {
+      chartProps: AreaChartProps;
+      error: null;
+      isAnomalyThresholdCutOff: boolean;
+      isLoading: false;
+    }
+  | {chartProps: null; error: null; isAnomalyThresholdCutOff: false; isLoading: true}
+  | {
+      chartProps: null;
+      error: RequestError;
+      isAnomalyThresholdCutOff: false;
+      isLoading: false;
+    };
+
+export function useMetricDetectorChart({
+  statsPeriod,
+  start,
+  end,
+  detector,
+  openPeriods,
+  highlightedOpenPeriodId,
+  height = CHART_HEIGHT,
+}: UseMetricDetectorChartProps): UseMetricDetectorChartResult {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const detectionType = detector.config.detectionType;
+  const comparisonDelta =
+    detectionType === 'percent' ? detector.config.comparisonDelta : undefined;
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+  const dataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+  const datasetConfig = getDatasetConfig(dataset);
+  const aggregate = datasetConfig.fromApiAggregate(snubaQuery.aggregate);
+  const {series, comparisonSeries, isLoading, error} = useMetricDetectorSeries({
+    detectorDataset: dataset,
+    dataset: snubaQuery.dataset,
+    extrapolationMode: snubaQuery.extrapolationMode,
+    aggregate,
+    interval: snubaQuery.timeWindow,
+    query: datasetConfig.toSnubaQueryString(snubaQuery),
+    environment: snubaQuery.environment,
+    projectId: detector.projectId,
+    eventTypes: snubaQuery.eventTypes,
+    comparisonDelta,
+    statsPeriod,
+    start,
+    end,
+  });
+
+  const metricTimestamps = useMetricTimestamps(series);
+
+  const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =
+    useMetricDetectorThresholdSeries({
+      aggregate,
+      conditions: detector.conditionGroup?.conditions,
+      detectionType,
+      comparisonSeries,
+    });
+
+  const {anomalyThresholdSeries} = useMetricDetectorAnomalyThresholds({
+    detectorId: detector.id,
+    detectionType,
+    startTimestamp: metricTimestamps.start,
+    endTimestamp: metricTimestamps.end,
+    series,
+  });
+
+  const filteredAnomalyThresholdSeries = useFilteredAnomalyThresholdSeries({
+    anomalyThresholdSeries,
+    detector,
+  });

--- a/packages/evals/fixtures/sentry-metric-issue-chart-open-period/metricIssueChart.tsx
+++ b/packages/evals/fixtures/sentry-metric-issue-chart-open-period/metricIssueChart.tsx
@@ -1,0 +1,141 @@
+import {Container, Flex} from '@sentry/scraps/layout';
+
+import {AreaChart} from 'sentry/components/charts/areaChart';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {Group, GroupOpenPeriod} from 'sentry/types/group';
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import {useMetricDetectorChart} from 'sentry/views/detectors/components/details/metric/chart';
+import {useDetectorQuery} from 'sentry/views/detectors/hooks';
+import {
+  useEventOpenPeriod,
+  useOpenPeriods,
+} from 'sentry/views/detectors/hooks/useOpenPeriods';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
+import {GraphAlert} from 'sentry/views/issueDetails/streamline/eventGraph';
+
+interface MetricIssueChartProps {
+  event: Event | undefined;
+  group: Group;
+}
+
+const CHART_HEIGHT = 180;
+
+function getDetectorErrorMessage(detectorError: RequestError): string {
+  if (detectorError.status === 404) {
+    return t('The metric monitor which created this issue no longer exists.');
+  }
+  if (detectorError.responseJSON?.detail) {
+    return t(
+      'The metric monitor could not be loaded: %s',
+      detectorError.responseJSON.detail
+    );
+  }
+  return t('The metric monitor could not be loaded.');
+}
+
+export function MetricIssueChart({group, event}: MetricIssueChartProps) {
+  const {detectorDetails} = useIssueDetails();
+  const detectorId = detectorDetails?.detectorId;
+
+  const {
+    data: detector,
+    isPending: isDetectorPending,
+    isError: isDetectorError,
+    error: detectorError,
+  } = useDetectorQuery<MetricDetector>(detectorId ?? '', {
+    enabled: !!detectorId && detectorDetails?.detectorType === 'metric_alert',
+    retry: false,
+  });
+  const {data: openPeriods = []} = useOpenPeriods({groupId: group.id});
+
+  if (isDetectorError) {
+    return (
+      <Container width="100%">
+        <GraphAlert variant="danger">{getDetectorErrorMessage(detectorError)}</GraphAlert>
+      </Container>
+    );
+  }
+
+  if (isDetectorPending) {
+    return <MetricIssueChartPlaceholder />;
+  }
+
+  return (
+    <MetricIssueChartContent
+      detector={detector}
+      openPeriods={openPeriods}
+      group={group}
+      event={event}
+    />
+  );
+}
+
+function MetricIssueChartContent({
+  detector,
+  openPeriods,
+  group,
+  event,
+}: {
+  detector: MetricDetector;
+  event: Event | undefined;
+  group: Group;
+  openPeriods: GroupOpenPeriod[];
+}) {
+  const {selection} = usePageFilters();
+  const {openPeriod} = useEventOpenPeriod({groupId: group.id, eventId: event?.id});
+
+  const {
+    chartProps,
+    isLoading,
+    error: chartError,
+  } = useMetricDetectorChart({
+    detector,
+    openPeriods,
+    highlightedOpenPeriodId: openPeriod?.id,
+    height: CHART_HEIGHT,
+    ...normalizeDateTimeParams(selection.datetime),
+  });
+
+  if (isLoading) {
+    return <MetricIssueChartPlaceholder />;
+  }
+
+  if (chartError) {
+    return (
+      <Container width="100%">
+        <GraphAlert variant="danger">
+          {t('Error loading metric monitor: %s', chartError?.message)}
+        </GraphAlert>
+      </Container>
+    );
+  }
+
+  return (
+    <MetricChartSection>
+      <AreaChart {...chartProps} />
+    </MetricChartSection>
+  );
+}
+
+function MetricIssueChartPlaceholder() {
+  return (
+    <MetricChartSection>
+      <Flex align="center" justify="center" padding="md 0" height={`${CHART_HEIGHT}px`}>
+        <Placeholder height="100%" />
+      </Flex>
+    </MetricChartSection>
+  );
+}
+
+function MetricChartSection({children}: {children: React.ReactNode}) {
+  return (
+    <Container width="100%" padding="0 lg sm lg">
+      {children}
+    </Container>
+  );
+}

--- a/packages/evals/fixtures/sentry-metric-issue-open-period-start/LICENSE.md
+++ b/packages/evals/fixtures/sentry-metric-issue-open-period-start/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-metric-issue-open-period-start/metricDetectorTriggeredSection.tsx
+++ b/packages/evals/fixtures/sentry-metric-issue-open-period-start/metricDetectorTriggeredSection.tsx
@@ -1,0 +1,153 @@
+// Source excerpt from getsentry/sentry static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx@d0819fa643ba398b0a0ed9f55555a87239631ec5.
+// Unrelated context omitted; captured around the fix diff for 44801511e3636356c7733ad1b33c8733d691c067.
+
+    return false;
+  }
+
+  const dataSource = evidenceData.dataSources[0];
+
+  return 'type' in dataSource && dataSource.type === 'snuba_query_subscription';
+}
+
+interface RelatedIssuesProps {
+  aggregate: string;
+  end: string;
+  eventDateCreated: string | undefined;
+  projectId: string | number;
+  query: string;
+  start: string;
+}
+
+function calculateStartOfInterval({
+  eventDateCreated,
+  timeWindow,
+}: {
+  eventDateCreated: string;
+  timeWindow: number;
+}) {
+  const eventTimestamp = new Date(eventDateCreated).getTime();
+  const startOfInterval = new Date(
+    eventTimestamp -
+      // Subtract the time window (which is in seconds)
+      timeWindow * 1000 -
+      // Subtract one extra minute to account for delay in processing
+      60 * 1000
+  );
+  // Start from the beginning of the minute
+  startOfInterval.setSeconds(0, 0);
+
+  return startOfInterval;
+}
+
+function getFormattedEvaluatedValue({
+  aggregate,
+  detectionType,
+  value,
+}: {
+
+// ... source context omitted ...
+
+
+      navigate(
+        {
+          pathname: normalizeUrl(
+            `/organizations/${organization.slug}/issues/${params.groupId}/events/${eventId}/`
+          ),
+          query,
+        },
+        {replace: true}
+      );
+    }
+  });
+
+  useEffect(() => {
+    zoomTimeRangeToOpenPeriod();
+  }, [openPeriodStart, openPeriodEnd, intervalSeconds]);
+}
+
+function ZoomToOpenPeriod({
+  eventId,
+  intervalSeconds,
+  openPeriodStart,
+  openPeriodEnd,
+}: {
+  eventId: string;
+  intervalSeconds: number | undefined;
+  openPeriodEnd: string;
+  openPeriodStart: string;
+}) {
+  useZoomTimeRangeToOpenPeriod({
+    eventId,
+    openPeriodStart,
+    openPeriodEnd,
+    intervalSeconds,
+  });
+
+  return null;
+}
+
+/**
+ * Issues list does not support AND/OR in the query, but Discover does.
+ */
+function BooleanLogicError({discoverUrl}: {discoverUrl: LocationDescriptor}) {
+  return (
+    <Alert.Container>
+      <Alert
+        variant="info"
+        trailingItems={
+          <Feature features="discover-basic">
+            <LinkButton priority="default" size="xs" to={discoverUrl}>
+              {t('Open in Discover')}
+            </LinkButton>
+          </Feature>
+
+// ... source context omitted ...
+
+    eventId,
+  });
+  const endDate = openPeriod?.end ?? fallbackEndDate;
+
+  if (!triggeredCondition || !snubaQuery || !eventDateCreated) {
+    return null;
+  }
+
+  const detectorDataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+  const datasetConfig = getDatasetConfig(detectorDataset);
+  const isErrorsDataset = detectorDataset === DetectorDataset.ERRORS;
+  const issueSearchQuery = datasetConfig.toSnubaQueryString?.(snubaQuery) ?? '';
+  const formattedEvaluatedValue = getFormattedEvaluatedValue({
+    value: defined(value) && typeof value === 'object' ? value.value : value,
+    aggregate: snubaQuery.aggregate,
+    detectionType,
+  });
+  const startDate = calculateStartOfInterval({
+    eventDateCreated,
+    timeWindow: snubaQuery.timeWindow,
+  }).toISOString();
+
+  return (
+    <Fragment>
+      <ZoomToOpenPeriod
+        eventId={eventId}
+        intervalSeconds={snubaQuery?.timeWindow}
+        openPeriodStart={startDate}
+        openPeriodEnd={endDate}
+      />
+      <InterimSection
+        title="Triggered Condition"
+        type="triggered_condition"
+        actions={
+          isOpenPeriodLoading ? null : (
+            <OpenInDestinationButton
+              snubaQuery={snubaQuery}
+              projectId={projectId}
+              start={startDate}
+              end={endDate}
+            />
+          )
+        }
+      >
+        <KeyValueList
+          shouldSort={false}
+          data={[
+            {

--- a/packages/evals/fixtures/sentry-perforce-shared-trust-locks/LICENSE.md
+++ b/packages/evals/fixtures/sentry-perforce-shared-trust-locks/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-perforce-shared-trust-locks/client.py
+++ b/packages/evals/fixtures/sentry-perforce-shared-trust-locks/client.py
@@ -1,0 +1,152 @@
+# Source excerpt from getsentry/sentry src/sentry/integrations/perforce/client.py@70ef2549cde90a8ff0ada2110239c7daed6883ad.
+# Unrelated context omitted; captured around the fix diff for bc7c26f2fc40f2c9e6861ca7e6d0918fa73a6214.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, TypedDict
+
+from P4 import P4, P4Exception
+
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.services.integration import RpcIntegration, RpcOrganizationIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitContextClient,
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
+from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.models.pullrequest import PullRequest, PullRequestComment
+
+# ... source context omitted ...
+
+        if not org_integration:
+            raise IntegrationError("Organization Integration is required for Perforce")
+
+        metadata = integration.metadata
+        self.p4port = metadata.get("p4port", "localhost:1666")
+        self.user = metadata.get("user", "")
+        self.password = metadata.get("password")
+        self.auth_type = metadata.get(
+            "auth_type", "password"
+        )  # Default to password for backwards compat
+        self.client_name = metadata.get("client")
+        self.ssl_fingerprint = metadata.get("ssl_fingerprint")
+
+    @contextmanager
+    def _connect(self) -> Generator[P4]:
+        """
+        Context manager for P4 connections with automatic cleanup.
+
+        Yields a connected P4 instance and ensures disconnection on exit.
+
+        Uses P4Python API:
+        - p4.connect(): https://www.perforce.com/manuals/p4python/Content/P4Python/python.programming.html#python.programming.connecting
+        - p4.run_trust(): https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_trust.html
+        - p4.run_login(): https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_login.html
+
+        Example:
+            with self._connect() as p4:
+                result = p4.run("info")
+        """
+        p4 = P4()
+        p4.port = self.p4port
+        p4.user = self.user
+        p4.password = self.password
+
+        if self.client_name:
+            p4.client = self.client_name
+
+        p4.exception_level = 1  # Only errors raise exceptions
+
+        # Connect to Perforce server
+        try:
+            p4.connect()
+        except P4Exception as e:
+            error_msg = str(e)
+            # Provide helpful error message for connection failures
+            if "SSL" in error_msg or "trust" in error_msg.lower():
+                raise ApiError(
+                    f"Failed to connect to Perforce (SSL issue): {error_msg}. "
+                    f"Ensure ssl_fingerprint is correct. Obtain with: p4 -p {self.p4port} trust -y"
+                )
+            raise ApiError(f"Failed to connect to Perforce: {error_msg}")
+
+        # Assert SSL trust after connection (if needed)
+        # This must be done after p4.connect() but before p4.run_login()
+        if self.ssl_fingerprint and self.p4port.startswith("ssl"):
+            try:
+                p4.run_trust("-i", self.ssl_fingerprint)
+            except P4Exception as trust_error:
+                try:
+                    p4.disconnect()
+                except Exception:
+                    pass
+                raise ApiError(
+                    f"Failed to establish SSL trust: {trust_error}. "
+                    f"Ensure ssl_fingerprint is correct. Obtain with: p4 -p {self.p4port} trust -y"
+                )
+
+        # Authenticate based on auth_type
+        # - password: Requires run_login() to exchange password for session ticket
+        # - ticket: Already authenticated via p4.password, no login needed
+        if self.password and self.auth_type == "password":
+            try:
+                p4.run_login()
+            except P4Exception as login_error:
+                try:
+                    p4.disconnect()
+                except Exception:
+                    pass
+                raise ApiUnauthorized(
+                    f"Failed to authenticate with Perforce: {login_error}. "
+                    "Verify your password is correct."
+                )
+        elif self.password and self.auth_type == "ticket":
+            # Ticket authentication: p4.password is already set to the ticket
+            # Verify ticket works by running a test command
+            try:
+                p4.run("info")
+            except P4Exception as e:
+                try:
+                    p4.disconnect()
+                except Exception:
+                    pass
+                raise ApiUnauthorized(
+                    f"Failed to authenticate with Perforce ticket: {e}. "
+                    "Verify your P4 ticket is valid. Obtain a new ticket with: p4 login -p"
+                )
+
+        try:
+            yield p4
+        finally:
+            # Ensure cleanup
+            try:
+                if p4.connected():
+                    p4.disconnect()
+            except Exception as e:
+                # Log disconnect failures as they may indicate connection leaks
+                logger.warning("Failed to disconnect from Perforce: %s", e, exc_info=True)
+
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
+        """
+        Check if a file exists in the depot.
+
+        Uses p4 files command to list file(s) in the depot.
+        API docs: https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_files.html
+
+        Args:
+            repo: Repository object containing depot path (includes stream if specified)
+            path: File path relative to depot
+            version: Not used (streams are part of depot_path)
+
+        Returns:
+            File info dict if exists, None otherwise
+        """
+        with self._connect() as p4:
+            try:

--- a/packages/evals/fixtures/sentry-seer-race-condition-unbound-local/LICENSE.md
+++ b/packages/evals/fixtures/sentry-seer-race-condition-unbound-local/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-seer-race-condition-unbound-local/seer.py
+++ b/packages/evals/fixtures/sentry-seer-race-condition-unbound-local/seer.py
@@ -1,0 +1,96 @@
+# Source excerpt from getsentry/sentry src/sentry/grouping/ingest/seer.py@f45b1850b52758fb2f6a9dbbc80a77fbc69d8eaf.
+# Unrelated context omitted; captured around the fix diff for 67e046ae53ae26ec2e69ad0002d44e6d5dbffcda.
+
+        or killswitch_enabled(project.id, ReferrerOptions.INGEST, event)
+        or _circuit_breaker_broken(event, project)
+        # The rate limit check has to be last (see below) but rate-limiting aside, call this after other checks
+        # because it calculates the stacktrace string, which we only want to spend the time to do if we already
+        # know the other checks have passed.
+        or _has_empty_stacktrace_string(event, variants)
+        # do this after the empty stacktrace string check because it calculates the stacktrace string
+        or _stacktrace_exceeds_limits(event, variants)
+        # **Do not add any new checks after this.** The rate limit check MUST remain the last of all
+        # the checks.
+        #
+        # (Checking the rate limit for calling Seer also increments the counter of how many times
+        # we've tried to call it, and if we fail any of the other checks, it shouldn't count as an
+        # attempt. Thus we only want to run the rate limit check if every other check has already
+        # succeeded.)
+        or _ratelimiting_enabled(event, project)
+    ):
+        return False
+
+    return True
+
+
+def _is_race_condition_skipped_event(event: Event, event_grouphash: GroupHash) -> bool:
+    """
+    In cases where multiple events with the same new hash are racing to assign that hash to a group,
+    we only want one of them to be sent to Seer.
+
+    We detect the race when creating `GroupHashMetadata` records, and track all but the winner of
+    the race as events whose Seer call we should skip.
+    """
+    if event.should_skip_seer:
+        logger.info(
+            "should_call_seer_for_grouping.race_condition_skip",
+            extra={
+                "grouphash_id": event_grouphash.id,
+                "grouphash_has_group": bool(event_grouphash.group_id),
+                "hash": event_grouphash.hash,
+                "event_id": event.event_id,
+            },
+        )
+        record_did_call_seer_metric(event, call_made=False, blocker="race_condition")
+        return True
+
+    # TODO: Temporary debugging for the fact that we're still sometimes seeing multiple events per
+    # hash being let through
+    initial_has_group = bool(event_grouphash.group_id)  # Should in theory always be False
+    if not initial_has_group:
+        new_has_group: Any = None  # mypy appeasement
+        try:
+            event_grouphash.refresh_from_db()
+            new_has_group = bool(event_grouphash.group_id)
+        except Exception as e:
+            new_has_group = repr(e)
+
+    logger.info(
+        "should_call_seer_for_grouping.race_condition_pass",
+        extra={
+            "grouphash_id": event_grouphash.id,
+            "initial_grouphash_has_group": initial_has_group,
+            "grouphash_has_group": new_has_group,
+            "hash": event_grouphash.hash,
+            "event_id": event.event_id,
+        },
+    )
+    return False
+
+
+def _event_content_is_seer_eligible(event: Event) -> bool:
+    """
+    Determine if an event's contents makes it fit for using with Seer's similar issues model.
+    """
+    platform = event.platform
+
+    if not event_content_has_stacktrace(event):
+        metrics.incr(
+            "grouping.similarity.event_content_seer_eligible",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"platform": platform, "eligible": False, "blocker": "no-stacktrace"},
+        )
+        return False
+
+    if event.platform in SEER_INELIGIBLE_EVENT_PLATFORMS:
+        metrics.incr(
+            "grouping.similarity.event_content_seer_eligible",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"platform": platform, "eligible": False, "blocker": "unsupported-platform"},
+        )
+        return False
+
+    metrics.incr(
+        "grouping.similarity.event_content_seer_eligible",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={"platform": platform, "eligible": True, "blocker": "none"},

--- a/packages/evals/fixtures/sentry-semver-build-ordering/LICENSE.md
+++ b/packages/evals/fixtures/sentry-semver-build-ordering/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-semver-build-ordering/release.py
+++ b/packages/evals/fixtures/sentry-semver-build-ordering/release.py
@@ -1,0 +1,110 @@
+# Source excerpt from getsentry/sentry src/sentry/models/release.py@0e64601cae2c42aed03cfd685511c982019307a0.
+# Unrelated context omitted; captured around the fix diff for 971655528404953bf863ab65583dd4b7ab6e0148.
+
+        # XXX(markus): Since the column is nullable we need to handle `null` here.
+        # However `null | undefined` in request payloads means "don't change
+        # status of release". This is why `from_string` does not consider
+        # `null` valid.
+        #
+        # We could remove `0` as valid state and only have `null` but I think
+        # that would make things worse.
+        #
+        # Eventually we should backfill releasestatus to 0
+        if value is None or value == ReleaseStatus.OPEN:
+            return "open"
+        elif value == ReleaseStatus.ARCHIVED:
+            return "archived"
+        else:
+            raise ValueError(repr(value))
+
+
+def _get_cache_key(project_id: int, group_id: int, first: bool) -> str:
+    return f"g-r:{group_id}-{project_id}-{first}"
+
+
+class ReleaseModelManager(BaseManager["Release"]):
+    def get_queryset(self) -> ReleaseQuerySet:
+        return ReleaseQuerySet(self.model, using=self._db)
+
+    def annotate_prerelease_column(self):
+        return self.get_queryset().annotate_prerelease_column()
+
+    def filter_to_semver(self) -> ReleaseQuerySet:
+        return self.get_queryset().filter_to_semver()
+
+    def filter_by_semver_build(
+        self,
+        organization_id: int,
+        operator: str,
+        build: str,
+        project_ids: Sequence[int] | None = None,
+        negated: bool = False,
+    ) -> models.QuerySet:
+        return self.get_queryset().filter_by_semver_build(
+            organization_id,
+            operator,
+            build,
+            project_ids,
+            negated=negated,
+        )
+
+    def filter_by_semver(
+        self,
+        organization_id: int,
+        semver_filter: SemverFilter,
+        project_ids: Sequence[int] | None = None,
+    ) -> models.QuerySet:
+
+# ... source context omitted ...
+
+                F("patch").desc(),
+                F("revision").desc(),
+                Case(When(prerelease="", then=1), default=0).desc(),
+                F("prerelease").desc(),
+                name="sentry_release_semver_by_package_idx",
+            ),
+            models.Index(
+                "organization",
+                F("major").desc(),
+                F("minor").desc(),
+                F("patch").desc(),
+                F("revision").desc(),
+                Case(When(prerelease="", then=1), default=0).desc(),
+                F("prerelease").desc(),
+                name="sentry_release_semver_idx",
+            ),
+            models.Index(fields=("organization", "build_code")),
+            models.Index(fields=("organization", "build_number")),
+            models.Index(fields=("organization", "date_added")),
+            models.Index(fields=("organization", "status")),
+        ]
+
+    __repr__ = sane_repr("organization_id", "version")
+
+    SEMVER_COLS = ["major", "minor", "patch", "revision", "prerelease_case", "prerelease"]
+
+    def __eq__(self, other: object) -> bool:
+        """Make sure that specialized releases are only comparable to the same
+        other specialized release.  This for instance lets us treat them
+        separately for serialization purposes.
+        """
+        return (
+            # don't treat `NotImplemented` as truthy
+            Model.__eq__(self, other) is True
+            and isinstance(other, Release)
+            and self._for_project_id == other._for_project_id
+        )
+
+    def __hash__(self):
+        # https://code.djangoproject.com/ticket/30333
+        return super().__hash__()
+
+    @staticmethod
+    def is_valid_version(value):
+        if value is None:
+            return False
+
+        if any(c in value for c in BAD_RELEASE_CHARS):
+            return False
+
+        value_stripped = str(value).strip()

--- a/packages/evals/fixtures/sentry-semver-build-ordering/util.py
+++ b/packages/evals/fixtures/sentry-semver-build-ordering/util.py
@@ -1,0 +1,100 @@
+# Source excerpt from getsentry/sentry src/sentry/models/releases/util.py@0e64601cae2c42aed03cfd685511c982019307a0.
+# Unrelated context omitted; captured around the fix diff for 971655528404953bf863ab65583dd4b7ab6e0148.
+
+from __future__ import annotations
+
+import logging
+from collections import namedtuple
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+from django.db import models
+from django.db.models import Case, F, Func, Q, Subquery, Value, When
+from django.db.models.signals import pre_save
+from sentry_relay.exceptions import RelayError
+from sentry_relay.processing import parse_release
+
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models.releases.release_project import ReleaseProject
+from sentry.utils.numbers import validate_bigint
+
+if TYPE_CHECKING:
+    from sentry.models.release import Release  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+class SemverVersion(
+    namedtuple("SemverVersion", "major minor patch revision prerelease_case prerelease")
+):
+    pass
+
+
+@dataclass
+class SemverFilter:
+    operator: str
+    version_parts: Sequence[int | str]
+    package: str | Sequence[str] | None = None
+    negated: bool = False
+
+
+class ReleaseQuerySet(BaseQuerySet["Release"]):
+    def annotate_prerelease_column(self):
+        """
+        Adds a `prerelease_case` column to the queryset which is used to properly sort
+        by prerelease. We treat an empty (but not null) prerelease as higher than any
+        other value.
+        """
+        return self.annotate(
+            prerelease_case=Case(
+                When(prerelease="", then=1), default=0, output_field=models.IntegerField()
+            )
+        )
+
+    def filter_to_semver(self) -> Self:
+        """
+        Filters the queryset to only include semver compatible rows
+        """
+        return self.filter(major__isnull=False)
+
+    def filter_by_semver_build(
+        self,
+        organization_id: int,
+        operator: str,
+        build: str,
+        project_ids: Sequence[int] | None = None,
+        negated: bool = False,
+    ) -> Self:
+        """
+        Filters released by build. If the passed `build` is a numeric string, we'll filter on
+        `build_number` and make use of the passed operator.
+        If it is a non-numeric string, then we'll filter on `build_code` instead. We support a
+        wildcard only at the end of this string, so that we can filter efficiently via the index.
+        """
+        qs = self.filter(organization_id=organization_id)
+        query_func = "exclude" if negated else "filter"
+
+        if project_ids:
+            qs = qs.filter(
+                id__in=ReleaseProject.objects.filter(project_id__in=project_ids).values_list(
+                    "release_id", flat=True
+                )
+            )
+
+        if build.isdecimal() and validate_bigint(int(build)):
+            qs = getattr(qs, query_func)(**{f"build_number__{operator}": int(build)})
+        else:
+            if not build or build.endswith("*"):
+                qs = getattr(qs, query_func)(build_code__startswith=build[:-1])
+            else:
+                qs = getattr(qs, query_func)(build_code=build)
+
+        return qs
+
+    def filter_by_semver(
+        self,
+        organization_id: int,
+        semver_filter: SemverFilter,
+        project_ids: Sequence[int] | None = None,

--- a/packages/evals/fixtures/sentry-similar-issues-duplicate-score/LICENSE.md
+++ b/packages/evals/fixtures/sentry-similar-issues-duplicate-score/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-similar-issues-duplicate-score/group_similar_issues_embeddings.py
+++ b/packages/evals/fixtures/sentry-similar-issues-duplicate-score/group_similar_issues_embeddings.py
@@ -1,0 +1,40 @@
+# Source excerpt from getsentry/sentry src/sentry/issues/endpoints/group_similar_issues_embeddings.py@1a9590be44235dfe22b52c3bf363df361ab273f6.
+# Unrelated context omitted; captured around the fix diff for 4c02626bf661b631ca26883a2919d4f672a35666.
+
+        self,
+        similar_issues_data: Sequence[SeerSimilarIssueData],
+        user: User | AnonymousUser,
+        group: Group,
+    ) -> Sequence[tuple[Mapping[str, Any], Mapping[str, Any]] | None]:
+        """
+        Format the responses using to be used by the frontend by changing the  field names and
+        changing the cosine distances into cosine similarities.
+        """
+        group_data = {}
+        parent_hashes = [
+            similar_issue_data.parent_hash for similar_issue_data in similar_issues_data
+        ]
+        group_hashes = GroupHash.objects.filter(project_id=group.project_id, hash__in=parent_hashes)
+        parent_hashes_group_ids = {
+            group_hash.hash: group_hash.group_id for group_hash in group_hashes
+        }
+        for similar_issue_data in similar_issues_data:
+            if parent_hashes_group_ids[similar_issue_data.parent_hash] != group.id:
+                formatted_response: FormattedSimilarIssuesEmbeddingsData = {
+                    "exception": round(1 - similar_issue_data.stacktrace_distance, 4),
+                    "shouldBeGrouped": "Yes" if similar_issue_data.should_group else "No",
+                }
+                group_data[similar_issue_data.parent_group_id] = formatted_response
+
+        serialized_groups = {
+            int(g["id"]): g
+            for g in serialize(
+                list(Group.objects.get_many_from_cache(group_data.keys())), user=user
+            )
+        }
+
+        return [(serialized_groups[group_id], group_data[group_id]) for group_id in group_data]
+
+    @deprecated(
+        CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-similar-issues-embeddings"]
+    )

--- a/packages/evals/fixtures/sentry-spans-null-attributes/LICENSE.md
+++ b/packages/evals/fixtures/sentry-spans-null-attributes/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-spans-null-attributes/buffer.py
+++ b/packages/evals/fixtures/sentry-spans-null-attributes/buffer.py
@@ -1,0 +1,94 @@
+# Source excerpt from getsentry/sentry src/sentry/spans/buffer.py@9f90bf49b54a25725005b0ca5ba822ce9483da87.
+# Unrelated context omitted; captured around the fix diff for 8a40a128b581e8d311869b6574598347e097b581.
+
+        flusher_logger_enabled = options.get("spans.buffer.flusher-cumulative-logger-enabled")
+        max_segments_per_shard = math.ceil(max_flush_segments / shard_factor)
+
+        ids_start = time.monotonic()
+        with metrics.timer("spans.buffer.flush_segments.load_segment_ids"):
+            with self.client.pipeline(transaction=False) as p:
+                for shard in self.assigned_shards:
+                    key = self._get_queue_key(shard)
+                    p.zrangebyscore(key, 0, cutoff, start=0, num=max_segments_per_shard)
+                    queue_keys.append(key)
+
+                result = p.execute()
+        load_ids_latency_ms = int((time.monotonic() - ids_start) * 1000)
+
+        segment_keys: list[tuple[int, QueueKey, SegmentKey]] = []
+        for shard, queue_key, keys in zip(self.assigned_shards, queue_keys, result):
+            for segment_key in keys:
+                segment_keys.append((shard, queue_key, segment_key))
+
+        data_start = time.monotonic()
+        with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
+            segments, oob_keys_by_segment = self._load_segment_data([k for _, _, k in segment_keys])
+        load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
+
+        return_segments = {}
+        num_has_root_spans = 0
+        any_shard_at_limit = False
+        flusher_log_entries: list[FlusherLogEntry] = []
+
+        for shard, queue_key, segment_key in segment_keys:
+            segment_span_id = segment_key_to_span_id(segment_key).decode("ascii")
+            segment = segments.get(segment_key, [])
+
+            if len(segment) >= max_segments_per_shard:
+                any_shard_at_limit = True
+
+            output_spans = []
+            has_root_span = False
+            metrics.timing("spans.buffer.flush_segments.num_spans_per_segment", len(segment))
+            # This incr metric is needed to get a rate overall.
+            metrics.incr("spans.buffer.flush_segments.count_spans_per_segment", amount=len(segment))
+            for payload in segment:
+                span = orjson.loads(payload)
+
+                if not attribute_value(span, "sentry.segment.id"):
+                    span.setdefault("attributes", {})["sentry.segment.id"] = {
+                        "type": "string",
+                        "value": segment_span_id,
+                    }
+
+                is_segment = segment_span_id == span["span_id"]
+                span["is_segment"] = is_segment
+                if is_segment:
+                    has_root_span = True
+
+                output_spans.append(OutputSpan(payload=span))
+
+            metrics.incr(
+                "spans.buffer.flush_segments.num_segments_per_shard", tags={"shard_i": shard}
+            )
+            return_segments[segment_key] = FlushedSegment(
+                queue_key=queue_key,
+                spans=output_spans,
+                oob_keys=oob_keys_by_segment.get(segment_key, []),
+            )
+            num_has_root_spans += int(has_root_span)
+
+            if flusher_logger_enabled and segment:
+                project_id, trace_id, _ = parse_segment_key(segment_key)
+                project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                flusher_log_entries.append(
+                    FlusherLogEntry(
+                        project_and_trace,
+                        len(segment),
+                        sum(len(s) for s in segment),
+                    )
+                )
+
+        if flusher_logger_enabled and flusher_log_entries:
+            self._flusher_logger.log(
+                flusher_log_entries,
+                load_ids_latency_ms,
+                load_data_latency_ms,
+                self._last_decompress_latency_ms,
+            )
+
+        metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
+        metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
+
+        self.any_shard_at_limit = any_shard_at_limit
+        return return_segments

--- a/packages/evals/fixtures/sentry-trace-metrics-none-unit/LICENSE.md
+++ b/packages/evals/fixtures/sentry-trace-metrics-none-unit/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-trace-metrics-none-unit/types.py
+++ b/packages/evals/fixtures/sentry-trace-metrics-none-unit/types.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+TraceMetricType = Literal["counter", "gauge", "distribution"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TraceMetric:
+    metric_name: str
+    metric_type: TraceMetricType
+    metric_unit: str | None
+
+    def get_filter(self) -> TraceItemFilter:
+        filters = [
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_name),
+                )
+            ),
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_type),
+                )
+            ),
+        ]
+
+        if self.metric_unit:
+            filters.append(
+                TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            name="sentry.metric_unit", type=AttributeKey.Type.TYPE_STRING
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_str=self.metric_unit),
+                    )
+                )
+            )
+
+        return TraceItemFilter(and_filter=AndFilter(filters=filters))

--- a/packages/evals/fixtures/sentry-user-details-revoke-staff-default-org/LICENSE.md
+++ b/packages/evals/fixtures/sentry-user-details-revoke-staff-default-org/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-user-details-revoke-staff-default-org/user_details.py
+++ b/packages/evals/fixtures/sentry-user-details-revoke-staff-default-org/user_details.py
@@ -1,0 +1,97 @@
+# Source excerpt from getsentry/sentry src/sentry/users/api/endpoints/user_details.py@b8493f599010a7da9f45466c2d875712ae0ba242.
+# Unrelated context omitted; captured around the fix diff for 05b41c4744af7233561bb3046f7b0fa458ee5783.
+
+                return Response(
+                    {"detail": "Missing required permission to add superuser."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            elif not user.is_staff and request.data.get("isStaff"):
+                return Response(
+                    {"detail": "Missing required permission to add admin."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+        serializer_cls: type[BaseUserSerializer]
+        if can_elevate_user:
+            serializer_cls = PrivilegedUserSerializer
+        # With superuser read/write separation, superuser read cannot hit this endpoint
+        # so we can keep this as is_active_superuser. Once the feature flag is
+        # removed and we only check is_active_staff, we can remove this comment.
+        elif has_elevated_mode(request):
+            # TODO(schew2381): Rename to staff serializer
+            serializer_cls = SuperuserUserSerializer
+        else:
+            serializer_cls = UserSerializer
+        serializer = serializer_cls(
+            instance=user, data=request.data, partial=True, context={"request": request}
+        )
+
+        serializer_options = UserOptionsSerializer(
+            data=request.data.get("options", {}), partial=True
+        )
+
+        # This serializer should NOT include privileged fields e.g. password
+        if not serializer.is_valid() or not serializer_options.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # We want to do extra checks in SaaS mode for superuser/staff elevation.
+        # The users have to also be a member of the default organization to be able to elevate
+        # to superuser/staff.
+        if settings.SENTRY_MODE == SentryMode.SAAS:
+            validated_data = serializer.validated_data
+            requested_superuser = validated_data.get("is_superuser")
+            requested_staff = validated_data.get("is_staff")
+
+            is_updating_superuser = requested_superuser is not None
+            is_updating_staff = requested_staff is not None
+
+            if is_updating_superuser or is_updating_staff:
+                if not user_can_elevate(user):
+                    return Response(
+                        {
+                            "detail": "User must be a member to the default organization to enable SuperUser mode."
+                        },
+                        status=status.HTTP_403_FORBIDDEN,
+                    )
+
+        # map API keys to keys in model
+        key_map = {
+            "theme": "theme",
+            "language": "language",
+            "timezone": "timezone",
+            "stacktraceOrder": "stacktrace_order",
+            "defaultIssueEvent": "default_issue_event",
+            "clock24Hours": "clock_24_hours",
+            "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
+        }
+
+        options_result = serializer_options.validated_data
+
+        for key in key_map:
+            if key in options_result:
+                UserOption.objects.set_value(
+                    user=user, key=key_map.get(key, key), value=options_result.get(key)
+                )
+
+        with transaction.atomic(using=router.db_for_write(User)):
+            user = serializer.save()
+
+        return Response(serialize(user, request.user, DetailedSelfUserSerializer()))
+
+    @sudo_required
+    def delete(self, request: Request, user: User) -> Response:
+        """
+        Delete User Account
+
+        Also removes organizations if they are an owner
+        :pparam string user_id: user id
+        :param boolean hard_delete: Completely remove the user from the database (requires super user)
+        :param list organizations: List of organization ids to remove
+        :auth required:
+        """
+        serializer = DeleteUserSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        # from `frontend/remove_account.py`

--- a/packages/evals/fixtures/sentry-user-misery-eap-validation/LICENSE.md
+++ b/packages/evals/fixtures/sentry-user-misery-eap-validation/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-user-misery-eap-validation/logic.py
+++ b/packages/evals/fixtures/sentry-user-misery-eap-validation/logic.py
@@ -1,0 +1,93 @@
+# Source excerpt from getsentry/sentry src/sentry/incidents/logic.py@9d76622623cec70718176b2f9a25112dbcd1a608.
+# Unrelated context omitted; captured around the fix diff for b05248b86eeefc61a98f98412e120ecabfe61550.
+
+    "transaction.duration",
+]
+TRANSLATABLE_COLUMNS = {
+    "user": "tags[sentry:user]",
+    "dist": "tags[sentry:dist]",
+    "release": "tags[sentry:release]",
+}
+INSIGHTS_FUNCTION_VALID_ARGS_MAP = {
+    "http_response_rate": ["3", "4", "5"],
+    "performance_score": [
+        "measurements.score.lcp",
+        "measurements.score.fcp",
+        "measurements.score.inp",
+        "measurements.score.cls",
+        "measurements.score.ttfb",
+        "measurements.score.total",
+    ],
+}
+EAP_COLUMNS = [
+    "span.duration",
+    "span.self_time",
+    "ai.total_tokens.used",
+    "ai.total_cost",
+    "cache.item_size",
+    "http.decoded_response_content_length",
+    "http.response_content_length",
+    "http.response_transfer_size",
+]
+EAP_FUNCTIONS = [
+    "count",
+    "count_unique",
+    "avg",
+    "p50",
+    "p75",
+    "p90",
+    "p95",
+    "p99",
+    "p100",
+    "max",
+    "min",
+    "sum",
+    "epm",
+    "failure_count",
+    "failure_rate",
+    "eps",
+    "apdex",
+]
+
+
+def get_column_from_aggregate(
+    aggregate: str, allow_mri: bool, allow_eap: bool = False
+) -> str | None:
+    # These functions exist as SnQLFunction definitions and are not supported in the older
+    # logic for resolving functions. We parse these using `fields.is_function`, otherwise
+    # they will fail using the old resolve_field logic.
+    match = is_function(aggregate)
+    if match and (
+        match.group("function") in SPANS_METRICS_FUNCTIONS
+        or match.group("function") in METRICS_LAYER_UNSUPPORTED_TRANSACTION_METRICS_FUNCTIONS
+    ):
+        return None if match.group("columns") == "" else match.group("columns")
+
+    # Skip additional validation for EAP queries. They don't exist in the old logic.
+    if match and match.group("function") in EAP_FUNCTIONS and allow_eap:
+        return match.group("columns")
+
+    if allow_mri:
+        mri_column = _get_column_from_aggregate_with_mri(aggregate)
+        # Only if the column was allowed, we return it, otherwise we fallback to the old logic.
+        if mri_column:
+            return mri_column
+
+    function = resolve_field(aggregate)
+    if function.aggregate is not None:
+        return function.aggregate[1]
+
+    return None
+
+
+def _get_column_from_aggregate_with_mri(aggregate: str) -> str | None:
+    match = is_function(aggregate)
+    if match is None:
+        return None
+
+    function = match.group("function")
+    columns = match.group("columns")
+
+    parsed_mri = parse_mri(columns)
+    if parsed_mri is None:
+        return None

--- a/packages/evals/fixtures/sentry-workflow-action-missing-workflow-id/LICENSE.md
+++ b/packages/evals/fixtures/sentry-workflow-action-missing-workflow-id/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-workflow-action-missing-workflow-id/action.py
+++ b/packages/evals/fixtures/sentry-workflow-action-missing-workflow-id/action.py
@@ -1,0 +1,95 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/processors/action.py@afeb841d94167044f6b1223bb075880668c35139.
+# Unrelated context omitted; captured around the fix diff for e91547d56a39183e2e1d16ec8846262a28abd421.
+
+        logger.info(
+            "workflow_engine.action.dedup.dropped",
+            extra={
+                "dedup_key": dedup_key,
+                "dropped_action_ids": sorted(action_ids),
+                "replacement_action_id": dedup_key_to_action_id[dedup_key],
+                "group_id": group.id,
+                "group_type": group_type,
+            },
+        )
+        metrics.incr(
+            "workflow_engine.action.dedup.dropped", len(action_ids), tags={"group_type": group_type}
+        )
+
+    return actions_queryset.filter(id__in=dedup_key_to_action_id.values())
+
+
+@scopedstats.timer()
+def fire_actions(
+    actions: BaseQuerySet[Action],
+    event_data: WorkflowEventData,
+    workflow_uuid_map: dict[int, str],
+) -> None:
+    deduped_actions = get_unique_active_actions(actions, event_data.group)
+
+    for action in deduped_actions:
+        task_params = build_trigger_action_task_params(action, event_data, workflow_uuid_map)
+        trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})
+
+
+def filter_recently_fired_workflow_actions(
+    filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
+) -> BaseQuerySet[Action]:
+    """
+    Returns actions associated with the provided DataConditionsGroups, excluding those that have been recently fired. Also updates associated WorkflowActionGroupStatus objects.
+    """
+
+    data_condition_group_actions = DataConditionGroupAction.objects.filter(
+        condition_group__in=filtered_action_groups
+    ).values_list("action_id", "condition_group__workflowdataconditiongroup__workflow_id")
+
+    action_to_workflows_ids: dict[int, set[int]] = defaultdict(set)
+    workflow_ids: set[int] = set()
+
+    for action_id, workflow_id in data_condition_group_actions:
+        action_to_workflows_ids[action_id].add(workflow_id)
+        workflow_ids.add(workflow_id)
+
+    workflows = Workflow.objects.filter(id__in=workflow_ids)
+
+    action_to_statuses = get_workflow_action_group_statuses(
+        action_to_workflows_ids=action_to_workflows_ids,
+        group=event_data.group,
+        workflow_ids=workflow_ids,
+    )
+    now = timezone.now()
+    action_to_workflows_ids, statuses_to_update, missing_statuses = (
+        process_workflow_action_group_statuses(
+            action_to_workflows_ids=action_to_workflows_ids,
+            action_to_statuses=action_to_statuses,
+            workflows=workflows,
+            group=event_data.group,
+            now=now,
+        )
+    )
+    update_result = update_workflow_action_group_statuses(now, statuses_to_update, missing_statuses)
+
+    # if statuses were not created for some reason, we should not fire for them
+    for workflow_id, action_id in update_result.not_created:
+        action_to_workflows_ids[action_id].remove(workflow_id)
+        if not action_to_workflows_ids[action_id]:
+            action_to_workflows_ids.pop(action_id)
+
+    actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
+
+    # annotate actions with workflow_id they are firing for (deduped)
+    workflow_id_cases = [
+        When(
+            id=action_id, then=Value(min(list(workflow_ids)))
+        )  # select 1 workflow to fire for, this is arbitrary but deterministic
+        for action_id, workflow_ids in action_to_workflows_ids.items()
+    ]
+
+    return actions_queryset.annotate(
+        workflow_id=Case(*workflow_id_cases, output_field=models.IntegerField()),
+    )
+
+
+def get_available_action_integrations_for_org(organization: Organization) -> list[RpcIntegration]:
+    providers = [
+        handler.provider_slug
+        for handler in action_handler_registry.registrations.values()

--- a/packages/evals/fixtures/sentry-workflow-status-missing-foreign-key/LICENSE.md
+++ b/packages/evals/fixtures/sentry-workflow-status-missing-foreign-key/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2008-2024 Functional Software, Inc. dba Sentry
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/evals/fixtures/sentry-workflow-status-missing-foreign-key/action.py
+++ b/packages/evals/fixtures/sentry-workflow-status-missing-foreign-key/action.py
@@ -1,0 +1,197 @@
+# Source excerpt from getsentry/sentry src/sentry/workflow_engine/processors/action.py@e36f46a85cf4a6c9a6ae0e5e545a7c13b789d478.
+# Unrelated context omitted; captured around the fix diff for f4cc09c52e73c2ab60a3b14291c60dd0db5458a7.
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from django.db import connection, models
+from django.db.models import Case, Value, When
+from django.utils import timezone
+
+from sentry import features
+from sentry.constants import ObjectStatus
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.exceptions import NotRegistered
+from sentry.integrations.base import IntegrationFeatures
+from sentry.integrations.manager import default_manager as integrations_manager
+from sentry.integrations.services.integration import RpcIntegration, integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.plugins.base import plugins
+from sentry.plugins.bases.notify import NotificationPlugin
+from sentry.rules.actions.services import PluginService
+from sentry.utils import metrics
+from sentry.workflow_engine.models import (
+    Action,
+    DataCondition,
+    DataConditionGroup,
+    DataConditionGroupAction,
+    Workflow,
+    WorkflowActionGroupStatus,
+)
+from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
+from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.utils import log_context, scopedstats
+
+logger = log_context.get_logger(__name__)
+
+EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
+UpdatedStatuses = int
+CreatedStatuses = int
+ConflictedStatuses = list[tuple[int, int]]  # (workflow_id, action_id)
+
+
+def get_workflow_action_group_statuses(
+    action_to_workflows_ids: dict[int, set[int]], group: Group, workflow_ids: set[int]
+) -> dict[int, list[WorkflowActionGroupStatus]]:
+    """
+    Returns a mapping of action IDs to their corresponding WorkflowActionGroupStatus objects
+    given the provided action_to_workflows_ids and group.
+    """
+
+    all_statuses = WorkflowActionGroupStatus.objects.filter(
+        group=group, action_id__in=action_to_workflows_ids.keys(), workflow_id__in=workflow_ids
+    )
+
+    actions_with_statuses: dict[int, list[WorkflowActionGroupStatus]] = defaultdict(list)
+
+    for status in all_statuses:
+        workflow_id = status.workflow_id
+
+# ... source context omitted ...
+
+
+    missing_statuses: list[WorkflowActionGroupStatus] = []
+    for action_id, expected_workflows in action_to_workflows_ids.items():
+        wags = action_to_statuses.get(action_id, [])
+        actual_workflows = {status.workflow_id for status in wags}
+        missing_workflows = expected_workflows - actual_workflows
+
+        for workflow_id in missing_workflows:
+            # create a new status for the missing workflow
+            missing_statuses.append(
+                WorkflowActionGroupStatus(
+                    workflow_id=workflow_id, action_id=action_id, group=group, date_updated=now
+                )
+            )
+            updated_action_to_workflows_ids[action_id].add(workflow_id)
+
+    return updated_action_to_workflows_ids, statuses_to_update, missing_statuses
+
+
+def update_workflow_action_group_statuses(
+    now: datetime, statuses_to_update: set[int], missing_statuses: list[WorkflowActionGroupStatus]
+) -> tuple[UpdatedStatuses, CreatedStatuses, ConflictedStatuses]:
+    updated_count = WorkflowActionGroupStatus.objects.filter(
+        id__in=statuses_to_update, date_updated__lt=now
+    ).update(date_updated=now)
+
+    if not missing_statuses:
+        return updated_count, 0, []
+
+    # Use raw SQL: only returns successfully created rows
+    # XXX: the query does not currently include batch size limit like bulk_create does
+    with connection.cursor() as cursor:
+        # Build values for batch insert
+        values_placeholders = []
+        values_data = []
+        for s in missing_statuses:
+            values_placeholders.append("(%s, %s, %s, %s, %s)")
+            values_data.extend([s.workflow_id, s.action_id, s.group_id, now, now])
+
+        sql = f"""
+            INSERT INTO workflow_engine_workflowactiongroupstatus
+            (workflow_id, action_id, group_id, date_added, date_updated)
+            VALUES {", ".join(values_placeholders)}
+            ON CONFLICT (workflow_id, action_id, group_id) DO NOTHING
+            RETURNING workflow_id, action_id
+        """
+
+        cursor.execute(sql, values_data)
+        created_rows = set(cursor.fetchall())  # Only returns newly inserted rows
+
+    # Figure out which ones conflicted (weren't returned)
+    conflicted_statuses = [
+        (s.workflow_id, s.action_id)
+        for s in missing_statuses
+        if (s.workflow_id, s.action_id) not in created_rows
+    ]
+
+    # Log action_ids for debugging
+    attempted_action_ids = {s.action_id for s in missing_statuses}
+    created_action_ids = {action_id for _, action_id in created_rows}
+    logger.debug(
+        "workflow_action_group_status.creation",
+        extra={
+            "attempted_action_ids": list(attempted_action_ids),
+            "created_action_ids": list(created_action_ids),
+        },
+    )
+
+    created_count = len(created_rows)
+    return updated_count, created_count, conflicted_statuses
+
+
+def get_unique_active_actions(
+    actions_queryset: BaseQuerySet[Action],  # decorated with the workflow_ids
+    group: Group,
+) -> BaseQuerySet[Action]:
+    """
+    Returns a queryset of unique active actions based on their handler's dedup_key method.
+    Group is used for logging only.
+    """
+    dedup_key_to_action_id: dict[str, int] = {}
+
+    dropped = defaultdict[str, set[int]](set)
+
+    for action in actions_queryset:
+        # We only want to fire active actions
+        if action.status != ObjectStatus.ACTIVE:
+            continue
+
+# ... source context omitted ...
+
+
+    workflows = Workflow.objects.filter(id__in=workflow_ids)
+
+    action_to_statuses = get_workflow_action_group_statuses(
+        action_to_workflows_ids=action_to_workflows_ids,
+        group=event_data.group,
+        workflow_ids=workflow_ids,
+    )
+    now = timezone.now()
+    action_to_workflows_ids, statuses_to_update, missing_statuses = (
+        process_workflow_action_group_statuses(
+            action_to_workflows_ids=action_to_workflows_ids,
+            action_to_statuses=action_to_statuses,
+            workflows=workflows,
+            group=event_data.group,
+            now=now,
+        )
+    )
+    _, _, conflicted_statuses = update_workflow_action_group_statuses(
+        now, statuses_to_update, missing_statuses
+    )
+
+    # if statuses were not created for some reason, we should not fire for them
+    for workflow_id, action_id in conflicted_statuses:
+        action_to_workflows_ids[action_id].remove(workflow_id)
+        if not action_to_workflows_ids[action_id]:
+            action_to_workflows_ids.pop(action_id)
+
+    actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
+
+    # annotate actions with workflow_id they are firing for (deduped)
+    workflow_id_cases = [
+        When(
+            id=action_id, then=Value(min(list(workflow_ids)))
+        )  # select 1 workflow to fire for, this is arbitrary but deterministic
+        for action_id, workflow_ids in action_to_workflows_ids.items()
+    ]
+
+    return actions_queryset.annotate(
+        workflow_id=Case(*workflow_id_cases, output_field=models.IntegerField()),
+    )

--- a/packages/evals/fixtures/stale-autosave-closure/editor.tsx
+++ b/packages/evals/fixtures/stale-autosave-closure/editor.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+interface AutoSaveEditorProps {
+  documentId: string;
+  initialText: string;
+  saveDocument: (documentId: string, text: string) => Promise<void>;
+}
+
+/**
+ * Saves the latest editor text every five seconds.
+ */
+export function AutoSaveEditor({
+  documentId,
+  initialText,
+  saveDocument,
+}: AutoSaveEditorProps) {
+  const [text, setText] = useState(initialText);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      void saveDocument(documentId, text);
+    }, 5000);
+
+    return () => window.clearInterval(timer);
+  }, [documentId, saveDocument]);
+
+  return (
+    <textarea
+      aria-label="Document body"
+      value={text}
+      onChange={(event) => setText(event.target.value)}
+    />
+  );
+}

--- a/packages/evals/security-review/junior-sandbox-egress-requester-context.json
+++ b/packages/evals/security-review/junior-sandbox-egress-requester-context.json
@@ -1,0 +1,51 @@
+{
+  "given": "sandbox credential egress proxy relies on command-scoped session state keyed only by sandbox_id instead of a signed requester context on each forwarded request",
+  "files": [
+    "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-policy.ts",
+    "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-proxy.ts",
+    "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-session.ts",
+    "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/sandbox.ts"
+  ],
+  "should_find": [
+    {
+      "finding": "sandbox egress credential activation is authorized by a persisted session keyed only by the Vercel sandbox_id, so forwarded requests do not have to present a signed requester-bound context before Junior mints provider credentials for the cached requester"
+    }
+  ],
+  "should_not_find": [
+    "missing tests",
+    "style or formatting issues",
+    "lazy credential activation failing after command cleanup as the primary security issue",
+    "forwarded path normalization as the primary issue"
+  ],
+  "supporting_files": [
+    "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/LICENSE"
+  ],
+  "notes": {
+    "source": "https://github.com/getsentry/junior/pull/399",
+    "repository": "getsentry/junior",
+    "source_ref": "15c62c9cddb85d5cd73dd4f1400d2d5b1ca5000b",
+    "side": "base",
+    "source_files": [
+      {
+        "fixturePath": "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-policy.ts",
+        "sourcePath": "packages/junior/src/chat/sandbox/egress-policy.ts",
+        "ref": "15c62c9cddb85d5cd73dd4f1400d2d5b1ca5000b"
+      },
+      {
+        "fixturePath": "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-proxy.ts",
+        "sourcePath": "packages/junior/src/chat/sandbox/egress-proxy.ts",
+        "ref": "15c62c9cddb85d5cd73dd4f1400d2d5b1ca5000b"
+      },
+      {
+        "fixturePath": "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/egress-session.ts",
+        "sourcePath": "packages/junior/src/chat/sandbox/egress-session.ts",
+        "ref": "15c62c9cddb85d5cd73dd4f1400d2d5b1ca5000b"
+      },
+      {
+        "fixturePath": "fixtures/junior-sandbox-egress-requester-context/github/getsentry/junior/packages/junior/src/chat/sandbox/sandbox.ts",
+        "sourcePath": "packages/junior/src/chat/sandbox/sandbox.ts",
+        "ref": "15c62c9cddb85d5cd73dd4f1400d2d5b1ca5000b"
+      }
+    ]
+  }
+}

--- a/packages/evals/src/code-review.eval.ts
+++ b/packages/evals/src/code-review.eval.ts
@@ -15,12 +15,17 @@ const evals = discoverEvalScenarios({
   runtime: 'pi',
   model: 'anthropic/claude-sonnet-4-6',
 });
+const CODE_REVIEW_RUN_TIMEOUT_MS = 120_000;
+const CODE_REVIEW_EVAL_TIMEOUT_MS = CODE_REVIEW_RUN_TIMEOUT_MS + 60_000;
 
 describeEval(
   'code-review',
   {
     harness: createWardenEvalHarness({
       apiKey,
+      maxTurns: 8,
+      timeoutMs: CODE_REVIEW_RUN_TIMEOUT_MS,
+      postProcessFindings: false,
       verbose: true,
     }),
     judges: [createWardenEvalJudge(apiKey)],
@@ -31,7 +36,7 @@ describeEval(
     for (const meta of evals) {
       it(
         formatEvalTestName(meta),
-        { timeout: 180_000 },
+        { timeout: CODE_REVIEW_EVAL_TIMEOUT_MS },
         async ({ run }) => {
           const result = await run(meta);
           const output = WardenEvalOutputSchema.parse(result.output);

--- a/packages/evals/src/index.test.ts
+++ b/packages/evals/src/index.test.ts
@@ -202,7 +202,7 @@ describe('standalone scenario files', () => {
       baseDir: evalsDir,
     });
 
-    expect(metas.length).toBe(10);
+    expect(metas.length).toBe(11);
     expect(metas.map((meta) => meta.name)).toContain('sentry-replay-delete-read-scope');
   });
 

--- a/packages/evals/src/judge.ts
+++ b/packages/evals/src/judge.ts
@@ -5,7 +5,7 @@ import { DEFAULT_EVAL_MODEL, JudgeResponseSchema } from './types.js';
 
 const JUDGE_MODEL = DEFAULT_EVAL_MODEL;
 const JUDGE_MAX_TOKENS = 4096;
-const JUDGE_TIMEOUT_MS = 60_000;
+const JUDGE_TIMEOUT_MS = 30_000;
 
 export interface JudgeResult {
   response: JudgeResponse;
@@ -109,7 +109,7 @@ export async function runJudge(
   findings: Finding[],
   apiKey: string
 ): Promise<JudgeResult> {
-  const client = new Anthropic({ apiKey, timeout: JUDGE_TIMEOUT_MS });
+  const client = new Anthropic({ apiKey, timeout: JUDGE_TIMEOUT_MS, maxRetries: 0 });
 
   const prompt = buildJudgePrompt(meta, findings);
 

--- a/packages/evals/src/runner.test.ts
+++ b/packages/evals/src/runner.test.ts
@@ -47,6 +47,7 @@ describe('setupEvalRepo', () => {
 
       expect(changedFiles).toEqual(['sentry-preprod-size-analysis-base-artifact-access/organization_preprod_size_analysis.py']);
       expect(existsSync(join(repoDir, '.warden', 'skills', 'security-review', 'SKILL.md'))).toBe(true);
+      expect(git(repoDir, ['config', '--get', 'commit.gpgsign']).trim()).toBe('false');
     } finally {
       rmSync(repoDir, { recursive: true, force: true });
     }

--- a/packages/evals/src/runner.ts
+++ b/packages/evals/src/runner.ts
@@ -15,6 +15,14 @@ export interface RunEvalOptions {
   model?: string;
   /** Override the runtime from the YAML spec */
   runtime?: RuntimeName;
+  /** Maximum turns per agent invocation. Keeps live evals bounded. */
+  maxTurns?: number;
+  /** Maximum wall-clock time for one Warden skill run before aborting. */
+  timeoutMs?: number;
+  /** Whether to run Warden's second-pass finding verifier. */
+  verifyFindings?: boolean;
+  /** Whether to run Warden post-processing. Disable for raw skill benchmarks. */
+  postProcessFindings?: boolean;
   /** Enable verbose logging */
   verbose?: boolean;
 }
@@ -64,6 +72,7 @@ export function setupEvalRepo(meta: EvalMeta, log: (msg: string) => void): strin
     git(['config', 'user.email', 'eval@warden.dev']);
     git(['config', 'user.name', 'Warden Eval']);
     git(['config', 'commit.gpgsign', 'false']);
+    git(['config', 'tag.gpgsign', 'false']);
     const sourceRepository = singleEvalFixtureSourceRepository(meta.filePaths);
     if (sourceRepository) {
       git(['remote', 'add', 'origin', `https://github.com/${sourceRepository}.git`]);
@@ -165,25 +174,43 @@ export async function runEvalSkill(
     const runtime = options.runtime ?? meta.runtime;
     log(`Running skill with model: ${model} [${runtime}]`);
 
-    const result = await runLocalSkill({
-      skillPath,
-      base: 'main',
-      head: 'eval',
-      cwd: repoDir,
-      defaultBranch: 'main',
-      apiKey: options.apiKey,
-      model,
-      runtime,
-      verbose: options.verbose,
-      parallel: false,
-      callbacks: options.verbose
-        ? {
-            onFindingProcessing: (event) => {
-              log(formatFindingProcessingEvent(event));
-            },
-          }
-        : undefined,
-    });
+    const abortController = options.timeoutMs ? new AbortController() : undefined;
+    const timeout = options.timeoutMs
+      ? setTimeout(() => {
+          log(`Run timeout reached after ${options.timeoutMs}ms; aborting skill`);
+          abortController?.abort();
+        }, options.timeoutMs)
+      : undefined;
+
+    const result = await (async () => {
+      try {
+        return await runLocalSkill({
+          skillPath,
+          base: 'main',
+          head: 'eval',
+          cwd: repoDir,
+          defaultBranch: 'main',
+          apiKey: options.apiKey,
+          model,
+          runtime,
+          maxTurns: options.maxTurns,
+          abortController,
+          verifyFindings: options.verifyFindings,
+          postProcessFindings: options.postProcessFindings,
+          verbose: options.verbose,
+          parallel: false,
+          callbacks: options.verbose
+            ? {
+                onFindingProcessing: (event) => {
+                  log(formatFindingProcessingEvent(event));
+                },
+              }
+            : undefined,
+        });
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    })();
     log(`Context built: ${result.context.pullRequest?.files.length ?? 0} file(s) from git diff`);
     log(`Skill resolved: ${result.skill.name}`);
 

--- a/packages/evals/src/setup.ts
+++ b/packages/evals/src/setup.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
+import { bridgeWardenProviderApiKeyEnv } from '../../warden/src/utils/index.js';
 
 /**
  * Load environment variables for evals.
@@ -23,3 +24,4 @@ function loadTestEnv(): void {
 }
 
 loadTestEnv();
+bridgeWardenProviderApiKeyEnv();

--- a/packages/warden/src/sdk/analyze-verification.test.ts
+++ b/packages/warden/src/sdk/analyze-verification.test.ts
@@ -98,4 +98,18 @@ describe('runSkill verification', () => {
       expect.objectContaining({ model: 'claude-haiku-4-5' })
     );
   });
+
+  it('can skip post-processing for raw skill benchmarks', async () => {
+    const report = await runSkill(makeSkill(), makeContext(), {
+      postProcessFindings: false,
+    });
+
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        title: 'Candidate',
+        location: { path: 'src/app.ts', startLine: 10 },
+      }),
+    ]);
+    expect(verifyFindings).not.toHaveBeenCalled();
+  });
 });

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -915,23 +915,26 @@ async function runSkillAnalysis(
     );
   }
 
-  const processed = await postProcessFindings(allFindings, {
-    skill,
-    repoPath: context.repoPath,
-    apiKey: options.apiKey,
-    runtime: options.runtime,
-    auxiliaryModel: options.auxiliaryModel,
-    synthesisModel: options.synthesisModel,
-    auxiliaryMaxRetries: options.auxiliaryMaxRetries,
-    verifyFindings: options.verifyFindings,
-    maxTurns: options.maxTurns,
-    abortController: options.abortController,
-    pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
-    prContext,
-    onFindingProcessing: options.callbacks?.onFindingProcessing,
-  });
-  const finalFindings = processed.findings;
-  allAuxiliaryUsage.push(...processed.auxiliaryUsage);
+  let finalFindings = allFindings;
+  if (options.postProcessFindings !== false) {
+    const processed = await postProcessFindings(allFindings, {
+      skill,
+      repoPath: context.repoPath,
+      apiKey: options.apiKey,
+      runtime: options.runtime,
+      auxiliaryModel: options.auxiliaryModel,
+      synthesisModel: options.synthesisModel,
+      auxiliaryMaxRetries: options.auxiliaryMaxRetries,
+      verifyFindings: options.verifyFindings,
+      maxTurns: options.maxTurns,
+      abortController: options.abortController,
+      pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+      prContext,
+      onFindingProcessing: options.callbacks?.onFindingProcessing,
+    });
+    finalFindings = processed.findings;
+    allAuxiliaryUsage.push(...processed.auxiliaryUsage);
+  }
 
   // Generate summary
   const summary = generateSummary(skill.name, finalFindings);

--- a/packages/warden/src/sdk/types.ts
+++ b/packages/warden/src/sdk/types.ts
@@ -128,6 +128,8 @@ export interface SkillRunnerOptions {
   auxiliaryMaxRetries?: number;
   /** Verify candidate findings in a second read-only pass. Defaults to true. */
   verifyFindings?: boolean;
+  /** Run post-analysis verification, merge, and suggested-fix quality gates. Defaults to true. */
+  postProcessFindings?: boolean;
   /** Trigger name to attach to skill-level telemetry when the caller has one. */
   telemetryTriggerName?: string;
 }


### PR DESCRIPTION
Add a larger code-review eval corpus based on real regressions.

This adds 40 code-review scenarios, including 30 source-captured fixtures from getsentry/sentry, plus the licenses and fixture metadata needed to keep provenance explicit. It also adds the Junior sandbox egress security fixture from the referenced PR so that case can stay in the eval suite.

The live eval runner now disables inherited git signing in temporary repos, bridges WARDEN_ANTHROPIC_API_KEY into ANTHROPIC_API_KEY, supports bounded skill runs, and lets discovery-focused suites skip Warden post-processing. The code-review suite uses raw skill output so these cases measure bug discovery rather than verifier, merge, or suggested-fix gate behavior.

The eval judge is also bounded with a shorter timeout and no SDK retries. During benchmarking, judge retries and leaked background runs made individual cases look slower than the code under review warranted.

Validated locally with pnpm lint, pnpm build, pnpm -C packages/evals typecheck, eval unit tests, and the SDK post-processing skip test.