### PR TITLE
fix(sdk): allow Pi model IDs with slashes

### DIFF
--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -19,7 +19,7 @@ runtime = "pi"
 
 | Runtime | Purpose |
 | --- | --- |
-| `pi` | Default. Runs through Pi. Model values must use `provider/model` selectors. |
+| `pi` | Default. Runs through Pi. Model values must use `provider/<provider-specific-model-id>` selectors. |
 | `claude` | Runs through Claude Code. Requires Anthropic API key or Claude Code OAuth auth. |
 
 Runtime selection is global within a config layer. `runtime` is not currently a
@@ -40,6 +40,11 @@ Examples:
 | --- | --- |
 | `openai/gpt-5.5` | `WARDEN_OPENAI_API_KEY` |
 | `anthropic/claude-sonnet-4-6` | `WARDEN_ANTHROPIC_API_KEY` |
+| `fireworks/accounts/fireworks/models/kimi-k2p6` | `WARDEN_FIREWORKS_API_KEY` |
+
+Warden splits Pi selectors at the first `/`. The provider comes before it and the
+provider-specific model ID comes after it, so model IDs may contain additional
+slashes.
 
 ## Claude Runtime Models
 

--- a/packages/warden/src/sdk/runtimes/model-selectors.test.ts
+++ b/packages/warden/src/sdk/runtimes/model-selectors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { assertValidPiModelSelectors, isPiModelSelector } from './model-selectors.js';
+
+describe('isPiModelSelector', () => {
+  it('accepts provider-prefixed model IDs', () => {
+    expect(isPiModelSelector('openai/gpt-5.5')).toBe(true);
+    expect(isPiModelSelector('fireworks/accounts/fireworks/models/kimi-k2p6')).toBe(true);
+  });
+
+  it('rejects selectors without both provider and model ID', () => {
+    expect(isPiModelSelector('gpt-5.5')).toBe(false);
+    expect(isPiModelSelector('/gpt-5.5')).toBe(false);
+    expect(isPiModelSelector('fireworks/')).toBe(false);
+  });
+});
+
+describe('assertValidPiModelSelectors', () => {
+  it('allows provider-specific model IDs with slashes in every Pi model lane', () => {
+    expect(() => assertValidPiModelSelectors([
+      {
+        runtime: 'pi',
+        model: 'fireworks/accounts/fireworks/models/kimi-k2p6',
+        auxiliaryModel: 'fireworks/accounts/fireworks/models/kimi-k2p6',
+        synthesisModel: 'fireworks/accounts/fireworks/models/kimi-k2p6',
+      },
+    ])).not.toThrow();
+  });
+});

--- a/packages/warden/src/sdk/runtimes/model-selectors.ts
+++ b/packages/warden/src/sdk/runtimes/model-selectors.ts
@@ -1,13 +1,9 @@
 /**
- * Return true when a Pi model selector uses provider/model syntax.
+ * Return true when a Pi model selector uses provider/model-id syntax.
  */
 export function isPiModelSelector(model: string): boolean {
   const slashIndex = model.indexOf('/');
-  return (
-    slashIndex > 0 &&
-    slashIndex < model.length - 1 &&
-    model.indexOf('/', slashIndex + 1) === -1
-  );
+  return slashIndex > 0 && slashIndex < model.length - 1;
 }
 
 export type PiModelSelectorOption = 'model' | 'auxiliaryModel' | 'synthesisModel';

--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -306,6 +306,20 @@ describe('piRuntime.runSkill', () => {
     expect(piMocks.authStorage.setRuntimeApiKey).not.toHaveBeenCalled();
   });
 
+  it('resolves provider-specific Pi model IDs that contain slashes', async () => {
+    await piRuntime.runSkill({
+      ...baseSkillRequest(),
+      options: {
+        model: 'fireworks/accounts/fireworks/models/kimi-k2p6',
+      },
+    });
+
+    expect(piMocks.registry.find).toHaveBeenCalledWith(
+      'fireworks',
+      'accounts/fireworks/models/kimi-k2p6'
+    );
+  });
+
   it('requires configured Pi models to use provider/model selectors', async () => {
     await expect(piRuntime.runSkill({
       ...baseSkillRequest(),


### PR DESCRIPTION
## What

Relax Pi model selector validation so the provider is the text before the first `/` and the provider-specific model ID is everything after it. This lets valid Fireworks selectors such as `fireworks/accounts/fireworks/models/kimi-k2p6` pass while still rejecting selectors with no slash, empty provider, or empty model ID.

Fixes #367.

## Changes

- Validate Pi selectors using the first slash only.
- Add selector regression coverage for normal selectors, Fireworks full IDs, and invalid forms.
- Add Pi runtime coverage proving Fireworks full IDs resolve as provider `fireworks` with model ID `accounts/fireworks/models/kimi-k2p6`.
- Update model docs to describe `provider/<provider-specific-model-id>` selectors and note that model IDs may contain slashes.

## Affected Providers

Pi currently has selectors with more than one `/` for these providers, so they were affected by the old exactly-one-slash validation:

| Provider | Affected selector count |
| --- | ---: |
| `cloudflare-ai-gateway` | 4 |
| `cloudflare-workers-ai` | 12 |
| `fireworks` | 12 |
| `groq` | 10 |
| `huggingface` | 22 |
| `openrouter` | 265 |
| `together` | 18 |
| `vercel-ai-gateway` | 158 |

## Verified

- `pnpm --filter @sentry/warden exec vitest run --config vitest.config.ts src/sdk/runtimes/model-selectors.test.ts src/sdk/runtimes/pi.test.ts` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm test` hit unrelated local environment-sensitive test failures in `src/cli/files.test.ts` and `src/sdk/local.resolve.test.ts` around macOS `/var` vs `/private/var` temp path canonicalization; Pi selector tests passed