### PR TITLE
Align GenAI telemetry with current OTel cache semantics

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -96,7 +96,7 @@ Agent/model calls for token or provider symptoms.
 
 ```text
 dataset=spans query='span.op:gen_ai.invoke_agent gen_ai.agent.name:"<skill_name>"'
-fields=timestamp,trace,span_id,span.duration,gen_ai.conversation.id,gen_ai.request.model,gen_ai.response.model,gen_ai.usage.total_tokens,error.type
+fields=timestamp,trace,span_id,span.duration,gen_ai.conversation.id,gen_ai.request.model,gen_ai.response.model,gen_ai.usage.input_tokens,gen_ai.usage.output_tokens,gen_ai.usage.cache_read.input_tokens,gen_ai.usage.cache_creation.input_tokens,error.type
 sort=-timestamp
 ```
 
@@ -231,7 +231,8 @@ Spans: `gen_ai.invoke_agent`, `gen_ai.chat`, `gen_ai.execute_tool`
 
 Attributes: `gen_ai.agent.name`, `gen_ai.conversation.id`,
 `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`,
-`gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`,
+`gen_ai.usage.cache_creation.input_tokens`,
 `gen_ai.tool.name`
 
 ### Finding Pipeline

--- a/packages/warden/src/sdk/haiku.test.ts
+++ b/packages/warden/src/sdk/haiku.test.ts
@@ -19,9 +19,8 @@ describe('setGenAiResponseAttrs', () => {
     // input_tokens is total: 10 + 5 + 3 = 18
     expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens', 18);
     expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.output_tokens', 20);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens.cached', 5);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens.cache_write', 3);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.total_tokens', 38);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_read.input_tokens', 5);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_creation.input_tokens', 3);
     expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.response.finish_reasons', ['end_turn']);
     expect(span._attrs.has('gen_ai.output.messages')).toBe(false);
   });
