### PR TITLE
feat(traces): Capture run traces in output

### DIFF
--- a/packages/warden/src/cli/args.test.ts
+++ b/packages/warden/src/cli/args.test.ts
@@ -109,6 +109,11 @@ describe('parseCliArgs', () => {
     expect(result.options.json).toBe(true);
   });
 
+  it('parses --traces flag', () => {
+    const result = parseCliArgs(['--traces']);
+    expect(result.options.traces).toBe(true);
+  });
+
   it('parses --fail-on option', () => {
     const result = parseCliArgs(['--fail-on', 'high']);
     expect(result.options.failOn).toBe('high');

--- a/packages/warden/src/cli/args.ts
+++ b/packages/warden/src/cli/args.ts
@@ -15,6 +15,8 @@ export const CLIOptionsSchema = z.object({
   json: z.boolean().default(false),
   /** Write full run output to a JSONL file */
   output: z.string().optional(),
+  /** Include per-hunk runtime traces in structured run output */
+  traces: z.boolean().default(false),
   failOn: SeverityThresholdSchema.optional(),
   /** Only show findings at or above this severity in output */
   reportOn: SeverityThresholdSchema.optional(),
@@ -313,6 +315,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       model: { type: 'string', short: 'm' },
       json: { type: 'boolean', default: false },
       output: { type: 'string', short: 'o' },
+      traces: { type: 'boolean', default: false },
       'fail-on': { type: 'string' },
       'report-on': { type: 'string' },
       'min-confidence': { type: 'string' },
@@ -513,6 +516,7 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): ParsedArgs
       model: typeof values.model === 'string' ? values.model : undefined,
       json: Boolean(values.json),
       output: typeof values.output === 'string' ? values.output : undefined,
+      traces: Boolean(values.traces),
       failOn: values['fail-on'] as SeverityThreshold | undefined,
       reportOn: values['report-on'] as SeverityThreshold | undefined,
       minConfidence: values['min-confidence'] as ConfidenceThreshold | undefined,

--- a/packages/warden/src/cli/commands/build.test.ts
+++ b/packages/warden/src/cli/commands/build.test.ts
@@ -68,6 +68,7 @@ function createTestReporter(): Reporter {
 function createOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
   return {
     json: false,
+    traces: false,
     help: false,
     quiet: false,
     verbose: 0,

--- a/packages/warden/src/cli/commands/init.test.ts
+++ b/packages/warden/src/cli/commands/init.test.ts
@@ -17,6 +17,7 @@ function createMockReporter(): Reporter {
 function createOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
   return {
     json: false,
+    traces: false,
     help: false,
     quiet: false,
     verbose: 0,

--- a/packages/warden/src/cli/commands/runs.test.ts
+++ b/packages/warden/src/cli/commands/runs.test.ts
@@ -33,6 +33,7 @@ function createTestReporter(): Reporter {
 function createDefaultOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
   return {
     json: false,
+    traces: false,
     help: false,
     quiet: false,
     verbose: 0,

--- a/packages/warden/src/cli/help.ts
+++ b/packages/warden/src/cli/help.ts
@@ -7,6 +7,7 @@ type HelpOptionId =
   | 'model'
   | 'json'
   | 'output'
+  | 'traces'
   | 'failOn'
   | 'reportOn'
   | 'minConfidence'
@@ -102,6 +103,10 @@ const HELP_OPTIONS: Record<HelpOptionId, HelpOptionSpec> = {
   output: {
     label: '-o, --output <path>',
     description: 'Write full run output to a JSONL file',
+  },
+  traces: {
+    label: '--traces',
+    description: 'Include per-hunk runtime traces in structured output',
   },
   failOn: {
     label: '--fail-on <severity>',
@@ -238,6 +243,7 @@ const HELP_COMMANDS: Record<HelpTarget, HelpCommandSpec> = {
       'model',
       'json',
       'output',
+      'traces',
       'failOn',
       'reportOn',
       'minConfidence',

--- a/packages/warden/src/cli/main.test.ts
+++ b/packages/warden/src/cli/main.test.ts
@@ -49,6 +49,7 @@ function createVisibleTestReporter(): Reporter {
 function createCliOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
   return {
     json: false,
+    traces: false,
     help: false,
     quiet: true,
     verbose: 0,

--- a/packages/warden/src/cli/main.ts
+++ b/packages/warden/src/cli/main.ts
@@ -287,6 +287,7 @@ function appendChunkToRunLog(log: RunLog, skillName: string, chunk: ChunkAnalysi
     durationMs: chunk.durationMs,
     auxiliaryUsage,
     error,
+    trace: chunk.trace,
   };
   let line: string;
   try {
@@ -1052,6 +1053,7 @@ export async function runSkills(
       config?.defaults?.auxiliary?.maxRetries ??
       config?.defaults?.auxiliaryMaxRetries,
     verifyFindings: config?.defaults?.verification?.enabled !== false,
+    captureTraces: options.traces,
   };
   const specs: RunSkillSpec[] = skillsToRun.map(({ skill, remote, filters, ...skillOptions }) => ({
     name: skill,
@@ -1382,6 +1384,7 @@ async function runConfigMode(options: CLIOptions, reporter: Reporter): Promise<n
       maxContextFiles: config.defaults?.chunking?.maxContextFiles,
       auxiliaryMaxRetries: trigger.auxiliaryMaxRetries,
       verifyFindings: trigger.verifyFindings,
+      captureTraces: options.traces,
     },
   }));
   const invalidModelSelector = findInvalidPiModelSelector(specs);

--- a/packages/warden/src/cli/output/jsonl-schema-gen.ts
+++ b/packages/warden/src/cli/output/jsonl-schema-gen.ts
@@ -18,6 +18,8 @@ import {
   AuxiliaryUsageMapSchema,
   SkippedFileSchema,
   FileReportSchema,
+  TraceSpanSchema,
+  HunkTraceSchema,
 } from '../../types/index.js';
 import {
   JsonlRecordSchema,
@@ -45,6 +47,8 @@ export function buildJsonlJsonSchema(): Record<string, unknown> {
   registry.add(AuxiliaryUsageMapSchema, { id: 'AuxiliaryUsage' });
   registry.add(SkippedFileSchema, { id: 'SkippedFile' });
   registry.add(FileReportSchema, { id: 'FileRecord' });
+  registry.add(TraceSpanSchema, { id: 'TraceSpan' });
+  registry.add(HunkTraceSchema, { id: 'HunkTrace' });
   registry.add(JsonlRunMetadataSchema, { id: 'RunMetadata' });
   registry.add(JsonlFixEvalDetailSchema, { id: 'FixEvalDetail' });
   registry.add(JsonlChunkRecordSchema, { id: 'ChunkRecord' });

--- a/packages/warden/src/cli/output/jsonl.test.ts
+++ b/packages/warden/src/cli/output/jsonl.test.ts
@@ -28,7 +28,7 @@ import {
   type JsonlRecord,
   type JsonlSummaryRecord,
 } from './jsonl.js';
-import type { SkillReport } from '../../types/index.js';
+import type { HunkTrace, SkillReport } from '../../types/index.js';
 
 describe('writeJsonlReport', () => {
   let testDir: string;
@@ -754,6 +754,61 @@ describe('parseJsonlReports', () => {
     expect(report.hunkFailures?.map((failure) => failure.type)).toEqual(['extraction', 'analysis']);
     expect(report.durationMs).toBe(300);
     expect(report.usage?.inputTokens).toBe(300);
+  });
+
+  it('reconstructs trace metadata from chunk records', () => {
+    const run = buildRunMetadata({ runId: 'chunk-traces', durationMs: 300 });
+    const trace: HunkTrace = {
+      filename: 'src/api.ts',
+      lineRange: '10-20',
+      runtime: 'claude',
+      status: 'success',
+      traceId: 'trace-123',
+      spanId: 'span-123',
+      responseId: 'resp-123',
+      responseModel: 'claude-test',
+      sessionId: 'session-123',
+      durationMs: 250,
+      durationApiMs: 200,
+      numTurns: 2,
+      spans: [
+        {
+          op: 'gen_ai.invoke_agent',
+          name: 'invoke_agent security-review',
+          traceId: 'trace-123',
+          spanId: 'span-invoke',
+          attributes: {
+            'gen_ai.operation.name': 'invoke_agent',
+            'gen_ai.agent.name': 'security-review',
+          },
+        },
+        {
+          op: 'gen_ai.chat',
+          name: 'chat security-review turn 1',
+          traceId: 'trace-123',
+          spanId: 'span-chat',
+          parentSpanId: 'span-invoke',
+          attributes: {
+            'gen_ai.operation.name': 'chat',
+            'gen_ai.response.finish_reasons': ['stop'],
+          },
+        },
+      ],
+    };
+    const chunk: JsonlChunkRecord = {
+      schemaVersion: 1,
+      run,
+      skill: 'security-review',
+      chunk: { file: 'src/api.ts', index: 1, total: 1, lineRange: '10-20' },
+      status: 'ok',
+      findings: [],
+      durationMs: 300,
+      trace,
+    };
+
+    const result = parseJsonlReports(renderJsonlChunkLine(chunk));
+
+    expect(result.reports[0]!.traces).toEqual([trace]);
   });
 
   it('only treats error-status chunks as extraction failures', () => {

--- a/packages/warden/src/cli/output/jsonl.ts
+++ b/packages/warden/src/cli/output/jsonl.ts
@@ -12,6 +12,7 @@ import {
   isExtractionErrorCode,
   SkillErrorSchema,
   SkippedFileSchema,
+  HunkTraceSchema,
 } from '../../types/index.js';
 import type { SkillReport, UsageStats, AuxiliaryUsageMap, SkillError, Finding, FileReport, HunkFailure } from '../../types/index.js';
 import { mergeAuxiliaryUsage } from '../../sdk/usage.js';
@@ -99,6 +100,7 @@ export const JsonlChunkRecordSchema = z.object({
   auxiliaryUsage: AuxiliaryUsageMapSchema.optional(),
   error: SkillErrorSchema.optional(),
   skippedFiles: z.array(SkippedFileSchema).optional(),
+  trace: HunkTraceSchema.optional(),
 });
 export type JsonlChunkRecord = z.infer<typeof JsonlChunkRecordSchema>;
 
@@ -241,6 +243,7 @@ export function buildSkillJsonlRecord(report: SkillReport, run: JsonlRunMetadata
     failedHunks: report.failedHunks || undefined,
     failedExtractions: report.failedExtractions || undefined,
     hunkFailures: report.hunkFailures?.length ? report.hunkFailures : undefined,
+    traces: report.traces?.length ? report.traces : undefined,
   };
   return { ...trimmed, run };
 }
@@ -441,6 +444,7 @@ function reportsFromChunks(chunks: JsonlChunkRecord[]): SkillReport[] {
       (acc, r) => mergeAuxiliaryUsage(acc, r.auxiliaryUsage),
       undefined,
     );
+    const traces = aggregateRecords.flatMap((r) => r.trace ? [r.trace] : []);
     const filesByName = new Map<string, FileReport>();
     const hunkFailures: HunkFailure[] = [];
     const skippedFiles = records.flatMap((r) => r.skippedFiles ?? []);
@@ -495,6 +499,7 @@ function reportsFromChunks(chunks: JsonlChunkRecord[]): SkillReport[] {
     if (failedHunks > 0) report.failedHunks = failedHunks;
     if (failedExtractions > 0) report.failedExtractions = failedExtractions;
     if (hunkFailures.length > 0) report.hunkFailures = hunkFailures;
+    if (traces.length > 0) report.traces = traces;
     if (skippedFiles.length > 0) report.skippedFiles = skippedFiles;
     reports.push(report);
   }

--- a/packages/warden/src/cli/output/tasks.ts
+++ b/packages/warden/src/cli/output/tasks.ts
@@ -5,7 +5,7 @@
  * Reporter spec: specs/reporters.md
  */
 
-import type { SkillReport, SeverityThreshold, ConfidenceThreshold, Finding, UsageStats, EventContext, HunkFailure, AuxiliaryUsageMap, ErrorCode } from '../../types/index.js';
+import type { SkillReport, SeverityThreshold, ConfidenceThreshold, Finding, UsageStats, EventContext, HunkFailure, AuxiliaryUsageMap, ErrorCode, HunkTrace } from '../../types/index.js';
 import type { SkillDefinition } from '../../config/schema.js';
 import { Sentry, emitSkillMetrics, logger } from '../../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, classifyError } from '../../sdk/errors.js';
@@ -46,6 +46,7 @@ interface FileProcessResult {
   failedExtractions: number;
   hunkFailures: HunkFailure[];
   auxiliaryUsage?: AuxiliaryUsageEntry[];
+  traces?: HunkTrace[];
 }
 
 function allAnalysisFailuresHaveCode(
@@ -462,6 +463,7 @@ export async function runSkillTask(
             failedExtractions: result.failedExtractions,
             hunkFailures: result.hunkFailures,
             auxiliaryUsage: result.auxiliaryUsage,
+            traces: result.traces,
           };
         };
 
@@ -511,6 +513,7 @@ export async function runSkillTask(
         const allFindings = allResults.flatMap((r) => r.findings);
         const allUsage = allResults.map((r) => r.usage).filter((u): u is UsageStats => u !== undefined);
         const allAuxEntries = allResults.flatMap((r) => r.auxiliaryUsage ?? []);
+        const allTraces = allResults.flatMap((r) => r.traces ?? []);
         const totalFailedHunks = allResults.reduce((sum, r) => sum + r.failedHunks, 0);
         const totalFailedExtractions = allResults.reduce((sum, r) => sum + r.failedExtractions, 0);
         const allHunkFailures: HunkFailure[] = allResults.flatMap((r) => r.hunkFailures);
@@ -574,6 +577,7 @@ export async function runSkillTask(
           if (totalFailedExtractions > 0) errorReport.failedExtractions = totalFailedExtractions;
           if (skippedFiles.length > 0) errorReport.skippedFiles = skippedFiles;
           if (auxUsage) errorReport.auxiliaryUsage = auxUsage;
+          if (runnerOptions.captureTraces && allTraces.length > 0) errorReport.traces = allTraces;
           span.setAttribute('warden.finding.count', 0);
           callbacks.onSkillError(name, error.message);
           // Mirror the success path: emit a final completion event with the
@@ -645,6 +649,9 @@ export async function runSkillTask(
         }
         if (allHunkFailures.length > 0) {
           report.hunkFailures = allHunkFailures;
+        }
+        if (runnerOptions.captureTraces && allTraces.length > 0) {
+          report.traces = allTraces;
         }
         const auxUsage = aggregateAuxiliaryUsage(allAuxEntries);
         if (auxUsage) {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -36,6 +36,8 @@ export {
   ErrorCodeSchema,
   SkillErrorSchema,
   HunkFailureSchema,
+  TraceSpanSchema,
+  HunkTraceSchema,
   // GitHub Events
   GitHubEventTypeSchema,
   PullRequestActionSchema,
@@ -63,6 +65,9 @@ export type {
   ErrorCode,
   SkillError,
   HunkFailure,
+  TraceSpanAttributeValue,
+  TraceSpan,
+  HunkTrace,
   GitHubEventType,
   PullRequestAction,
   FileChange,

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
 import { APIError } from '@anthropic-ai/sdk';
 import type { SkillDefinition } from '../config/schema.js';
 import type { HunkWithContext } from '../diff/index.js';
@@ -7,11 +7,28 @@ import { analyzeFile, buildSourceSnippet, filterOutOfRangeFindings, runSkill } f
 import type { PreparedFile } from './types.js';
 import { getRuntime, type Runtime } from './runtimes/index.js';
 import { ProviderFailureCircuitBreaker } from './circuit-breaker.js';
+import { Sentry } from '../sentry.js';
+import { startTracedSpan } from '../sentry-trace.js';
 
 vi.mock('./runtimes/index.js', () => ({
   getRuntime: vi.fn(),
   getRuntimeProviderOptions: vi.fn(() => undefined),
 }));
+
+beforeAll(() => {
+  Sentry.init({
+    dsn: 'https://public@example.com/1',
+    tracesSampleRate: 1,
+    transport: () => ({
+      send: vi.fn(async () => ({})),
+      flush: vi.fn(async () => true),
+    }),
+  });
+});
+
+afterAll(async () => {
+  await Sentry.close(0);
+});
 
 function makeFinding(startLine: number, id = `f-${startLine}`): Finding {
   return {
@@ -410,6 +427,108 @@ describe('analyzeFile', () => {
     consoleSpy.mockRestore();
   });
 
+  it('captures Warden-created Sentry spans for completed hunks when enabled', async () => {
+    const runSkill = vi.fn(async () => startTracedSpan(
+      {
+        op: 'gen_ai.invoke_agent',
+        name: 'invoke_agent security-review',
+        attributes: {
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.agent.name': 'security-review',
+        },
+      },
+      () => {
+        startTracedSpan(
+          {
+            op: 'fs.read',
+            name: 'read package.json',
+            attributes: { 'file.path': 'package.json' },
+          },
+          () => undefined,
+        );
+        return {
+          result: {
+            status: 'success',
+            text: JSON.stringify({ findings: [] }),
+            errors: [],
+            usage: makeUsage(),
+            responseId: 'resp-123',
+            responseModel: 'claude-test',
+            sessionId: 'session-123',
+            durationMs: 1200,
+            durationApiMs: 900,
+            numTurns: 2,
+          },
+        };
+      },
+    ));
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+    const onChunkComplete = vi.fn();
+    const skill: SkillDefinition = {
+      name: 'security-review',
+      description: 'Security review.',
+      prompt: 'Return findings as JSON.',
+    };
+
+    const result = await analyzeFile(
+      skill,
+      makePreparedFile(),
+      '/tmp/repo',
+      {
+        runtime: 'claude',
+        captureTraces: true,
+      },
+      { onChunkComplete },
+    );
+
+    const trace = result.traces?.[0];
+    expect(trace).toEqual(expect.objectContaining({
+      filename: 'src/example.ts',
+      lineRange: '1',
+      runtime: 'claude',
+      status: 'success',
+      responseId: 'resp-123',
+      responseModel: 'claude-test',
+      sessionId: 'session-123',
+      durationMs: 1200,
+      durationApiMs: 900,
+      numTurns: 2,
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          op: 'gen_ai.invoke_agent',
+          name: 'invoke_agent security-review',
+          traceId: expect.any(String),
+          spanId: expect.any(String),
+          attributes: expect.objectContaining({
+            'gen_ai.operation.name': 'invoke_agent',
+          }),
+        }),
+        expect.objectContaining({
+          op: 'fs.read',
+          name: 'read package.json',
+          traceId: expect.any(String),
+          spanId: expect.any(String),
+          attributes: expect.objectContaining({
+            'file.path': 'package.json',
+          }),
+        }),
+      ]),
+    }));
+    expect(trace?.spans?.map((span) => span.traceId)).toEqual(
+      expect.arrayContaining([trace?.traceId, trace?.traceId]),
+    );
+    expect(onChunkComplete).toHaveBeenCalledWith(expect.objectContaining({
+      trace,
+    }));
+  });
+
   it('counts provider failures once per hunk after retries are exhausted', async () => {
     const controller = new AbortController();
     const circuitBreaker = new ProviderFailureCircuitBreaker({
@@ -692,6 +811,78 @@ describe('runSkill', () => {
     expect(report.failedHunks).toBeUndefined();
     expect(report.failedExtractions).toBeUndefined();
     expect(report.error).toBeUndefined();
+  });
+
+  it('includes Warden-created Sentry spans on SkillReport when trace capture is enabled', async () => {
+    const runSkillMock = vi.fn(async () => startTracedSpan(
+      {
+        op: 'gen_ai.invoke_agent',
+        name: 'invoke_agent security-review',
+        attributes: {
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.agent.name': 'security-review',
+        },
+      },
+      () => ({
+        result: {
+          status: 'success',
+          text: JSON.stringify({ findings: [] }),
+          errors: [],
+          usage: makeUsage(),
+          responseId: 'resp-report',
+          responseModel: 'claude-report',
+          sessionId: 'session-report',
+          durationMs: 500,
+          numTurns: 1,
+        },
+      }),
+    ));
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const report = await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makeContextWithOneHunk(),
+      {
+        runtime: 'claude',
+        captureTraces: true,
+        postProcessFindings: false,
+      },
+    );
+
+    const trace = report.traces?.[0];
+    expect(trace).toEqual(expect.objectContaining({
+      filename: 'src/example.ts',
+      lineRange: '10',
+      runtime: 'claude',
+      status: 'success',
+      responseId: 'resp-report',
+      responseModel: 'claude-report',
+      sessionId: 'session-report',
+      durationMs: 500,
+      numTurns: 1,
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          op: 'gen_ai.invoke_agent',
+          traceId: expect.any(String),
+          spanId: expect.any(String),
+          attributes: expect.objectContaining({
+            'gen_ai.operation.name': 'invoke_agent',
+          }),
+        }),
+      ]),
+    }));
+    expect(trace?.spans?.[0]?.traceId).toBe(trace?.traceId);
   });
 
   it('classifies mixed provider and extraction failures as provider unavailable', async () => {

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -28,7 +28,7 @@ import { prepareFiles } from './prepare.js';
 import type { EventContext, SkillReport, UsageStats, HunkFailure, HunkTrace } from '../types/index.js';
 import type { SourceSnippet, SourceSnippetLine } from '../types/index.js';
 import { runPool } from '../utils/index.js';
-import { startTraceRecorder, withTraceRecorder, type TraceRecorder } from '../sentry-trace.js';
+import { getSpanContext, startTraceRecorder, withTraceRecorder, type TraceRecorder } from '../sentry-trace.js';
 
 /** Result from parsing hunk output */
 interface ParseHunkOutputResult {
@@ -113,12 +113,7 @@ function buildHunkTrace(args: {
 }): HunkTrace | undefined {
   if (!args.enabled) return undefined;
 
-  let spanContext: { traceId?: string; spanId?: string } | undefined;
-  try {
-    spanContext = args.span.spanContext?.();
-  } catch {
-    // Trace capture is diagnostic only.
-  }
+  const spanContext = getSpanContext(args.span);
   const spans = args.traceRecorder?.snapshot();
   const childTraceId = spans?.find((span) => span.traceId)?.traceId;
 

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@sentry/node';
 import type { SkillDefinition } from '../config/schema.js';
 import type { ErrorCode, Finding, RetryConfig } from '../types/index.js';
 import { getHunkLineRange, type HunkWithContext } from '../diff/index.js';
@@ -103,7 +104,7 @@ function allHunksFailedGuidance(runtime: SkillRunnerOptions['runtime'] | undefin
 
 function buildHunkTrace(args: {
   enabled: boolean | undefined;
-  span: { spanContext?: () => { traceId?: string; spanId?: string } };
+  span: Span;
   filename: string;
   lineRange: string;
   runtime: NonNullable<SkillRunnerOptions['runtime']>;

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -25,9 +25,10 @@ import {
   type ChunkAnalysisResult,
 } from './types.js';
 import { prepareFiles } from './prepare.js';
-import type { EventContext, SkillReport, UsageStats, HunkFailure } from '../types/index.js';
+import type { EventContext, SkillReport, UsageStats, HunkFailure, HunkTrace } from '../types/index.js';
 import type { SourceSnippet, SourceSnippetLine } from '../types/index.js';
 import { runPool } from '../utils/index.js';
+import { startTraceRecorder, withTraceRecorder, type TraceRecorder } from '../sentry-trace.js';
 
 /** Result from parsing hunk output */
 interface ParseHunkOutputResult {
@@ -68,6 +69,7 @@ function hunkFailureFromCircuit(
   reason: CircuitBreakerReason,
   usage: UsageStats[],
   attempts: number,
+  trace?: HunkTrace,
 ): HunkAnalysisResult {
   return {
     findings: [],
@@ -77,6 +79,7 @@ function hunkFailureFromCircuit(
     failureCode: reason.code,
     failureMessage: reason.message,
     attempts,
+    trace,
   };
 }
 
@@ -96,6 +99,45 @@ function allHunksFailedGuidance(runtime: SkillRunnerOptions['runtime'] | undefin
   }
 
   return "Verify WARDEN_ANTHROPIC_API_KEY is set correctly, or run 'claude login' when using the Claude runtime without an API key.";
+}
+
+function buildHunkTrace(args: {
+  enabled: boolean | undefined;
+  span: { spanContext?: () => { traceId?: string; spanId?: string } };
+  filename: string;
+  lineRange: string;
+  runtime: NonNullable<SkillRunnerOptions['runtime']>;
+  status: string;
+  result?: SkillRunResult;
+  traceRecorder?: TraceRecorder;
+}): HunkTrace | undefined {
+  if (!args.enabled) return undefined;
+
+  let spanContext: { traceId?: string; spanId?: string } | undefined;
+  try {
+    spanContext = args.span.spanContext?.();
+  } catch {
+    // Trace capture is diagnostic only.
+  }
+  const spans = args.traceRecorder?.snapshot();
+  const childTraceId = spans?.find((span) => span.traceId)?.traceId;
+
+  const trace: HunkTrace = {
+    filename: args.filename,
+    lineRange: args.lineRange,
+    runtime: args.runtime,
+    status: args.status,
+    traceId: spanContext?.traceId ?? childTraceId,
+    spanId: spanContext?.spanId,
+    responseId: args.result?.responseId,
+    responseModel: args.result?.responseModel,
+    sessionId: args.result?.sessionId,
+    durationMs: args.result?.durationMs,
+    durationApiMs: args.result?.durationApiMs,
+    numTurns: args.result?.numTurns,
+    spans,
+  };
+  return trace;
 }
 
 /**
@@ -263,6 +305,8 @@ async function analyzeHunk(
     },
     async (span) => {
       const { abortController, retry } = options;
+      const runtimeName = options.runtime ?? 'pi';
+      const traceRecorder = options.captureTraces ? startTraceRecorder(span) : undefined;
 
       const systemPrompt = buildHunkSystemPrompt(skill);
       const userPrompt = buildHunkUserPrompt(skill, hunkCtx, prContext);
@@ -294,7 +338,20 @@ async function analyzeHunk(
       for (let attempt = 0; attempt <= retryConfig.maxRetries; attempt++) {
         const circuitReason = options.circuitBreaker?.reason;
         if (circuitReason) {
-          return hunkFailureFromCircuit(circuitReason, accumulatedUsage, attempt);
+          return hunkFailureFromCircuit(
+            circuitReason,
+            accumulatedUsage,
+            attempt,
+            buildHunkTrace({
+              enabled: options.captureTraces,
+              span,
+              filename: hunkCtx.filename,
+              lineRange,
+              runtime: runtimeName,
+              status: circuitReason.code,
+              traceRecorder,
+            }),
+          );
         }
 
         // Check for abort before each attempt
@@ -308,13 +365,21 @@ async function analyzeHunk(
             failureCode: 'aborted',
             failureMessage: 'Analysis aborted',
             attempts: attempt,
+            trace: buildHunkTrace({
+              enabled: options.captureTraces,
+              span,
+              filename: hunkCtx.filename,
+              lineRange,
+              runtime: runtimeName,
+              status: 'aborted',
+              traceRecorder,
+            }),
           };
         }
 
         try {
-          const runtimeName = options.runtime ?? 'pi';
           const runtime = getRuntime(runtimeName);
-          const { result: resultMessage, authError } = await runtime.runSkill({
+          const { result: resultMessage, authError } = await withTraceRecorder(traceRecorder, () => runtime.runSkill({
             apiKey: options.apiKey,
             systemPrompt,
             userPrompt,
@@ -330,7 +395,7 @@ async function analyzeHunk(
             providerOptions: getRuntimeProviderOptions(runtimeName, {
               pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
             }),
-          });
+          }));
 
           // Check for authentication errors from auth_status messages
           // auth_status errors are always auth-related - throw immediately
@@ -348,6 +413,15 @@ async function analyzeHunk(
               failureCode: 'sdk_error',
               failureMessage: 'SDK returned no result',
               attempts: attempt + 1,
+              trace: buildHunkTrace({
+                enabled: options.captureTraces,
+                span,
+                filename: hunkCtx.filename,
+                lineRange,
+                runtime: runtimeName,
+                status: 'missing_result',
+                traceRecorder,
+              }),
             };
           }
 
@@ -383,7 +457,21 @@ async function analyzeHunk(
             const openReason = recordCircuitFailure(options, failureCode, failureMessage);
             notifyHunkFailed(callbacks, callbacks?.lineRange ?? lineRange, failureMessage);
             if (openReason) {
-              return hunkFailureFromCircuit(openReason, accumulatedUsage, attempt + 1);
+              return hunkFailureFromCircuit(
+                openReason,
+                accumulatedUsage,
+                attempt + 1,
+                buildHunkTrace({
+                  enabled: options.captureTraces,
+                  span,
+                  filename: hunkCtx.filename,
+                  lineRange,
+                  runtime: runtimeName,
+                  status: resultMessage.status,
+                  result: resultMessage,
+                  traceRecorder,
+                }),
+              );
             }
             return {
               findings: [],
@@ -393,11 +481,24 @@ async function analyzeHunk(
               failureCode,
               failureMessage,
               attempts: attempt + 1,
+              trace: buildHunkTrace({
+                enabled: options.captureTraces,
+                span,
+                filename: hunkCtx.filename,
+                lineRange,
+                runtime: runtimeName,
+                status: resultMessage.status,
+                result: resultMessage,
+                traceRecorder,
+              }),
             };
           }
 
           options.circuitBreaker?.recordSuccess();
-          const parseResult = await parseHunkOutput(resultMessage, hunkCtx.filename, skill.name, options);
+          const parseResult = await withTraceRecorder(
+            traceRecorder,
+            () => parseHunkOutput(resultMessage, hunkCtx.filename, skill.name, options),
+          );
 
           // Filter findings outside hunk line range (defense-in-depth)
           const hunkRange = getHunkLineRange(hunkCtx.hunk);
@@ -449,6 +550,16 @@ async function analyzeHunk(
             auxiliaryUsage: parseResult.extractionUsage
               ? [{ agent: 'extraction', usage: parseResult.extractionUsage }]
               : undefined,
+            trace: buildHunkTrace({
+              enabled: options.captureTraces,
+              span,
+              filename: hunkCtx.filename,
+              lineRange,
+              runtime: runtimeName,
+              status: resultMessage.status,
+              result: resultMessage,
+              traceRecorder,
+            }),
           };
         } catch (error) {
           lastError = error;
@@ -463,6 +574,15 @@ async function analyzeHunk(
               failureCode: 'aborted',
               failureMessage: 'Analysis aborted',
               attempts: attempt + 1,
+              trace: buildHunkTrace({
+                enabled: options.captureTraces,
+                span,
+                filename: hunkCtx.filename,
+                lineRange,
+                runtime: runtimeName,
+                status: 'aborted',
+                traceRecorder,
+              }),
             };
           }
 
@@ -532,6 +652,15 @@ async function analyzeHunk(
               failureCode: 'aborted',
               failureMessage: 'Analysis aborted during retry delay',
               attempts: attempt + 1,
+              trace: buildHunkTrace({
+                enabled: options.captureTraces,
+                span,
+                filename: hunkCtx.filename,
+                lineRange,
+                runtime: runtimeName,
+                status: 'aborted',
+                traceRecorder,
+              }),
             };
           }
         }
@@ -563,7 +692,20 @@ async function analyzeHunk(
       const retryMsg = sanitizeErrorMessage(message);
       const openReason = recordCircuitFailure(options, retryCode, retryMsg);
       if (openReason) {
-        return hunkFailureFromCircuit(openReason, accumulatedUsage, retryConfig.maxRetries + 1);
+        return hunkFailureFromCircuit(
+          openReason,
+          accumulatedUsage,
+          retryConfig.maxRetries + 1,
+          buildHunkTrace({
+            enabled: options.captureTraces,
+            span,
+            filename: hunkCtx.filename,
+            lineRange,
+            runtime: runtimeName,
+            status: retryCode,
+            traceRecorder,
+          }),
+        );
       }
       return {
         findings: [],
@@ -573,6 +715,15 @@ async function analyzeHunk(
         failureCode: retryCode,
         failureMessage: `All retry attempts failed: ${retryMsg}`,
         attempts: retryConfig.maxRetries + 1,
+        trace: buildHunkTrace({
+          enabled: options.captureTraces,
+          span,
+          filename: hunkCtx.filename,
+          lineRange,
+          runtime: runtimeName,
+          status: retryCode,
+          traceRecorder,
+        }),
       };
     },
   );
@@ -625,6 +776,7 @@ export async function analyzeFile(
       const fileUsage: UsageStats[] = [];
       const fileAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
       const hunkFailures: HunkFailure[] = [];
+      const hunkTraces: HunkTrace[] = [];
       let failedHunks = 0;
       let failedExtractions = 0;
 
@@ -679,6 +831,9 @@ export async function analyzeFile(
 
         attachElapsedTime(result.findings, callbacks?.skillStartTime);
         callbacks?.onHunkComplete?.(hunkIndex + 1, result.findings, result.usage);
+        if (result.trace) {
+          hunkTraces.push(result.trace);
+        }
         const chunkResult: ChunkAnalysisResult = {
           filename: file.filename,
           model: options.model,
@@ -695,6 +850,7 @@ export async function analyzeFile(
           extractionError: result.extractionError,
           extractionPreview: result.extractionPreview,
           auxiliaryUsage: result.auxiliaryUsage,
+          trace: result.trace,
         };
         callbacks?.onChunkComplete?.(chunkResult);
 
@@ -717,6 +873,7 @@ export async function analyzeFile(
         failedExtractions,
         hunkFailures,
         auxiliaryUsage: fileAuxiliaryUsage.length > 0 ? fileAuxiliaryUsage : undefined,
+        traces: hunkTraces.length > 0 ? hunkTraces : undefined,
       };
     },
   );
@@ -816,6 +973,7 @@ async function runSkillAnalysis(
   // Track all usage stats for aggregation
   const allUsage: UsageStats[] = [];
   const allAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
+  const allTraces: HunkTrace[] = [];
 
   // Track failed hunks across all files
   let totalFailedHunks = 0;
@@ -942,6 +1100,9 @@ async function runSkillAnalysis(
     if (fr.result.auxiliaryUsage) {
       allAuxiliaryUsage.push(...fr.result.auxiliaryUsage);
     }
+    if (fr.result.traces) {
+      allTraces.push(...fr.result.traces);
+    }
   }
 
   // All hunks failed — typically a systemic problem (auth, subprocess, etc).
@@ -1039,6 +1200,9 @@ async function runSkillAnalysis(
   }
   if (allHunkFailures.length > 0) {
     report.hunkFailures = allHunkFailures;
+  }
+  if (options.captureTraces && allTraces.length > 0) {
+    report.traces = allTraces;
   }
   const auxUsage = aggregateAuxiliaryUsage(allAuxiliaryUsage);
   if (auxUsage) {

--- a/packages/warden/src/sdk/haiku.ts
+++ b/packages/warden/src/sdk/haiku.ts
@@ -2,10 +2,11 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Span } from '@sentry/node';
 import type { z } from 'zod';
 import type { UsageStats } from '../types/index.js';
-import { Sentry } from '../sentry.js';
+import { startTracedSpan } from '../sentry-trace.js';
 import { apiUsageToStats } from './pricing.js';
 import { aggregateUsage, emptyUsage } from './usage.js';
 import {
+  genAiToolCallAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
   setGenAiUsageAttrs,
@@ -187,7 +188,7 @@ function inferPrefill(schema: z.ZodType): string | undefined {
 export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuResult<T>> {
   const { apiKey, prompt, schema, agentName, task, model = HAIKU_MODEL, maxTokens = DEFAULT_MAX_TOKENS, timeout = DEFAULT_TIMEOUT_MS, maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES } = options;
 
-  return Sentry.startSpan(
+  return startTracedSpan(
     {
       op: 'gen_ai.chat',
       name: `chat ${model}`,
@@ -298,7 +299,7 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
     maxRetries = DEFAULT_AUXILIARY_MAX_RETRIES,
   } = options;
 
-  return Sentry.startSpan(
+  return startTracedSpan(
     {
       op: 'gen_ai.chat',
       name: `chat ${model}`,
@@ -383,23 +384,32 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
 
           const toolResults: Anthropic.ToolResultBlockParam[] = [];
           for (const block of toolUseBlocks) {
-            await Sentry.startSpan(
+            await startTracedSpan(
               {
                 op: 'gen_ai.execute_tool',
                 name: `execute_tool ${block.name}`,
-                attributes: {
-                  'gen_ai.operation.name': 'execute_tool',
-                  ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
-                  ...(task ? { 'warden.ai.task': task } : {}),
-                  'gen_ai.tool.name': block.name,
-                },
+                attributes: genAiToolCallAttributes({
+                  agentName,
+                  task,
+                  toolName: block.name,
+                  toolCallId: block.id,
+                  toolType: 'function',
+                  arguments: block.input,
+                }),
               },
-              async () => {
+              async (toolSpan) => {
                 try {
                   const result = await executeTool(block.name, block.input as Record<string, unknown>);
+                  for (const [key, value] of Object.entries(genAiToolCallAttributes({
+                    toolName: block.name,
+                    result,
+                  }))) {
+                    toolSpan.setAttribute(key, value);
+                  }
                   toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: result });
                 } catch (error) {
                   const errMsg = error instanceof Error ? error.message : String(error);
+                  toolSpan.setAttribute('error.type', error instanceof Error ? error.name : '_OTHER');
                   toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: errMsg, is_error: true });
                 }
               },

--- a/packages/warden/src/sdk/otel.test.ts
+++ b/packages/warden/src/sdk/otel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { genAiProviderName, genAiUsageAttributes } from './otel.js';
+import { genAiProviderName, genAiToolCallAttributes, genAiUsageAttributes } from './otel.js';
 
 describe('OpenTelemetry GenAI provider attribution', () => {
   it('uses provider ids from model selectors', () => {
@@ -22,6 +22,27 @@ describe('OpenTelemetry GenAI usage attributes', () => {
       'gen_ai.usage.output_tokens': 500,
       'gen_ai.usage.cache_read.input_tokens': 200,
       'gen_ai.usage.cache_creation.input_tokens': 100,
+    });
+  });
+});
+
+describe('OpenTelemetry GenAI tool call attributes', () => {
+  it('serializes tool call arguments and results for span attributes', () => {
+    expect(genAiToolCallAttributes({
+      agentName: 'test-skill',
+      toolName: 'Read',
+      toolCallId: 'tool-1',
+      toolType: 'function',
+      arguments: { path: 'src/index.ts' },
+      result: { ok: true },
+    })).toEqual({
+      'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.agent.name': 'test-skill',
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.tool.call.id': 'tool-1',
+      'gen_ai.tool.type': 'function',
+      'gen_ai.tool.call.arguments': '{"path":"src/index.ts"}',
+      'gen_ai.tool.call.result': '{"ok":true}',
     });
   });
 });

--- a/packages/warden/src/sdk/otel.ts
+++ b/packages/warden/src/sdk/otel.ts
@@ -13,6 +13,7 @@ interface GenAiMessage {
 }
 
 type GenAiUsageAttributes = Record<string, number>;
+type GenAiToolAttributeValue = string | number | boolean | string[] | undefined;
 
 const PROVIDER_NAME_ALIASES: Record<string, string> = {
   mistral: 'mistral_ai',
@@ -46,6 +47,52 @@ export function genAiUsageAttributes(usage: UsageStats): GenAiUsageAttributes {
     'gen_ai.usage.cache_read.input_tokens': usage.cacheReadInputTokens ?? 0,
     'gen_ai.usage.cache_creation.input_tokens': usage.cacheCreationInputTokens ?? 0,
   };
+}
+
+function stringifyGenAiAttribute(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}
+
+/** Build OpenTelemetry GenAI attributes for an executed tool call span. */
+export function genAiToolCallAttributes(args: {
+  agentName?: string;
+  task?: string;
+  toolName: string;
+  toolCallId?: string;
+  toolType?: string;
+  arguments?: unknown;
+  result?: unknown;
+  isError?: boolean;
+}): Record<string, GenAiToolAttributeValue> {
+  const attributes: Record<string, GenAiToolAttributeValue> = {
+    'gen_ai.operation.name': 'execute_tool',
+    ...(args.agentName ? { 'gen_ai.agent.name': args.agentName } : {}),
+    ...(args.task ? { 'warden.ai.task': args.task } : {}),
+    'gen_ai.tool.name': args.toolName,
+    ...(args.toolCallId ? { 'gen_ai.tool.call.id': args.toolCallId } : {}),
+    ...(args.toolType ? { 'gen_ai.tool.type': args.toolType } : {}),
+  };
+
+  const serializedArguments = stringifyGenAiAttribute(args.arguments);
+  if (serializedArguments !== undefined) {
+    attributes['gen_ai.tool.call.arguments'] = serializedArguments;
+  }
+
+  const serializedResult = args.isError ? undefined : stringifyGenAiAttribute(args.result);
+  if (serializedResult !== undefined) {
+    attributes['gen_ai.tool.call.result'] = serializedResult;
+  }
+
+  return attributes;
 }
 
 /** Set GenAI token usage attributes expected by Sentry AI monitoring. */

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -19,8 +19,10 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { query, type EffortLevel, type SDKResultMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { ToolConfig, ToolName } from '../../config/schema.js';
 import { Sentry } from '../../sentry.js';
+import { recordTracedSpan, startInactiveTracedSpan, startTracedSpan } from '../../sentry-trace.js';
 import { callHaiku, callHaikuWithTools } from '../haiku.js';
 import {
+  genAiToolCallAttributes,
   genAiUsageAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
@@ -45,7 +47,7 @@ import type {
 
 /** Buffered data for a single SDK turn, flushed into gen_ai.chat child spans. */
 interface TurnData {
-  toolUses: { id: string; name: string }[];
+  toolUses: { id: string; name: string; input?: unknown }[];
   inputTokens: number;
   outputTokens: number;
   cacheRead: number;
@@ -309,7 +311,7 @@ export const claudeRuntime: Runtime = {
     const skillTools = resolveClaudeSkillTools(tools, allowMutatingTools);
     const modelId = model ?? 'unknown';
 
-    return Sentry.startSpan(
+    return startTracedSpan(
       {
         op: 'gen_ai.invoke_agent',
         name: `invoke_agent ${skillName}`,
@@ -384,7 +386,7 @@ export const claudeRuntime: Runtime = {
               costUSD: 0,
             });
 
-            Sentry.startSpan(
+            startTracedSpan(
               {
                 op: 'gen_ai.chat',
                 name: `chat ${skillName} turn ${turnCount}`,
@@ -400,28 +402,31 @@ export const claudeRuntime: Runtime = {
               () => {
                 for (const toolUse of turn.toolUses) {
                   const elapsed = toolProgress.get(toolUse.id);
-                  const attributes = {
-                    'gen_ai.operation.name': 'execute_tool',
-                    'gen_ai.agent.name': skillName,
-                    'gen_ai.tool.name': toolUse.name,
-                  };
+                  const attributes = genAiToolCallAttributes({
+                    agentName: skillName,
+                    toolName: toolUse.name,
+                    toolCallId: toolUse.id,
+                    toolType: 'function',
+                    arguments: toolUse.input,
+                  });
 
                   if (elapsed !== undefined) {
                     const endTime = Date.now() / 1000;
                     const parentSpan = Sentry.getActiveSpan();
-                    const span = Sentry.startInactiveSpan({
+                    const span = startInactiveTracedSpan({
                       op: 'gen_ai.execute_tool',
-                      name: toolUse.name,
+                      name: `execute_tool ${toolUse.name}`,
                       ...(parentSpan && { parentSpan }),
                       startTime: Math.max(0, endTime - elapsed),
                       attributes,
                     });
                     span.end(endTime);
+                    recordTracedSpan(span);
                   } else {
-                    Sentry.startSpan(
+                    startTracedSpan(
                       {
                         op: 'gen_ai.execute_tool',
-                        name: toolUse.name,
+                        name: `execute_tool ${toolUse.name}`,
                         attributes,
                       },
                       () => undefined
@@ -444,7 +449,7 @@ export const claudeRuntime: Runtime = {
               const cacheWrite1h = msg.usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
               const toolUses = msg.content
                 .filter((block): block is typeof block & { type: 'tool_use' } => block.type === 'tool_use')
-                .map(({ id, name }) => ({ id, name }));
+                .map(({ id, name, input }) => ({ id, name, input }));
               pendingTurn = {
                 toolUses,
                 inputTokens: msg.usage?.input_tokens ?? 0,
@@ -485,7 +490,7 @@ export const claudeRuntime: Runtime = {
             const cacheWrite1h = usage.cache_creation?.ephemeral_1h_input_tokens ?? 0;
             const cacheWrite = Math.max(usage.cache_creation_input_tokens ?? 0, cacheWrite5m + cacheWrite1h);
             const totalInputTokens = inputTokens + cacheRead + cacheWrite;
-            setGenAiUsageAttrs(span, {
+            const normalizedUsage = {
               inputTokens: totalInputTokens,
               outputTokens,
               cacheReadInputTokens: cacheRead,
@@ -494,7 +499,8 @@ export const claudeRuntime: Runtime = {
               cacheCreation1hInputTokens: cacheWrite1h,
               webSearchRequests: usage.server_tool_use?.web_search_requests ?? 0,
               costUSD: resultMessage.total_cost_usd ?? 0,
-            });
+            };
+            setGenAiUsageAttrs(span, normalizedUsage);
           }
           if (resultMessage.uuid) {
             span.setAttribute('gen_ai.response.id', resultMessage.uuid);
@@ -528,18 +534,19 @@ export const claudeRuntime: Runtime = {
         const stderr = stderrChunks.join('').trim() || undefined;
         const streamedUsage = turnUsages.length > 0 ? aggregateUsage(turnUsages) : undefined;
         const responseModel = responseModels.size === 1 ? [...responseModels][0] : undefined;
-        return {
-          result: resultMessage
-            ? normalizeResult(
-              resultMessage,
-              reconcileStreamedUsage({
-                result: resultMessage,
-                streamedUsage,
-                responseModel,
-              }),
+        const result = resultMessage
+          ? normalizeResult(
+            resultMessage,
+            reconcileStreamedUsage({
+              result: resultMessage,
+              streamedUsage,
               responseModel,
-            )
-            : undefined,
+            }),
+            responseModel,
+          )
+          : undefined;
+        return {
+          result,
           authError,
           stderr,
         };

--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import { z } from 'zod';
 import {
   AuthStorage,
@@ -9,6 +9,9 @@ import {
   createAgentSession,
 } from '@earendil-works/pi-coding-agent';
 import { piRuntime } from './pi.js';
+import { Sentry } from '../../sentry.js';
+import { startTraceRecorder, withTraceRecorder } from '../../sentry-trace.js';
+import type { TraceSpan } from '../../types/index.js';
 
 const piMocks = vi.hoisted(() => {
   const model = {
@@ -86,6 +89,21 @@ vi.mock('@earendil-works/pi-coding-agent', () => ({
   defineTool: vi.fn((tool: unknown) => tool),
   getAgentDir: vi.fn(() => '/pi-agent'),
 }));
+
+beforeAll(() => {
+  Sentry.init({
+    dsn: 'https://public@example.com/1',
+    tracesSampleRate: 1,
+    transport: () => ({
+      send: vi.fn(async () => ({})),
+      flush: vi.fn(async () => true),
+    }),
+  });
+});
+
+afterAll(async () => {
+  await Sentry.close(0);
+});
 
 function assistantMessage(overrides: Record<string, unknown> = {}) {
   return {
@@ -204,6 +222,61 @@ describe('piRuntime.runSkill', () => {
         costUSD: 0.033,
       },
     });
+  });
+
+  it('records Pi tool execution spans when trace capture is active', async () => {
+    const toolResult = {
+      role: 'toolResult',
+      toolCallId: 'tool-1',
+      toolName: 'read',
+      content: [{ type: 'text', text: 'file contents' }],
+      details: { path: 'README.md' },
+      isError: false,
+      timestamp: 2,
+    };
+    piMocks.session.prompt.mockImplementation(async () => {
+      const listener = piMocks.listeners[0];
+      if (!listener) {
+        throw new Error('Pi session listener was not registered');
+      }
+      listener({
+        type: 'tool_execution_start',
+        toolCallId: 'tool-1',
+        toolName: 'read',
+        args: { path: 'README.md' },
+      });
+      listener({
+        type: 'tool_execution_end',
+        toolCallId: 'tool-1',
+        toolName: 'read',
+        result: toolResult,
+        isError: false,
+      });
+      emitSuccessfulRun();
+    });
+
+    let spans: TraceSpan[] | undefined;
+    await Sentry.startSpan({ op: 'test', name: 'parent' }, async (span) => {
+      const recorder = startTraceRecorder(span);
+      await withTraceRecorder(recorder, () => piRuntime.runSkill(baseSkillRequest()));
+      spans = recorder?.snapshot();
+    });
+
+    expect(spans).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        op: 'gen_ai.execute_tool',
+        name: 'execute_tool read',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.agent.name': 'test-skill',
+          'gen_ai.tool.name': 'read',
+          'gen_ai.tool.call.id': 'tool-1',
+          'gen_ai.tool.type': 'function',
+          'gen_ai.tool.call.arguments': JSON.stringify({ path: 'README.md' }),
+          'gen_ai.tool.call.result': JSON.stringify(toolResult),
+        }),
+      }),
+    ]));
   });
 
   it('does not treat a final answer on the max turn as a turn-limit failure', async () => {

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -31,11 +31,13 @@ import {
 import { z } from 'zod';
 import type { ReasoningEffort, ToolConfig, ToolName } from '../../config/schema.js';
 import { Sentry } from '../../sentry.js';
+import { recordTracedSpan, startInactiveTracedSpan, startTracedSpan } from '../../sentry-trace.js';
 import type { UsageStats } from '../../types/index.js';
 import { bridgeWardenProviderApiKeyEnv } from '../../utils/index.js';
 import { extractJson } from '../haiku.js';
 import { isAuthenticationErrorMessage, sanitizeErrorMessage } from '../errors.js';
 import {
+  genAiToolCallAttributes,
   genAiProviderName,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
@@ -90,6 +92,7 @@ interface PiPromptOptions {
   cwd: string;
   systemPrompt: string;
   userPrompt: string;
+  agentName?: string;
   model?: string;
   legacyAnthropicApiKey?: string;
   toolNames: string[];
@@ -280,6 +283,16 @@ function buildSettingsManager(timeout: number | undefined, maxRetries: number | 
   });
 }
 
+type PiToolSpan = ReturnType<typeof startInactiveTracedSpan>;
+
+function setSpanAttributes(span: PiToolSpan, attributes: Record<string, string | number | boolean | string[] | undefined>): void {
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) {
+      span.setAttribute(key, value);
+    }
+  }
+}
+
 async function promptWithTimeout(
   session: AgentSession,
   userPrompt: string,
@@ -342,6 +355,86 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
   let numTurns = 0;
   let hitMaxTurns = false;
   const startedAt = Date.now();
+  const activeToolSpans = new Map<string, PiToolSpan>();
+
+  const buildToolAttributes = (args: {
+    toolName: string;
+    toolCallId?: string;
+    input?: unknown;
+    result?: unknown;
+    isError?: boolean;
+  }): Record<string, string | number | boolean | string[] | undefined> =>
+    genAiToolCallAttributes({
+      agentName: options.agentName,
+      toolName: args.toolName,
+      toolCallId: args.toolCallId,
+      toolType: 'function',
+      arguments: args.input,
+      result: args.result,
+      isError: args.isError,
+    });
+
+  function startToolSpan(event: { toolCallId: string; toolName: string; args: unknown }): void {
+    try {
+      const parentSpan = Sentry.getActiveSpan();
+      const span = startInactiveTracedSpan({
+        op: 'gen_ai.execute_tool',
+        name: `execute_tool ${event.toolName}`,
+        ...(parentSpan && { parentSpan }),
+        attributes: buildToolAttributes({
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          input: event.args,
+        }),
+      });
+      activeToolSpans.set(event.toolCallId, span);
+    } catch {
+      // Telemetry should never break the workflow.
+    }
+  }
+
+  function finishToolSpan(event: {
+    toolCallId: string;
+    toolName: string;
+    result: unknown;
+    isError: boolean;
+  }): void {
+    try {
+      const parentSpan = Sentry.getActiveSpan();
+      const span = activeToolSpans.get(event.toolCallId) ?? startInactiveTracedSpan({
+        op: 'gen_ai.execute_tool',
+        name: `execute_tool ${event.toolName}`,
+        ...(parentSpan && { parentSpan }),
+      });
+      activeToolSpans.delete(event.toolCallId);
+      setSpanAttributes(span, buildToolAttributes({
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        result: event.result,
+        isError: event.isError,
+      }));
+      if (event.isError) {
+        span.setAttribute('error.type', 'tool_error');
+      }
+      span.end();
+      recordTracedSpan(span);
+    } catch {
+      // Telemetry should never break the workflow.
+    }
+  }
+
+  function finishOpenToolSpans(errorType: string): void {
+    for (const span of activeToolSpans.values()) {
+      try {
+        span.setAttribute('error.type', errorType);
+        span.end();
+        recordTracedSpan(span);
+      } catch {
+        // Telemetry should never break the workflow.
+      }
+    }
+    activeToolSpans.clear();
+  }
 
   try {
     const result = await createAgentSession({
@@ -376,6 +469,10 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
         lastAssistant = event.message;
       } else if (event.type === 'agent_end') {
         agentEndMessages = [...event.messages];
+      } else if (event.type === 'tool_execution_start') {
+        startToolSpan(event);
+      } else if (event.type === 'tool_execution_end') {
+        finishToolSpan(event);
       } else if (event.type === 'turn_end') {
         numTurns++;
         if (
@@ -408,6 +505,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
       unsubscribe();
     }
   } finally {
+    finishOpenToolSpans('aborted');
     session?.dispose();
   }
 
@@ -492,7 +590,7 @@ async function runStructured<T>(
   const systemPrompt = toStructuredPrompt(request.kind, request.task, request.schema);
   const toolNames = customTools?.map((tool) => tool.name) ?? [];
 
-  return Sentry.startSpan(
+  return startTracedSpan(
     {
       op: 'gen_ai.chat',
       name: `chat ${request.model ?? 'pi-default'}`,
@@ -514,6 +612,7 @@ async function runStructured<T>(
           cwd: process.cwd(),
           systemPrompt,
           userPrompt: request.prompt,
+          agentName: request.agentName,
           model: request.model,
           legacyAnthropicApiKey: request.apiKey,
           toolNames,
@@ -589,7 +688,7 @@ export const piRuntime: Runtime = {
     const { maxTurns = 50, model, reasoningEffort, abortController } = options;
     const skillTools = resolvePiSkillTools(tools, allowMutatingTools);
 
-    return Sentry.startSpan(
+    return startTracedSpan(
       {
         op: 'gen_ai.invoke_agent',
         name: `invoke_agent ${skillName}`,
@@ -610,6 +709,7 @@ export const piRuntime: Runtime = {
             cwd: repoPath,
             systemPrompt,
             userPrompt,
+            agentName: skillName,
             model,
             legacyAnthropicApiKey: apiKey,
             toolNames: skillTools.toolNames,

--- a/packages/warden/src/sdk/types.ts
+++ b/packages/warden/src/sdk/types.ts
@@ -1,4 +1,4 @@
-import type { Finding, UsageStats, SkippedFile, RetryConfig, ErrorCode, HunkFailure } from '../types/index.js';
+import type { Finding, UsageStats, SkippedFile, RetryConfig, ErrorCode, HunkFailure, HunkTrace } from '../types/index.js';
 import type { HunkWithContext } from '../diff/index.js';
 import type { ChunkingConfig, ReasoningEffort } from '../config/schema.js';
 import type { RuntimeName } from './runtimes/index.js';
@@ -44,6 +44,8 @@ export interface HunkAnalysisResult {
   attempts?: number;
   /** Usage from auxiliary LLM calls (e.g., extraction repair) */
   auxiliaryUsage?: AuxiliaryUsageEntry[];
+  /** Optional runtime trace captured for this hunk. */
+  trace?: HunkTrace;
 }
 
 /** Result from one completed chunk, suitable for durable run logging. */
@@ -63,6 +65,8 @@ export interface ChunkAnalysisResult {
   extractionError?: string;
   extractionPreview?: string;
   auxiliaryUsage?: AuxiliaryUsageEntry[];
+  /** Optional runtime trace captured for this chunk. */
+  trace?: HunkTrace;
 }
 
 /**
@@ -134,6 +138,8 @@ export interface SkillRunnerOptions {
   postProcessFindings?: boolean;
   /** Trigger name to attach to skill-level telemetry when the caller has one. */
   telemetryTriggerName?: string;
+  /** Capture per-hunk runtime traces in structured run output. Defaults to false. */
+  captureTraces?: boolean;
 }
 
 /**
@@ -201,6 +207,8 @@ export interface FileAnalysisResult {
   hunkFailures: HunkFailure[];
   /** Usage from auxiliary LLM calls across all hunks */
   auxiliaryUsage?: AuxiliaryUsageEntry[];
+  /** Optional runtime traces captured for analyzed hunks. */
+  traces?: HunkTrace[];
 }
 
 /**

--- a/packages/warden/src/sentry-trace.ts
+++ b/packages/warden/src/sentry-trace.ts
@@ -3,42 +3,13 @@ import type { Span } from '@sentry/node';
 import { Sentry } from './sentry.js';
 import type { TraceSpan, TraceSpanAttributeValue } from './types/index.js';
 
-type SentrySpan = Span;
-
-type TracedSpanAttributeValue = string | number | boolean | (string | number | boolean)[] | undefined;
-
-export interface TracedSpanOptions {
-  op?: string;
-  name?: string;
-  attributes?: Record<string, TracedSpanAttributeValue>;
-  startTime?: number | Date;
-  parentSpan?: SentrySpan;
-}
-
-interface SpanContextLike {
-  traceId?: string;
-  spanId?: string;
-}
-
-interface SpanLike {
-  spanContext?: () => SpanContextLike;
-}
-
-interface SentrySpanJsonLike {
-  data?: Record<string, unknown>;
-  description?: unknown;
-  op?: unknown;
-  parent_span_id?: unknown;
-  span_id?: unknown;
-  start_timestamp?: unknown;
-  status?: unknown;
-  timestamp?: unknown;
-  trace_id?: unknown;
-  origin?: unknown;
-}
+type SentryStartSpanOptions = Parameters<typeof Sentry.startSpan>[0];
+type SentrySpanContext = ReturnType<Span['spanContext']>;
+type SentrySpanJson = ReturnType<typeof Sentry.spanToJSON>;
+type SentrySpanAttributeValue = SentrySpanJson['data'][string];
 
 export interface TraceRecorder {
-  record(span: SentrySpan | undefined): void;
+  record(span: Span | undefined): void;
   snapshot(): TraceSpan[] | undefined;
 }
 
@@ -51,7 +22,7 @@ export function withTraceRecorder<T>(recorder: TraceRecorder | undefined, callba
 }
 
 /** Return the Sentry span context when available. */
-export function getSpanContext(span: SpanLike | undefined): SpanContextLike | undefined {
+export function getSpanContext(span: Span | undefined): SentrySpanContext | undefined {
   try {
     return span?.spanContext?.();
   } catch {
@@ -68,7 +39,7 @@ function isTraceSpanAttributeValue(value: unknown): value is TraceSpanAttributeV
   );
 }
 
-function compactAttributes(attributes: Record<string, unknown> | undefined): Record<string, TraceSpanAttributeValue> | undefined {
+function compactAttributes(attributes: Record<string, SentrySpanAttributeValue | undefined> | undefined): Record<string, TraceSpanAttributeValue> | undefined {
   if (!attributes) return undefined;
 
   const compact: Record<string, TraceSpanAttributeValue> = {};
@@ -91,11 +62,11 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
-function snapshotSpan(span: unknown): TraceSpan | undefined {
+function snapshotSpan(span: Span | undefined): TraceSpan | undefined {
   if (!span) return undefined;
-  let spanJson: SentrySpanJsonLike;
+  let spanJson: SentrySpanJson;
   try {
-    spanJson = Sentry.spanToJSON(span as SentrySpan) as SentrySpanJsonLike;
+    spanJson = Sentry.spanToJSON(span);
   } catch {
     return undefined;
   }
@@ -152,16 +123,16 @@ function hasFinally(value: unknown): value is Promise<unknown> {
  * Warden-owned, though, so structured run output only depends on spans we
  * explicitly create through this helper.
  */
-export function startTracedSpan<T>(options: TracedSpanOptions, callback: (span: SentrySpan) => T): T {
+export function startTracedSpan<T>(options: SentryStartSpanOptions, callback: (span: Span) => T): T {
   const recorder = activeTraceRecorder();
-  let spanRef: SentrySpan | undefined;
+  let spanRef: Span | undefined;
   const recordSpan = (): void => recorder?.record(spanRef);
 
   try {
-    const result = Sentry.startSpan(options as Parameters<typeof Sentry.startSpan>[0], (span) => {
+    const result = Sentry.startSpan(options, (span) => {
       spanRef = span;
       return callback(span);
-    }) as T;
+    });
 
     if (hasFinally(result)) {
       return result.finally(recordSpan) as T;
@@ -175,24 +146,24 @@ export function startTracedSpan<T>(options: TracedSpanOptions, callback: (span: 
 }
 
 /** Start an inactive Sentry span that can be ended and recorded manually. */
-export function startInactiveTracedSpan(options: TracedSpanOptions): SentrySpan {
-  return Sentry.startInactiveSpan(options as Parameters<typeof Sentry.startInactiveSpan>[0]) as SentrySpan;
+export function startInactiveTracedSpan(options: SentryStartSpanOptions): Span {
+  return Sentry.startInactiveSpan(options);
 }
 
 /** Record a manually-ended span in the active Warden trace buffer. */
-export function recordTracedSpan(span: SentrySpan | undefined): void {
+export function recordTracedSpan(span: Span | undefined): void {
   activeTraceRecorder()?.record(span);
 }
 
 /** Create a hunk-scoped recorder for Warden-owned spans under a Sentry parent span. */
-export function startTraceRecorder(parentSpan: SpanLike | undefined): TraceRecorder | undefined {
+export function startTraceRecorder(parentSpan: Span | undefined): TraceRecorder | undefined {
   if (!parentSpan) return undefined;
 
   const parentContext = getSpanContext(parentSpan);
   const buffer = new Map<string, TraceSpan>();
 
   return {
-    record(span: SentrySpan | undefined) {
+    record(span: Span | undefined) {
       const snapshot = snapshotSpan(span);
       if (!snapshot) return;
       if (parentContext?.traceId && snapshot.traceId !== parentContext.traceId) return;

--- a/packages/warden/src/sentry-trace.ts
+++ b/packages/warden/src/sentry-trace.ts
@@ -1,0 +1,207 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Span } from '@sentry/node';
+import { Sentry } from './sentry.js';
+import type { TraceSpan, TraceSpanAttributeValue } from './types/index.js';
+
+type SentrySpan = Span;
+
+type TracedSpanAttributeValue = string | number | boolean | (string | number | boolean)[] | undefined;
+
+export interface TracedSpanOptions {
+  op?: string;
+  name?: string;
+  attributes?: Record<string, TracedSpanAttributeValue>;
+  startTime?: number | Date;
+  parentSpan?: SentrySpan;
+}
+
+interface SpanContextLike {
+  traceId?: string;
+  spanId?: string;
+}
+
+interface SpanLike {
+  spanContext?: () => SpanContextLike;
+}
+
+interface SentrySpanJsonLike {
+  data?: Record<string, unknown>;
+  description?: unknown;
+  op?: unknown;
+  parent_span_id?: unknown;
+  span_id?: unknown;
+  start_timestamp?: unknown;
+  status?: unknown;
+  timestamp?: unknown;
+  trace_id?: unknown;
+  origin?: unknown;
+}
+
+export interface TraceRecorder {
+  record(span: SentrySpan | undefined): void;
+  snapshot(): TraceSpan[] | undefined;
+}
+
+const traceRecorderStore = new AsyncLocalStorage<TraceRecorder>();
+
+/** Run a callback with a hunk-scoped trace recorder for Warden-created spans. */
+export function withTraceRecorder<T>(recorder: TraceRecorder | undefined, callback: () => T): T {
+  if (!recorder) return callback();
+  return traceRecorderStore.run(recorder, callback);
+}
+
+/** Return the Sentry span context when available. */
+export function getSpanContext(span: SpanLike | undefined): SpanContextLike | undefined {
+  try {
+    return span?.spanContext?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function isTraceSpanAttributeValue(value: unknown): value is TraceSpanAttributeValue {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+  return Array.isArray(value) && value.every((item) =>
+    typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean'
+  );
+}
+
+function compactAttributes(attributes: Record<string, unknown> | undefined): Record<string, TraceSpanAttributeValue> | undefined {
+  if (!attributes) return undefined;
+
+  const compact: Record<string, TraceSpanAttributeValue> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (isTraceSpanAttributeValue(value)) {
+      compact[key] = value;
+    }
+  }
+
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.round(value * 1000)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function snapshotSpan(span: unknown): TraceSpan | undefined {
+  if (!span) return undefined;
+  let spanJson: SentrySpanJsonLike;
+  try {
+    spanJson = Sentry.spanToJSON(span as SentrySpan) as SentrySpanJsonLike;
+  } catch {
+    return undefined;
+  }
+  const traceId = stringValue(spanJson?.trace_id);
+  const spanId = stringValue(spanJson?.span_id);
+  if (!traceId || !spanId) return undefined;
+
+  const startTimeUnixMs = timestampMs(spanJson?.start_timestamp);
+  const endTimeUnixMs = timestampMs(spanJson?.timestamp);
+
+  return {
+    traceId,
+    spanId,
+    parentSpanId: stringValue(spanJson?.parent_span_id),
+    op: stringValue(spanJson?.op),
+    name: stringValue(spanJson?.description),
+    startTimeUnixMs,
+    endTimeUnixMs,
+    durationMs: startTimeUnixMs !== undefined && endTimeUnixMs !== undefined
+      ? Math.max(0, endTimeUnixMs - startTimeUnixMs)
+      : undefined,
+    status: stringValue(spanJson?.status),
+    origin: stringValue(spanJson?.origin),
+    attributes: compactAttributes(spanJson?.data),
+  };
+}
+
+function descendantsForParent(spans: TraceSpan[], parentSpanId: string | undefined): TraceSpan[] {
+  if (!parentSpanId) return spans;
+
+  const byId = new Map(spans.map((span) => [span.spanId, span]));
+  return spans.filter((span) => {
+    let currentParentId = span.parentSpanId;
+    while (currentParentId) {
+      if (currentParentId === parentSpanId) return true;
+      currentParentId = byId.get(currentParentId)?.parentSpanId;
+    }
+    return false;
+  });
+}
+
+function activeTraceRecorder(): TraceRecorder | undefined {
+  return traceRecorderStore.getStore();
+}
+
+function hasFinally(value: unknown): value is Promise<unknown> {
+  return Boolean(value && typeof value === 'object' && typeof (value as { finally?: unknown }).finally === 'function');
+}
+
+/**
+ * Start a real Sentry span and record it in Warden's active hunk trace buffer.
+ *
+ * The span still participates in Sentry's distributed trace. The buffer is
+ * Warden-owned, though, so structured run output only depends on spans we
+ * explicitly create through this helper.
+ */
+export function startTracedSpan<T>(options: TracedSpanOptions, callback: (span: SentrySpan) => T): T {
+  const recorder = activeTraceRecorder();
+  let spanRef: SentrySpan | undefined;
+  const recordSpan = (): void => recorder?.record(spanRef);
+
+  try {
+    const result = Sentry.startSpan(options as Parameters<typeof Sentry.startSpan>[0], (span) => {
+      spanRef = span;
+      return callback(span);
+    }) as T;
+
+    if (hasFinally(result)) {
+      return result.finally(recordSpan) as T;
+    }
+    recordSpan();
+    return result;
+  } catch (error) {
+    recordSpan();
+    throw error;
+  }
+}
+
+/** Start an inactive Sentry span that can be ended and recorded manually. */
+export function startInactiveTracedSpan(options: TracedSpanOptions): SentrySpan {
+  return Sentry.startInactiveSpan(options as Parameters<typeof Sentry.startInactiveSpan>[0]) as SentrySpan;
+}
+
+/** Record a manually-ended span in the active Warden trace buffer. */
+export function recordTracedSpan(span: SentrySpan | undefined): void {
+  activeTraceRecorder()?.record(span);
+}
+
+/** Create a hunk-scoped recorder for Warden-owned spans under a Sentry parent span. */
+export function startTraceRecorder(parentSpan: SpanLike | undefined): TraceRecorder | undefined {
+  if (!parentSpan) return undefined;
+
+  const parentContext = getSpanContext(parentSpan);
+  const buffer = new Map<string, TraceSpan>();
+
+  return {
+    record(span: SentrySpan | undefined) {
+      const snapshot = snapshotSpan(span);
+      if (!snapshot) return;
+      if (parentContext?.traceId && snapshot.traceId !== parentContext.traceId) return;
+      if (snapshot.spanId === parentContext?.spanId) return;
+      buffer.set(snapshot.spanId, snapshot);
+    },
+    snapshot() {
+      const spans = descendantsForParent([...buffer.values()], parentContext?.spanId);
+      return spans.length > 0 ? spans : undefined;
+    },
+  };
+}

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -274,6 +274,47 @@ export const HunkFailureSchema = z.object({
 });
 export type HunkFailure = z.infer<typeof HunkFailureSchema>;
 
+const TraceSpanAttributeValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.union([z.string(), z.number(), z.boolean()])),
+]);
+export type TraceSpanAttributeValue = z.infer<typeof TraceSpanAttributeValueSchema>;
+
+export const TraceSpanSchema = z.object({
+  traceId: z.string(),
+  spanId: z.string(),
+  parentSpanId: z.string().optional(),
+  op: z.string().optional(),
+  name: z.string().optional(),
+  startTimeUnixMs: z.number().nonnegative().optional(),
+  endTimeUnixMs: z.number().nonnegative().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  status: z.string().optional(),
+  origin: z.string().optional(),
+  attributes: z.record(z.string(), TraceSpanAttributeValueSchema).optional(),
+});
+export type TraceSpan = z.infer<typeof TraceSpanSchema>;
+
+// Optional per-hunk runtime trace captured in structured run output.
+export const HunkTraceSchema = z.object({
+  filename: z.string(),
+  lineRange: z.string(),
+  runtime: z.string(),
+  status: z.string(),
+  traceId: z.string().optional(),
+  spanId: z.string().optional(),
+  responseId: z.string().optional(),
+  responseModel: z.string().optional(),
+  sessionId: z.string().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  durationApiMs: z.number().nonnegative().optional(),
+  numTurns: z.number().int().nonnegative().optional(),
+  spans: z.array(TraceSpanSchema).optional(),
+});
+export type HunkTrace = z.infer<typeof HunkTraceSchema>;
+
 // Skill report output
 export const SkillReportSchema = z.object({
   skill: z.string(),
@@ -290,6 +331,8 @@ export const SkillReportSchema = z.object({
   failedExtractions: z.number().int().nonnegative().optional(),
   /** Per-hunk failure details, in execution order. */
   hunkFailures: z.array(HunkFailureSchema).optional(),
+  /** Optional per-hunk runtime traces, only captured when explicitly requested. */
+  traces: z.array(HunkTraceSchema).optional(),
   /** Set when the run cannot complete normally. */
   error: SkillErrorSchema.optional(),
   /** Usage from auxiliary LLM calls (extraction repair, semantic dedup, etc.) */

--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -94,6 +94,9 @@
           "items": {
             "$ref": "#/$defs/SkippedFile"
           }
+        },
+        "trace": {
+          "$ref": "#/$defs/HunkTrace"
         }
       },
       "required": [
@@ -428,6 +431,142 @@
       ],
       "additionalProperties": false
     },
+    "HunkTrace": {
+      "type": "object",
+      "properties": {
+        "filename": {
+          "type": "string"
+        },
+        "lineRange": {
+          "type": "string"
+        },
+        "runtime": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "traceId": {
+          "type": "string"
+        },
+        "spanId": {
+          "type": "string"
+        },
+        "responseId": {
+          "type": "string"
+        },
+        "responseModel": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "durationApiMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "numTurns": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "spans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TraceSpan"
+          }
+        }
+      },
+      "required": [
+        "filename",
+        "lineRange",
+        "runtime",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "TraceSpan": {
+      "type": "object",
+      "properties": {
+        "traceId": {
+          "type": "string"
+        },
+        "spanId": {
+          "type": "string"
+        },
+        "parentSpanId": {
+          "type": "string"
+        },
+        "op": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "startTimeUnixMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "endTimeUnixMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "status": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "traceId",
+        "spanId"
+      ],
+      "additionalProperties": false
+    },
     "SkillRecord": {
       "type": "object",
       "properties": {
@@ -477,6 +616,12 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/HunkFailure"
+          }
+        },
+        "traces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HunkTrace"
           }
         },
         "error": {


### PR DESCRIPTION
Add opt-in trace capture to Warden run output with `--traces`, attaching each hunk's distributed trace metadata and Warden-owned spans to chunk JSONL records and reconstructed skill reports.

**Trace Capture**

The SDK now records spans created through Warden tracing helpers under the hunk analysis span, so run artifacts include invoke-agent, chat, and tool execution spans for Claude, Haiku, and Pi without relying on Sentry hook capture.

**JSONL Output**

Chunk records can include a trace payload, and the JSONL parser rehydrates report-level traces for follow and finalized output consumers.

**Tool Semantics**

Tool execution spans follow OTel GenAI semantics, including `gen_ai.tool.call.id` and serialized arguments/results when available.