### PR TITLE
build(action): Validate release action layout

### DIFF
--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -19,7 +19,7 @@
     "cli": "tsx src/cli/index.ts",
     "clean:dist": "rm -rf dist",
     "build": "pnpm run clean:dist && tsc -p tsconfig.build.json",
-    "build:action": "rm -rf ../../dist/action && ncc build src/action/main.ts -o ../../dist/action --no-source-map-register --license licenses.txt",
+    "build:action": "tsx scripts/validate-action-layout.ts && rm -rf ../../dist/action && ncc build src/action/main.ts -o ../../dist/action --no-source-map-register --license licenses.txt && tsx scripts/validate-action-layout.ts --require-dist",
     "dev": "tsc --watch",
     "test": "vitest run --config vitest.config.ts",
     "test:coverage": "vitest run --config vitest.config.ts --coverage",

--- a/packages/warden/scripts/validate-action-layout.ts
+++ b/packages/warden/scripts/validate-action-layout.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { validateActionLayout } from '../src/action/layout.js';
+
+const scriptPath = process.argv[1];
+
+if (scriptPath && import.meta.url === pathToFileURL(scriptPath).href) {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+  const errors = validateActionLayout({
+    repoRoot,
+    requireDist: process.argv.includes('--require-dist'),
+  });
+
+  if (errors.length > 0) {
+    console.error(errors.map((error) => `- ${error}`).join('\n'));
+    process.exit(1);
+  }
+}

--- a/packages/warden/src/action/layout.ts
+++ b/packages/warden/src/action/layout.ts
@@ -1,0 +1,103 @@
+import { accessSync, existsSync, lstatSync, readlinkSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+export interface ValidateActionLayoutOptions {
+  repoRoot: string;
+  requireDist?: boolean;
+}
+
+/**
+ * Validates files that GitHub must stage before the composite action can run.
+ */
+export function validateActionLayout(options: ValidateActionLayoutOptions): string[] {
+  const errors: string[] = [];
+
+  expectFile(join(options.repoRoot, 'action.yml'), errors);
+  validateTrackedSymlinks(options.repoRoot, errors);
+
+  const pluginSkillPath = join(options.repoRoot, 'plugins/warden/skills/warden');
+  const expectedSkillPath = join(options.repoRoot, 'packages/warden/skills/warden');
+
+  try {
+    const stat = lstatSync(pluginSkillPath);
+    if (!stat.isSymbolicLink()) {
+      errors.push('plugins/warden/skills/warden must be a symlink');
+    } else {
+      const target = readlinkSync(pluginSkillPath);
+      const resolvedTarget = realpathSync(pluginSkillPath);
+      const expectedTarget = realpathSync(expectedSkillPath);
+
+      if (resolvedTarget !== expectedTarget) {
+        errors.push(
+          `plugins/warden/skills/warden points to ${target}, expected packages/warden/skills/warden`,
+        );
+      }
+    }
+
+    expectFile(join(pluginSkillPath, 'SKILL.md'), errors);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    errors.push(`plugins/warden/skills/warden is not usable: ${reason}`);
+  }
+
+  if (options.requireDist) {
+    expectFile(join(options.repoRoot, 'dist/action/index.js'), errors);
+    expectFile(join(options.repoRoot, 'dist/action/package.json'), errors);
+  }
+
+  return errors;
+}
+
+function validateTrackedSymlinks(repoRoot: string, errors: string[]): void {
+  let output: string;
+  try {
+    output = execFileSync('git', ['ls-files', '-s'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    errors.push(`Unable to inspect tracked symlinks: ${reason}`);
+    return;
+  }
+
+  for (const line of output.split('\n')) {
+    if (!line.startsWith('120000 ')) {
+      continue;
+    }
+
+    const path = line.split('\t')[1];
+    if (!path) {
+      continue;
+    }
+
+    const absolutePath = join(repoRoot, path);
+    let target: string;
+    try {
+      const stat = lstatSync(absolutePath);
+      if (!stat.isSymbolicLink()) {
+        errors.push(`${path} is tracked as a symlink but is not a symlink`);
+        continue;
+      }
+
+      target = readlinkSync(absolutePath);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      errors.push(`Tracked symlink is missing: ${path} (${reason})`);
+      continue;
+    }
+
+    if (!existsSync(absolutePath)) {
+      errors.push(`${path} points to missing target ${target}`);
+    }
+  }
+}
+
+function expectFile(path: string, errors: string[]): void {
+  try {
+    accessSync(path);
+  } catch {
+    errors.push(`Missing required action file: ${path}`);
+  }
+}

--- a/packages/warden/src/package.test.ts
+++ b/packages/warden/src/package.test.ts
@@ -1,10 +1,14 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import ignore from 'ignore';
+import { validateActionLayout } from './action/layout.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const monorepoRoot = join(repoRoot, '../..');
 
 describe('npm package contents', () => {
   it('exposes only the documented package entrypoints', () => {
@@ -44,5 +48,37 @@ describe('npm package contents', () => {
     expect(ignored.ignores('specs/generated-skills.md')).toBe(true);
     expect(ignored.ignores('bin/debug-helper.js')).toBe(true);
     expect(ignored.ignores('bin/warden.js')).toBe(false);
+  });
+});
+
+describe('GitHub Action layout', () => {
+  it('keeps plugin skill symlinks resolvable for action checkout staging', () => {
+    expect(validateActionLayout({ repoRoot: monorepoRoot })).toEqual([]);
+  });
+
+  it('reports broken tracked symlinks before the action is published', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warden-action-layout-'));
+
+    try {
+      execFileSync('git', ['init'], { cwd: tempDir });
+      writeFileSync(join(tempDir, 'action.yml'), 'name: test\nruns:\n  using: composite\n  steps: []\n');
+      mkdirSync(join(tempDir, 'plugins/warden/skills'), { recursive: true });
+      mkdirSync(join(tempDir, 'packages/warden/skills/warden'), { recursive: true });
+      writeFileSync(join(tempDir, 'packages/warden/skills/warden/SKILL.md'), '---\nname: warden\n---\n');
+      symlinkSync('../../../packages/warden/skills/warden', join(tempDir, 'plugins/warden/skills/warden'));
+      symlinkSync('missing-target', join(tempDir, 'broken-link'));
+      symlinkSync('target', join(tempDir, 'missing-link'));
+      execFileSync('git', ['add', 'action.yml', 'plugins', 'packages', 'broken-link', 'missing-link'], {
+        cwd: tempDir,
+      });
+      rmSync(join(tempDir, 'missing-link'));
+
+      const errors = validateActionLayout({ repoRoot: tempDir });
+
+      expect(errors).toContain('broken-link points to missing target missing-target');
+      expect(errors).toContainEqual(expect.stringContaining('Tracked symlink is missing: missing-link'));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/warden/skills/warden
+++ b/plugins/warden/skills/warden
@@ -1,1 +1,1 @@
-../../../skills/warden
+../../../packages/warden/skills/warden


### PR DESCRIPTION
Fix Warden published composite action layout so GitHub can stage the bundled plugin skill after the monorepo move. The action build now fails if the checkout tree has any broken tracked symlink or is missing the built action bundle files.

Release Guard

Run the action-layout validator before and after pnpm build:action bundles with ncc. This gives PR CI and the release tag update workflow the same guard before v0 or version tags move.

Symlink Coverage

Point plugins/warden/skills/warden at packages/warden/skills/warden, matching the current monorepo layout. The regression tests cover the real plugin skill path and a synthetic broken tracked symlink so future repository-layout changes fail in CI before publishing.