@@ -30,9 +29,8 @@ describe('setGenAiResponseAttrs', () => {
     const span = makeSpan();
     setGenAiResponseAttrs(span as never, { input_tokens: 10, output_tokens: 20 }, 'end_turn');
     expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens', 10);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens.cached', 0);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens.cache_write', 0);
-    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.total_tokens', 30);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_read.input_tokens', 0);
+    expect(span.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_creation.input_tokens', 0);
   });
 
   it('sets gen_ai.output.messages when responseText is provided', () => {

--- a/packages/warden/src/sdk/otel.test.ts
+++ b/packages/warden/src/sdk/otel.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { genAiProviderName } from './otel.js';
+import { genAiProviderName, genAiUsageAttributes } from './otel.js';
 
 describe('OpenTelemetry GenAI provider attribution', () => {
   it('uses provider ids from model selectors', () => {
     expect(genAiProviderName('pi', 'openai/gpt-test')).toBe('openai');
     expect(genAiProviderName('pi', 'anthropic/claude-test')).toBe('anthropic');
-    expect(genAiProviderName('pi', 'xai/grok-test')).toBe('xai');
+    expect(genAiProviderName('pi', 'xai/grok-test')).toBe('x_ai');
+  });
+});
+
+describe('OpenTelemetry GenAI usage attributes', () => {
+  it('uses current cache subset attribute names', () => {
+    expect(genAiUsageAttributes({
+      inputTokens: 1300,
+      outputTokens: 500,
+      cacheReadInputTokens: 200,
+      cacheCreationInputTokens: 100,
+      costUSD: 0.01,
+    })).toEqual({
+      'gen_ai.usage.input_tokens': 1300,
+      'gen_ai.usage.output_tokens': 500,
+      'gen_ai.usage.cache_read.input_tokens': 200,
+      'gen_ai.usage.cache_creation.input_tokens': 100,
+    });
   });
 });

--- a/packages/warden/src/sdk/otel.ts
+++ b/packages/warden/src/sdk/otel.ts
@@ -12,6 +12,13 @@ interface GenAiMessage {
   content: unknown;
 }
 
+type GenAiUsageAttributes = Record<string, number>;
+
+const PROVIDER_NAME_ALIASES: Record<string, string> = {
+  mistral: 'mistral_ai',
+  xai: 'x_ai',
+};
+
 function providerFromModel(model: string | undefined): string | undefined {
   if (!model) {
     return undefined;
@@ -19,7 +26,8 @@ function providerFromModel(model: string | undefined): string | undefined {
 
   const slashIndex = model.indexOf('/');
   if (slashIndex > 0) {
-    return model.slice(0, slashIndex);
+    const provider = model.slice(0, slashIndex);
+    return PROVIDER_NAME_ALIASES[provider] ?? provider;
   }
 
   return undefined;
@@ -30,13 +38,21 @@ export function genAiProviderName(runtime: string | undefined, model: string | u
   return providerFromModel(model) ?? (runtime === 'pi' ? 'pi' : 'anthropic');
 }
 
+/** Build current OpenTelemetry GenAI usage attributes from normalized usage. */
+export function genAiUsageAttributes(usage: UsageStats): GenAiUsageAttributes {
+  return {
+    'gen_ai.usage.input_tokens': usage.inputTokens,
+    'gen_ai.usage.output_tokens': usage.outputTokens,
+    'gen_ai.usage.cache_read.input_tokens': usage.cacheReadInputTokens ?? 0,
+    'gen_ai.usage.cache_creation.input_tokens': usage.cacheCreationInputTokens ?? 0,
+  };
+}
+
 /** Set GenAI token usage attributes expected by Sentry AI monitoring. */
 export function setGenAiUsageAttrs(span: SpanLike, usage: UsageStats): void {
-  span.setAttribute('gen_ai.usage.input_tokens', usage.inputTokens);
-  span.setAttribute('gen_ai.usage.output_tokens', usage.outputTokens);
-  span.setAttribute('gen_ai.usage.input_tokens.cached', usage.cacheReadInputTokens ?? 0);
-  span.setAttribute('gen_ai.usage.input_tokens.cache_write', usage.cacheCreationInputTokens ?? 0);
-  span.setAttribute('gen_ai.usage.total_tokens', usage.inputTokens + usage.outputTokens);
+  for (const [key, value] of Object.entries(genAiUsageAttributes(usage))) {
+    span.setAttribute(key, value);
+  }
 }
 
 /** Set OpenTelemetry GenAI system-instruction attributes for prompt spans. */

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -21,6 +21,7 @@ import type { ToolConfig, ToolName } from '../../config/schema.js';
 import { Sentry } from '../../sentry.js';
 import { callHaiku, callHaikuWithTools } from '../haiku.js';
 import {
+  genAiUsageAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
   setGenAiSystemInstructionsAttr,
@@ -372,6 +373,16 @@ export const claudeRuntime: Runtime = {
 
           try {
             const totalInput = turn.inputTokens + turn.cacheRead + turn.cacheWrite;
+            const usageAttrs = genAiUsageAttributes({
+              inputTokens: totalInput,
+              outputTokens: turn.outputTokens,
+              cacheReadInputTokens: turn.cacheRead,
+              cacheCreationInputTokens: turn.cacheWrite,
+              cacheCreation5mInputTokens: turn.cacheWrite5m,
+              cacheCreation1hInputTokens: turn.cacheWrite1h,
+              webSearchRequests: turn.webSearchRequests,
+              costUSD: 0,
+            });
 
             Sentry.startSpan(
               {
@@ -383,11 +394,7 @@ export const claudeRuntime: Runtime = {
                   'gen_ai.agent.name': skillName,
                   'gen_ai.request.model': modelId,
                   'gen_ai.response.model': turn.model,
-                  'gen_ai.usage.input_tokens': totalInput,
-                  'gen_ai.usage.output_tokens': turn.outputTokens,
-                  'gen_ai.usage.input_tokens.cached': turn.cacheRead,
-                  'gen_ai.usage.input_tokens.cache_write': turn.cacheWrite,
-                  'gen_ai.usage.total_tokens': totalInput + turn.outputTokens,
+                  ...usageAttrs,
                 },
               },
               () => {

--- a/packages/warden/src/sentry.test.ts
+++ b/packages/warden/src/sentry.test.ts
@@ -141,11 +141,73 @@ describe('sentry telemetry scope', () => {
       unit: '{token}',
       attributes: expect.objectContaining({
         'gen_ai.operation.name': 'invoke_agent',
-        'gen_ai.provider.name': 'xai',
+        'gen_ai.provider.name': 'x_ai',
         'gen_ai.request.model': 'xai/grok-test',
         'gen_ai.token.type': 'input',
         'warden.runtime.name': 'pi',
       }),
     });
+  });
+
+  it('emits Warden token and cost components for cached-token accounting', async () => {
+    const sentry = await loadInitializedSentry();
+
+    sentry.emitSkillMetrics({
+      skill: 'security-review',
+      summary: 'No findings',
+      findings: [],
+      runtime: 'claude',
+      model: 'claude-haiku-4-5',
+      durationMs: 1200,
+      usage: {
+        inputTokens: 1300,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        cacheCreation5mInputTokens: 100,
+        cacheCreation1hInputTokens: 0,
+        webSearchRequests: 0,
+        costUSD: 0.003645,
+      },
+    });
+
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('gen_ai.client.token.usage', 1300, {
+      unit: '{token}',
+      attributes: expect.objectContaining({
+        'gen_ai.token.type': 'input',
+      }),
+    });
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 1000, {
+      unit: '{token}',
+      attributes: expect.objectContaining({
+        'warden.gen_ai.token.category': 'standard_input',
+      }),
+    });
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 200, {
+      unit: '{token}',
+      attributes: expect.objectContaining({
+        'warden.gen_ai.token.category': 'cache_read_input',
+      }),
+    });
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 100, {
+      unit: '{token}',
+      attributes: expect.objectContaining({
+        'warden.gen_ai.token.category': 'cache_creation_5m_input',
+      }),
+    });
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.cost.component.usd', 0.00002, {
+      attributes: expect.objectContaining({
+        'warden.gen_ai.cost.component': 'cache_read_input',
+      }),
+    });
+    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith(
+      'warden.gen_ai.cost.component.usd',
+      0.000125,
+      {
+        attributes: expect.objectContaining({
+          'warden.gen_ai.cost.component': 'cache_creation_5m_input',
+        }),
+      }
+    );
   });
 });

--- a/packages/warden/src/sentry.ts
+++ b/packages/warden/src/sentry.ts
@@ -3,6 +3,7 @@ import type { Severity, SkillReport } from './types/index.js';
 import { SEVERITY_ORDER } from './types/index.js';
 import { getVersion } from './utils/index.js';
 import { genAiProviderName } from './sdk/otel.js';
+import { estimateUsageCostBreakdown } from './sdk/pricing.js';
 
 export type SentryContext = 'cli' | 'action';
 
@@ -151,6 +152,73 @@ function agentMetricAttributes(skill: string, model?: string, runtime?: string):
   return attrs;
 }
 
