### PR TITLE
fix(workflow): stop impersonating release bot

### DIFF
--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -102,19 +102,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          APP_SLUG: ${{ steps.token.outputs.app-slug }}
           GH_REPO: ${{ github.repository }}
+          GIT_AUTHOR_NAME: Warden Pricing Workflow
+          GIT_AUTHOR_EMAIL: actions@github.com
+          GIT_COMMITTER_NAME: Warden Pricing Workflow
+          GIT_COMMITTER_EMAIL: actions@github.com
         run: |
-          # Derive a stable bot identity for the commit. The user id keeps
-          # GitHub's "verified bot" attribution working when present.
-          BOT_USER="${APP_SLUG}[bot]"
-          BOT_USER_ID=$(gh api "/users/${BOT_USER}" --jq .id)
-          export GIT_AUTHOR_NAME="$BOT_USER"
-          export GIT_COMMITTER_NAME="$BOT_USER"
-          export GIT_AUTHOR_EMAIL="${BOT_USER_ID}+${BOT_USER}@users.noreply.github.com"
-          export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
-
           # Swap the origin remote over to the app-token credential so
-          # both git push and gh CLI use the write-capable identity.
+          # both git push and gh CLI use write-capable auth. Commit identity
+          # stays the explicit workflow identity above, not the app credential.
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GH_REPO}.git"
           pnpm --filter @sentry/warden update-pricing-pr

--- a/packages/warden/scripts/create-pricing-update-pr.ts
+++ b/packages/warden/scripts/create-pricing-update-pr.ts
@@ -142,8 +142,8 @@ function findOpenPrNumber(): number | null {
 }
 
 function configureGitIdentity(): void {
-  // Honour CI-provided identity (e.g. from actions/create-github-app-token);
-  // otherwise leave whatever the local config has.
+  // Honour caller-provided commit identity; otherwise leave whatever the local
+  // config has.
   const name = process.env.GIT_AUTHOR_NAME ?? process.env.GIT_COMMITTER_NAME;
   const email = process.env.GIT_AUTHOR_EMAIL ?? process.env.GIT_COMMITTER_EMAIL;
   if (name) {


### PR DESCRIPTION
## What

Stops the model pricing workflow from manufacturing a `sentry-release-bot[bot]` commit identity.

## Why

The GitHub App token is an authorization credential for pushing the automation branch and creating the PR. It should not also be used to pretend the generated commit was authored by the release bot account.

## How

- Removes the `APP_SLUG` / `BOT_USER` / `/users/...` lookup flow.
- Sets generated pricing commits to a transparent workflow identity:

```text
Warden Pricing Workflow <actions@github.com>
```

- Leaves the GitHub App token as push/PR auth only.

## Verification

- `pnpm lint`
- `pnpm --filter @sentry/warden typecheck`
- commit hook ran full `pnpm typecheck`

Refs #356
