### PR TITLE
feat(cli): Add explicit Claude runtime selection

### DIFF
--- a/packages/docs/src/content/docs/cli/run.mdx
+++ b/packages/docs/src/content/docs/cli/run.mdx
@@ -27,6 +27,7 @@ The bare `warden` command is an alias for this command.
 | `--config-path <path>` | Path to `warden.toml`, or a directory containing it. `--config` is a deprecated alias. |
 | `-m, --model <model>` | Model fallback when `warden.toml` does not specify one. See [Models and Runtimes](/config/models/). |
 | `--effort <level>` | Override effort level for this run. Values: `off`, `low`, `medium`, `high`, `xhigh`. |
+| `--runtime <claude\|pi>` | Runtime backend for model-backed execution. |
 | `--json` | Output results as JSON. |
 | `-o, --output <path>` | Write full run output to a JSONL file. |
 | `--fail-on <severity>` | Exit with code 1 if findings meet this severity. |

--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -119,7 +119,8 @@ lane. Prefer `defaults.agent.model` and `defaults.agent.maxTurns` in new config.
 
 `defaults.agent.effort` optionally controls repo-aware skill effort
 across runtimes. Supported values are `off`, `low`, `medium`, `high`, and
-`xhigh`. When omitted, each runtime uses its own default.
+`xhigh`. When omitted, Warden sends explicit `high` adaptive thinking to the
+Claude runtime; Pi uses its own default thinking level.
 
 ## Overrides
 

--- a/packages/warden/src/cli/args.test.ts
+++ b/packages/warden/src/cli/args.test.ts
@@ -77,6 +77,13 @@ describe('parseCliArgs', () => {
     expect(result.options.skill).toBe('security-review');
   });
 