+function usageTokenComponents(usage: SkillReport['usage']): { category: string; tokens: number }[] {
+  if (!usage) return [];
+  const cacheReadInputTokens = usage.cacheReadInputTokens ?? 0;
+  const cacheCreation5mInputTokens = usage.cacheCreation5mInputTokens ?? 0;
+  const cacheCreation1hInputTokens = usage.cacheCreation1hInputTokens ?? 0;
+  const cacheCreationInputTokens = Math.max(
+    usage.cacheCreationInputTokens ?? 0,
+    cacheCreation5mInputTokens + cacheCreation1hInputTokens,
+  );
+  const categorizedCacheCreationInputTokens = cacheCreation5mInputTokens + cacheCreation1hInputTokens;
+  const uncategorizedCacheCreationInputTokens = Math.max(
+    0,
+    cacheCreationInputTokens - categorizedCacheCreationInputTokens,
+  );
+  const standardInputTokens = Math.max(
+    0,
+    usage.inputTokens - cacheReadInputTokens - cacheCreationInputTokens,
+  );
+
+  return [
+    { category: 'standard_input', tokens: standardInputTokens },
+    { category: 'cache_read_input', tokens: cacheReadInputTokens },
+    {
+      category: 'cache_creation_5m_input',
+      tokens: cacheCreation5mInputTokens + uncategorizedCacheCreationInputTokens,
+    },
+    { category: 'cache_creation_1h_input', tokens: cacheCreation1hInputTokens },
+    { category: 'output', tokens: usage.outputTokens },
+  ];
+}
+
+function emitUsageComponentMetrics(attrs: TelemetryAttributes, usage: SkillReport['usage']): void {
+  for (const { category, tokens } of usageTokenComponents(usage)) {
+    if (tokens <= 0) continue;
+    Sentry.metrics.distribution('warden.gen_ai.token.usage', tokens, {
+      unit: '{token}',
+      attributes: { ...attrs, 'warden.gen_ai.token.category': category },
+    });
+  }
+}
+
+function emitCostComponentMetrics(
+  attrs: TelemetryAttributes,
+  model: string | undefined,
+  usage: SkillReport['usage'],
+): void {
+  if (!usage) return;
+  const breakdown = estimateUsageCostBreakdown(model, usage);
+  if (!breakdown) return;
+
+  const components = [
+    { component: 'standard_input', costUSD: breakdown.freshInputUSD },
+    { component: 'cache_read_input', costUSD: breakdown.cacheReadUSD },
+    { component: 'cache_creation_5m_input', costUSD: breakdown.cacheCreationUSD + breakdown.cacheCreation5mUSD },
+    { component: 'cache_creation_1h_input', costUSD: breakdown.cacheCreation1hUSD },
+    { component: 'output', costUSD: breakdown.outputUSD },
+    { component: 'web_search', costUSD: breakdown.webSearchUSD },
+  ];
+
+  for (const { component, costUSD } of components) {
+    if (costUSD <= 0) continue;
+    Sentry.metrics.distribution('warden.gen_ai.cost.component.usd', costUSD, {
+      attributes: { ...attrs, 'warden.gen_ai.cost.component': component },
+    });
+  }
+}
+
 /**
  * Emit a single run count. Call once per analysis workflow execution.
  * Inherits warden.source, repository, and GitHub Actions attributes from global scope.
@@ -184,6 +252,8 @@ export function emitSkillMetrics(report: SkillReport): void {
         unit: '{token}',
         attributes: { ...tokenAttrs, 'gen_ai.token.type': 'output' },
       });
+      emitUsageComponentMetrics(tokenAttrs, report.usage);
+      emitCostComponentMetrics(attrs, report.model, report.usage);
       if (report.usage.costUSD) {
         Sentry.metrics.distribution('warden.gen_ai.cost.usd', report.usage.costUSD, { attributes: attrs });
       }

--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -131,15 +131,14 @@ The `gen_ai.invoke_agent` span on `executeQuery()` carries attributes for Sentry
 |-----------|--------|------|
 | `gen_ai.usage.input_tokens` | Uncached input + cache read + cache write | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/). **Total** input tokens, not just uncached. |
 | `gen_ai.usage.output_tokens` | `resultMessage.usage.output_tokens` | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
-| `gen_ai.usage.input_tokens.cached` | Cache-read input tokens | Sentry AI Agents |
-| `gen_ai.usage.input_tokens.cache_write` | Cache-write input tokens | Sentry AI Agents |
-| `gen_ai.usage.total_tokens` | `input_tokens + output_tokens` (after totaling) | OTel GenAI |
+| `gen_ai.usage.cache_read.input_tokens` | Cache-read input tokens | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
+| `gen_ai.usage.cache_creation.input_tokens` | Cache-write input tokens | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
 | `gen_ai.response.id` | `resultMessage.uuid` | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
 | `gen_ai.response.model` | Actual response model | [OTel recommended](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) |
 | `gen_ai.response.finish_reasons` | Provider stop reason array | OTel GenAI |
 | `gen_ai.output.messages` | Stringified normalized assistant message array | OTel GenAI |
 
-**Token accounting:** Provider usage can split input into uncached input, cache-read input, and cache-write input. Anthropic exposes these as `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens`; Pi exposes the same normalized shape as `input`, `cacheRead`, and `cacheWrite`. The `gen_ai.usage.input_tokens` attribute represents the *total* input tokens, so Warden sums all three and records the cache subsets with Sentry's `gen_ai.usage.input_tokens.*` attributes. Setting the top-level field to only the uncached value underreports spend and makes cache accounting ambiguous.
+**Token accounting:** Provider usage can split input into uncached input, cache-read input, and cache-write input. Anthropic exposes these as `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens`; Pi exposes the same normalized shape as `input`, `cacheRead`, and `cacheWrite`. The `gen_ai.usage.input_tokens` attribute represents the *total* input tokens, so Warden sums all three and records the cache subsets with OTel's `gen_ai.usage.cache_*` attributes. Setting the top-level field to only the uncached value underreports usage and makes cache accounting ambiguous.
 
 ### SDK-specific attributes
 
@@ -162,9 +161,8 @@ Created from `SDKAssistantMessage` events streamed by `query()`. Each span repre
 | `gen_ai.response.model` | `message.message.model` | Actual model used for this turn |
 | `gen_ai.usage.input_tokens` | `input + cache_read + cache_write` | Total input tokens (same accounting as parent) |
 | `gen_ai.usage.output_tokens` | `message.message.usage.output_tokens` | Output tokens for this turn |
-| `gen_ai.usage.input_tokens.cached` | `message.message.usage.cache_read_input_tokens` | Cache read subset |
-| `gen_ai.usage.input_tokens.cache_write` | `message.message.usage.cache_creation_input_tokens` | Cache write subset |
-| `gen_ai.usage.total_tokens` | `input + output` | Total tokens for this turn |
+| `gen_ai.usage.cache_read.input_tokens` | `message.message.usage.cache_read_input_tokens` | Cache read subset |
+| `gen_ai.usage.cache_creation.input_tokens` | `message.message.usage.cache_creation_input_tokens` | Cache write subset |
 
 ### Per-tool `gen_ai.execute_tool` attributes
 
@@ -325,8 +323,12 @@ scheduled workflow execution.
 |--------|------|-----------------------|
 | `warden.skill.duration` | distribution (ms) | `gen_ai.agent.name`, `gen_ai.request.model`, `warden.runtime.name` |
 | `gen_ai.client.token.usage` | distribution (`{token}`) | `gen_ai.agent.name`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.token.type`, `warden.runtime.name` |
+| `warden.gen_ai.token.usage` | distribution (`{token}`) | `gen_ai.agent.name`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.provider.name`, `warden.runtime.name`, `warden.gen_ai.token.category` |
 | `warden.gen_ai.cost.usd` | distribution | `gen_ai.agent.name`, `gen_ai.request.model`, `warden.runtime.name` |
+| `warden.gen_ai.cost.component.usd` | distribution | `gen_ai.agent.name`, `gen_ai.request.model`, `warden.runtime.name`, `warden.gen_ai.cost.component` |
 | `warden.findings` | count | `gen_ai.agent.name`, `gen_ai.request.model`, `warden.runtime.name`, `warden.finding.severity` |
+
+`gen_ai.client.token.usage` follows current OTel semantics and emits only total `input` and `output` token histograms. Cache-sensitive dashboards must use Warden component metrics: `warden.gen_ai.token.usage` emits mutually exclusive token categories (`standard_input`, `cache_read_input`, `cache_creation_5m_input`, `cache_creation_1h_input`, `output`), and `warden.gen_ai.cost.component.usd` emits estimated relative-cost components when Warden has local pricing for the model.
 
 `gen_ai.request.model` is included when `report.model` is set (i.e. when the caller specifies a model). `warden.runtime.name` is included when the report runtime is known (`claude` or `pi`).
 
@@ -399,12 +401,12 @@ Called from `evaluateFixesAndResolveStale` when stale comments are resolved. Emi
 
 1. **No-op when disabled.** Every function checks `initialized` first. No env var = no overhead.
 2. **Never break the workflow.** All metric emission and span attribute setting is wrapped in try/catch. Telemetry failures are swallowed silently.
-3. **Follow OTel conventions.** Use OTel semantic attributes (`vcs.*`, `code.*`, `cicd.*`, `gen_ai.*`) where they exist. Use `warden.*` only for Warden-specific concepts that OTel does not define. When OTel and Sentry conventions diverge, follow [Sentry's AI Agents module spec](https://develop.sentry.dev/sdk/telemetry/traces/modules/ai-agents/) as the source of truth for what Sentry actually processes.
+3. **Follow OTel conventions.** Use OTel semantic attributes (`vcs.*`, `code.*`, `cicd.*`, `gen_ai.*`) where they exist. Use `warden.*` only for Warden-specific concepts that OTel does not define. When OTel and a vendor-specific convention diverge, prefer the current OTel GenAI semantic convention and keep vendor-specific additions under `warden.*`.
 4. **Do not emit compatibility aliases.** The same concept must have one canonical attribute name. Breaking telemetry queries is preferable to preserving conflicting semantics.
 5. **Auto-instrument where possible.** Direct provider API calls and HTTP requests are handled by Sentry integrations where available. Manual spans are only for coding-agent runtime wrappers and internal orchestration.
 6. **Attributes over events.** Prefer span attributes to separate events. Attributes are searchable in Sentry and don't create noise.
 7. **Breadcrumbs for retries.** Retry attempts are breadcrumbs (not spans) because they're supplementary context for the parent span, not independent operations.
-8. **Tokens are totals, subfields are subsets.** `gen_ai.usage.input_tokens` is the total count including cached input. `gen_ai.usage.input_tokens.cached` and `gen_ai.usage.input_tokens.cache_write` are subsets. Never set the top-level field to only the uncached count.
+8. **Tokens are totals, subfields are subsets.** `gen_ai.usage.input_tokens` is the total count including cached input. `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens` are subsets. Never set the top-level field to only the uncached count.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update GenAI span usage attributes to current OTel cache field names
- Keep `gen_ai.client.token.usage` limited to total input/output volume
- Add Warden token and cost component metrics so cached usage stays distinct from fresh input
- Refresh telemetry docs and regression tests to match the new semantics

## Testing
- `pnpm exec vitest run packages/warden/src/sdk/otel.test.ts packages/warden/src/sdk/haiku.test.ts packages/warden/src/sentry.test.ts`
- `pnpm exec tsc -p packages/warden/tsconfig.json --noEmit`
- `pnpm lint`
- `pnpm build`
- `pnpm test` ran, but still fails in unrelated existing tests: `src/cli/files.test.ts` and `src/sdk/local.resolve.test.ts`