### PR TITLE
fix(workflow): use app token for pricing push

### DIFF
--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Keep the default read-only GITHUB_TOKEN out of git config so the
+          # later app-token remote URL is used for the automation branch push.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What

Fixes the model pricing update workflow after the first manual run failed while pushing `automation/update-model-pricing`.

## Why

`actions/checkout@v4` persisted the default read-only `GITHUB_TOKEN` into git config as an extra HTTP authorization header. The workflow later rewrites `origin` to use the GitHub App token, but git still prefers the persisted checkout header, so the push authenticated as `github-actions[bot]` and failed with:

```text
Permission to getsentry/warden.git denied to github-actions[bot]
```

## How

Set `persist-credentials: false` on checkout so the app-token remote URL is the credential used by `git push`.

## Verification

- `pnpm lint`
- commit hook ran `pnpm typecheck`

Refs #356