+  it('parses --runtime option', () => {
+    const result = parseCliArgs(['src/auth.ts', '--skill', 'code-review', '--runtime', 'claude']);
+    expect(result.options.targets).toEqual(['src/auth.ts']);
+    expect(result.options.skill).toBe('code-review');
+    expect(result.options.runtime).toBe('claude');
+  });
+
   it('parses --config-path option', () => {
     const result = parseCliArgs(['--config-path', './custom.toml']);
     expect(result.options.configPath).toBe('./custom.toml');

--- a/packages/warden/src/cli/args.ts
+++ b/packages/warden/src/cli/args.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { EffortSchema, type Effort } from '../config/schema.js';
 import { SeverityThresholdSchema, ConfidenceThresholdSchema } from '../types/index.js';
 import type { SeverityThreshold, ConfidenceThreshold } from '../types/index.js';
+import { RuntimeNameSchema } from '../sdk/runtimes/types.js';
 import { getVersion } from '../utils/index.js';
 import type { HelpTarget } from './help.js';
 
@@ -28,6 +29,8 @@ export const CLIOptionsSchema = z.object({
   model: z.string().optional(),
   /** Effort level to use for this run */
   effort: EffortSchema.optional(),
+  /** Runtime backend for model-backed execution */
+  runtime: RuntimeNameSchema.optional(),
   // Verbosity options
   quiet: z.boolean().default(false),
   verbose: z.number().default(0),
@@ -315,6 +318,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       config: { type: 'string' }, // deprecated alias for --config-path
       model: { type: 'string', short: 'm' },
       'effort': { type: 'string' },
+      runtime: { type: 'string' },
       json: { type: 'boolean', default: false },
       output: { type: 'string', short: 'o' },
       'fail-on': { type: 'string' },
@@ -516,6 +520,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
         typeof values.config === 'string' ? values.config : undefined,
       model: typeof values.model === 'string' ? values.model : undefined,
       effort: values['effort'] as Effort | undefined,
+      runtime: typeof values.runtime === 'string' ? values.runtime : undefined,
       json: Boolean(values.json),
       output: typeof values.output === 'string' ? values.output : undefined,
       failOn: values['fail-on'] as SeverityThreshold | undefined,

--- a/packages/warden/src/cli/auth-flow.test.ts
+++ b/packages/warden/src/cli/auth-flow.test.ts
@@ -1,10 +1,11 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EventContext } from '../types/index.js';
 import { verifyAuth } from '../sdk/runner.js';
 import type * as RunnerModule from '../sdk/runner.js';
+import { WardenAuthenticationError } from '../sdk/errors.js';
 import { CLIOptionsSchema } from './args.js';
 import { runSkills } from './main.js';
 import { Reporter, Verbosity } from './output/index.js';
@@ -57,6 +58,7 @@ describe('runSkills auth flow', () => {
     process.env = { ...originalEnv };
     delete process.env['WARDEN_ANTHROPIC_API_KEY'];
     delete process.env['ANTHROPIC_API_KEY'];
+    delete process.env['CLAUDE_CODE_PATH'];
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     verifyAuthMock.mockReset();
   });
@@ -112,5 +114,64 @@ describe('runSkills auth flow', () => {
       message: 'Pi runtime model for security-review must use provider/model format: claude-sonnet-4-5',
     });
     expect(verifyAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('checks Claude auth for CLI runtime override and forwards CLAUDE_CODE_PATH', async () => {
+    const fakeClaudePath = join(tempDir, 'fake-claude');
+    process.env['CLAUDE_CODE_PATH'] = fakeClaudePath;
+    verifyAuthMock.mockImplementation(() => {
+      throw new WardenAuthenticationError('missing auth');
+    });
+
+    const exitCode = await runSkills(
+      makeContext(tempDir),
+      CLIOptionsSchema.parse({
+        targets: ['src/example.ts'],
+        skill: 'security-review',
+        runtime: 'claude',
+        quiet: true,
+      }),
+      new Reporter({ isTTY: false, supportsColor: false, columns: 80 }, Verbosity.Quiet)
+    );
+
+    expect(exitCode).toBe(1);
+    expect(verifyAuthMock).toHaveBeenCalledWith({
+      apiKey: undefined,
+      pathToClaudeCodeExecutable: fakeClaudePath,
+    });
+  });
+
+  it('checks Claude auth for config default runtime', async () => {
+    const configPath = join(tempDir, 'warden.toml');
+    writeFileSync(configPath, [
+      'version = 1',
+      '',
+      '[defaults]',
+      'runtime = "claude"',
+      '',
+      '[[skills]]',
+      'name = "security-review"',
+      '',
+    ].join('\n'));
+    verifyAuthMock.mockImplementation(() => {
+      throw new WardenAuthenticationError('missing auth');
+    });
+
+    const exitCode = await runSkills(
+      makeContext(tempDir),
+      CLIOptionsSchema.parse({
+        targets: ['src/example.ts'],
+        skill: 'security-review',
+        configPath,
+        quiet: true,
+      }),
+      new Reporter({ isTTY: false, supportsColor: false, columns: 80 }, Verbosity.Quiet)
+    );
+
+    expect(exitCode).toBe(1);
+    expect(verifyAuthMock).toHaveBeenCalledWith({
+      apiKey: undefined,
+      pathToClaudeCodeExecutable: undefined,
+    });
   });
 });

--- a/packages/warden/src/cli/help.ts
+++ b/packages/warden/src/cli/help.ts
@@ -6,6 +6,7 @@ type HelpOptionId =
   | 'configPath'
   | 'model'
   | 'effort'
+  | 'runtime'
   | 'json'
   | 'output'
   | 'failOn'
@@ -100,6 +101,10 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
     label: '--effort <level>',
     description: 'Override effort level for this run',
     continuation: 'Values: off, low, medium, high, xhigh',
+  },
+  runtime: {
+    label: '--runtime <claude|pi>',
+    description: 'Runtime backend for model-backed execution',
   },
   json: {
     label: '--json',
@@ -243,6 +248,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
       'configPath',
       'model',
       'effort',
+      'runtime',
       'json',
       'output',
       'failOn',

--- a/packages/warden/src/cli/main.ts
+++ b/packages/warden/src/cli/main.ts
@@ -625,17 +625,18 @@ function emitInvalidPiModelSelectorRunLog(
 
 function verifyClaudeAuthForRun(args: {
   apiKey?: string;
+  pathToClaudeCodeExecutable?: string;
   reporter: Reporter;
   repoPath: string;
   options: CLIOptions;
 }): boolean {
-  const { apiKey, reporter, repoPath, options } = args;
+  const { apiKey, pathToClaudeCodeExecutable, reporter, repoPath, options } = args;
   if (!apiKey) {
     reporter.debug('No API key found. Using Claude Code local auth.');
   }
 
   try {
-    verifyAuth({ apiKey });
+    verifyAuth({ apiKey, pathToClaudeCodeExecutable });
     return true;
   } catch (error: unknown) {
     const message = (error as WardenAuthenticationError).message;
@@ -764,6 +765,10 @@ export function resolveCliDefaultSynthesisModel(
     emptyToUndefined(config?.defaults?.synthesis?.model) ??
     resolveCliDefaultAuxiliaryModel(config)
   );
+}
+
+function resolveClaudeCodeExecutablePath(): string | undefined {
+  return emptyToUndefined(process.env['CLAUDE_CODE_PATH']);
 }
 
 /** Resolve the model label recorded in JSONL output, including the default sentinel. */
@@ -959,6 +964,8 @@ export async function runSkills(
   const defaultAuxiliaryModel = resolveCliDefaultAuxiliaryModel(config);
   const defaultSynthesisModel = resolveCliDefaultSynthesisModel(config);
   const defaultEffort = resolveCliEffort(config, options.effort);
+  const defaultRuntime = options.runtime ?? config?.defaults?.runtime ?? 'pi';
+  const pathToClaudeCodeExecutable = resolveClaudeCodeExecutablePath();
 
   // Determine which triggers/skills to run
   let skillsToRun: SkillToRun[];
@@ -979,7 +986,7 @@ export async function runSkills(
       model: match?.model ?? defaultModel,
       maxTurns: match?.maxTurns ?? config?.defaults?.agent?.maxTurns ?? config?.defaults?.maxTurns,
       effort: options.effort ?? match?.effort ?? defaultEffort,
-      runtime: match?.runtime ?? config?.defaults?.runtime ?? 'pi',
+      runtime: options.runtime ?? match?.runtime ?? config?.defaults?.runtime ?? 'pi',
       auxiliaryModel: match?.auxiliaryModel ?? defaultAuxiliaryModel,
       synthesisModel: match?.synthesisModel ?? defaultSynthesisModel,
       auxiliaryMaxRetries:
@@ -1006,8 +1013,8 @@ export async function runSkills(
         filters: t.filters,
         model: t.model,
         maxTurns: t.maxTurns,
+        runtime: options.runtime ?? t.runtime,
         effort: options.effort ?? t.effort,
-        runtime: t.runtime,
         auxiliaryModel: t.auxiliaryModel,
         synthesisModel: t.synthesisModel,
         auxiliaryMaxRetries: t.auxiliaryMaxRetries,
@@ -1033,6 +1040,7 @@ export async function runSkills(
 
   if (needsClaudeAuth(skillsToRun) && !verifyClaudeAuthForRun({
     apiKey,
+    pathToClaudeCodeExecutable,
     reporter,
     repoPath: repoPath ?? cwd,
     options,
@@ -1049,7 +1057,8 @@ export async function runSkills(
   const runnerOptions: SkillRunnerOptions = {
     apiKey,
     model: sdkModel,
-    runtime: config?.defaults?.runtime ?? 'pi',
+    runtime: defaultRuntime,
+    pathToClaudeCodeExecutable,
     auxiliaryModel: defaultAuxiliaryModel,
     synthesisModel: defaultSynthesisModel,
     abortController,
@@ -1358,9 +1367,14 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
 
   // Claude runtime can fall back to local Claude Code auth.
   const apiKey = getAnthropicApiKey();
+  const pathToClaudeCodeExecutable = resolveClaudeCodeExecutablePath();
 
-  if (needsClaudeAuth(triggersToRun) && !verifyClaudeAuthForRun({
+  const triggerRuntimes = triggersToRun.map((trigger) => ({
+    runtime: options.runtime ?? trigger.runtime,
+  }));
+  if (needsClaudeAuth(triggerRuntimes) && !verifyClaudeAuthForRun({
     apiKey,
+    pathToClaudeCodeExecutable,
     reporter,
     repoPath,
     options,
@@ -1382,7 +1396,8 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
     runnerOptions: {
       apiKey,
       model: trigger.model,
-      runtime: trigger.runtime,
+      runtime: options.runtime ?? trigger.runtime,
+      pathToClaudeCodeExecutable,
       effort: options.effort ?? trigger.effort,
       auxiliaryModel: trigger.auxiliaryModel,
       synthesisModel: trigger.synthesisModel,

--- a/packages/warden/src/sdk/auth.test.ts
+++ b/packages/warden/src/sdk/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { verifyAuth } from './auth.js';
 import { WardenAuthenticationError } from './errors.js';
 import { ExecError } from '../utils/exec.js';
@@ -16,6 +16,10 @@ import { execFileNonInteractive } from '../utils/exec.js';
 const mockExec = vi.mocked(execFileNonInteractive);
 
 describe('verifyAuth', () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
   it('returns immediately when API key is provided', () => {
     verifyAuth({ apiKey: 'sk-test-key' });
     expect(mockExec).not.toHaveBeenCalled();
@@ -25,6 +29,15 @@ describe('verifyAuth', () => {
     mockExec.mockReturnValue('1.0.0');
     verifyAuth({ apiKey: undefined });
     expect(mockExec).toHaveBeenCalledWith('claude', ['--version'], { timeout: 5000 });
+  });
+
+  it('checks configured Claude Code executable path when provided', () => {
+    mockExec.mockReturnValue('1.0.0');
+    verifyAuth({
+      apiKey: undefined,
+      pathToClaudeCodeExecutable: '/private/tmp/claude',
+    });
+    expect(mockExec).toHaveBeenCalledWith('/private/tmp/claude', ['--version'], { timeout: 5000 });
   });
 
   it('throws WardenAuthenticationError when claude binary is missing', () => {

--- a/packages/warden/src/sdk/auth.ts
+++ b/packages/warden/src/sdk/auth.ts
@@ -5,20 +5,27 @@ import { WardenAuthenticationError } from './errors.js';
  * Pre-flight auth check: verify that authentication will work before starting analysis.
  *
  * - If an API key is provided, returns immediately (direct API auth).
- * - If no API key, verifies the `claude` binary exists on PATH so the SDK
- *   can use local Claude Code auth. Throws WardenAuthenticationError
- *   if the binary is missing.
+ * - If no API key, verifies the configured Claude Code executable, or the
+ *   `claude` binary on PATH, so the SDK can use local Claude Code auth.
+ *   Throws WardenAuthenticationError if the binary is missing.
  *
  * This catches the most common failure mode (binary not installed) early.
  * Subtler failures (binary exists but sandbox blocks IPC) are caught by the
  * isSubprocessError() handler in analyzeHunk().
  */
-export function verifyAuth({ apiKey }: { apiKey?: string }): void {
+export function verifyAuth({
+  apiKey,
+  pathToClaudeCodeExecutable,
+}: {
+  apiKey?: string;
+  pathToClaudeCodeExecutable?: string;
+}): void {
   // Direct API auth — no subprocess needed
   if (apiKey) return;
 
+  const executable = pathToClaudeCodeExecutable ?? 'claude';
   try {
-    execFileNonInteractive('claude', ['--version'], { timeout: 5000 });
+    execFileNonInteractive(executable, ['--version'], { timeout: 5000 });
   } catch (error) {
     // execFileNonInteractive wraps spawn failures in ExecError.
     // The original error message (e.g., "spawn claude ENOENT") is in ExecError.stderr.
@@ -28,8 +35,9 @@ export function verifyAuth({ apiKey }: { apiKey?: string }): void {
         : (error as NodeJS.ErrnoException).code === 'ENOENT';
     if (isNotFound) {
       throw new WardenAuthenticationError(
-        'Claude Code CLI not found on PATH.\n' +
-        'Either install Claude Code (https://claude.ai/install.sh) or set an API key.',
+        'Claude Code CLI not found on PATH or configured path.\n' +
+        'Either install Claude Code (https://claude.ai/install.sh), ' +
+        'set WARDEN_ANTHROPIC_API_KEY, or set ANTHROPIC_API_KEY.',
         { cause: error }
       );
     }

--- a/packages/warden/src/sdk/runtimes/claude.test.ts
+++ b/packages/warden/src/sdk/runtimes/claude.test.ts
@@ -185,6 +185,28 @@ describe('claudeRuntime.runSkill', () => {
     });
   });
 
+  it('uses explicit high Claude adaptive thinking when reasoning effort is omitted', async () => {
+    mockQuery.mockReturnValue(mockStream([successResult()]));
+
+    await claudeRuntime.runSkill({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      repoPath: '/repo',
+      skillName: 'test-skill',
+      options: {
+        model: 'claude-test',
+      },
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith({
+      prompt: 'user',
+      options: expect.objectContaining({
+        effort: 'high',
+        thinking: { type: 'adaptive' },
+      }),
+    });
+  });
+
   it('can disable Claude thinking', async () => {
     mockQuery.mockReturnValue(mockStream([successResult()]));
 

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -64,6 +64,7 @@ const DEFAULT_READ_ONLY_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob'];
 const READ_ONLY_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
 const MUTATING_TOOLS = ['Write', 'Edit', 'Bash'] as const;
 const CLAUDE_AGENT_TOOLS = ['Task', 'TodoWrite'] as const;
+const DEFAULT_CLAUDE_EFFORT: EffortLevel = 'high';
 
 function getClaudeProviderOptions(providerOptions: unknown): ClaudeProviderOptions {
   if (!providerOptions || typeof providerOptions !== 'object') {
@@ -82,13 +83,10 @@ function effortOptions(effort: SkillRunRequest['options']['effort']): {
   thinking?: { type: 'adaptive' } | { type: 'disabled' };
   effort?: EffortLevel;
 } {
-  if (!effort) {
-    return {};
-  }
   if (effort === 'off') {
     return { thinking: { type: 'disabled' } };
   }
-  return { thinking: { type: 'adaptive' }, effort };
+  return { thinking: { type: 'adaptive' }, effort: effort ?? DEFAULT_CLAUDE_EFFORT };
 }
 
 function missingApiKeyResult<T>(kind: 'auxiliary' | 'synthesis'): AuxiliaryRunResult<T> {

--- a/packages/warden/src/sdk/types.ts
+++ b/packages/warden/src/sdk/types.ts
@@ -104,7 +104,7 @@ export interface SkillRunnerOptions {
   batchDelayMs?: number;
   /** Model to use for analysis (e.g., 'openai/gpt-5.5'). Uses SDK default if not specified. */
   model?: string;
-  /** Effort level to use for analysis. Uses SDK default if not specified. */
+  /** Effort level to use for analysis. Uses the runtime-specific default if not specified. */
   effort?: Effort;
   /** Runtime backend for all model-backed execution. Defaults to Pi. */
   runtime?: RuntimeName;

--- a/skills/warden/references/config-schema.md
+++ b/skills/warden/references/config-schema.md
@@ -38,7 +38,7 @@ ignorePaths = ["*.test.ts"]           # Exclude matching files
 [defaults.agent]
 model = "openai/gpt-5.5"              # Default repo-aware analysis model
 maxTurns = 50                         # Max agentic turns per hunk
-reasoningEffort = "medium"            # off | low | medium | high | xhigh
+effort = "medium"                     # off | low | medium | high | xhigh
 
 [defaults.auxiliary]
 model = "anthropic/claude-haiku-4-5"  # Helper model for extraction and fix gates
@@ -60,7 +60,7 @@ pattern = "*.config.*"         # Glob pattern
 mode = "whole-file"            # per-hunk | whole-file | skip
 ```
 
-`[defaults.agent].reasoningEffort` controls repo-aware skill reasoning across runtimes. When omitted, each runtime uses its own default.
+`[defaults.agent].effort` controls repo-aware skill reasoning across runtimes. When omitted, Warden sends explicit `high` adaptive thinking to the Claude runtime; Pi uses its own default thinking level.
 
 `[defaults.synthesis].model` falls back to `[defaults.auxiliary].model` when omitted. Legacy `[defaults].model` and `[defaults].maxTurns` are still supported as analysis fallbacks.
 

--- a/skills/warden/references/configuration.md
+++ b/skills/warden/references/configuration.md
@@ -21,7 +21,7 @@ version = 1
 
 [defaults.agent]
 model = "openai/gpt-5.5"
-reasoningEffort = "medium"
+effort = "medium"
 
 [[skills]]
 name = "my-skill"           # matches .agents/skills/my-skill/SKILL.md
@@ -94,7 +94,7 @@ Warden uses different model lanes for different kinds of work:
 
 If `[defaults.synthesis].model` is omitted, synthesis falls back to `[defaults.auxiliary].model`.
 
-`[defaults.agent].reasoningEffort` optionally controls repo-aware skill reasoning across runtimes. Supported values are `off`, `low`, `medium`, `high`, and `xhigh`. When omitted, each runtime uses its own default.
+`[defaults.agent].effort` optionally controls repo-aware skill reasoning across runtimes. Supported values are `off`, `low`, `medium`, `high`, and `xhigh`. When omitted, Warden sends explicit `high` adaptive thinking to the Claude runtime; Pi uses its own default thinking level.
 
 ## Model Precedence
 
@@ -138,6 +138,6 @@ preferred in CI so they do not collide with locally-set provider keys.
 
 **Token/cost issues:**
 - Reduce `maxTurns` (default: 50)
-- Lower `[defaults.agent].reasoningEffort` when the runtime supports cheaper reasoning levels
+- Lower `[defaults.agent].effort` when the runtime supports cheaper reasoning levels
 - Use chunking settings to control chunk size
 - Filter to relevant files with `paths`


### PR DESCRIPTION
Add an explicit runtime override to `warden run` so local runs and benchmarks can force Claude or Pi instead of relying only on config defaults. Claude runs without a configured reasoning effort now send explicit high adaptive thinking, while Pi keeps its own default thinking level.

**Runtime Selection**

`--runtime <claude|pi>` is parsed, documented, and applied to explicit skill runs and config-triggered runs. Claude auth preflight also forwards `CLAUDE_CODE_PATH` so custom Claude Code installations use the same executable path for auth and SDK execution.

**Claude Reasoning Default**

The Claude runtime now sends adaptive thinking with `high` effort when `reasoningEffort` is omitted. Explicit efforts still pass through, and `off` still disables thinking.
