### PR TITLE
fix(sdk): Capture GenAI tool trace content

### DIFF
--- a/packages/warden/src/sdk/haiku.ts
+++ b/packages/warden/src/sdk/haiku.ts
@@ -6,9 +6,11 @@ import { startTracedSpan } from '../sentry-trace.js';
 import { apiUsageToStats } from './pricing.js';
 import { aggregateUsage, emptyUsage } from './usage.js';
 import {
+  genAiSpanName,
   genAiToolCallAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
+  setGenAiOutputMessagesAttrFromMessages,
   setGenAiUsageAttrs,
 } from './otel.js';
 
@@ -191,7 +193,7 @@ export async function callHaiku<T>(options: CallHaikuOptions<T>): Promise<HaikuR
   return startTracedSpan(
     {
       op: 'gen_ai.chat',
-      name: `chat ${model}`,
+      name: genAiSpanName('chat', model),
       attributes: {
         'gen_ai.operation.name': 'chat',
         'gen_ai.provider.name': 'anthropic',
@@ -282,6 +284,10 @@ export interface CallHaikuWithToolsOptions<T> {
  * Multi-turn Haiku call with tool use loop.
  * Iterates tool calls until the model produces a final text response.
  * Accumulates usage across all iterations.
+ *
+ * Telemetry mirrors an agent run: the outer span describes the local
+ * orchestration, each Anthropic API call gets its own `gen_ai.chat` span, and
+ * every application-executed tool call is recorded as `gen_ai.execute_tool`.
  */
 export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T>): Promise<HaikuResult<T>> {
   const {
@@ -301,10 +307,10 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
 
   return startTracedSpan(
     {
-      op: 'gen_ai.chat',
-      name: `chat ${model}`,
+      op: 'gen_ai.invoke_agent',
+      name: genAiSpanName('invoke_agent', agentName),
       attributes: {
-        'gen_ai.operation.name': 'chat',
+        'gen_ai.operation.name': 'invoke_agent',
         'gen_ai.provider.name': 'anthropic',
         ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
         ...(task ? { 'warden.ai.task': task } : {}),
@@ -315,14 +321,17 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
     },
     async (span) => {
       const client = new Anthropic({ apiKey, timeout, maxRetries });
+      const toolDescriptions = new Map(
+        tools
+          .map((tool) => [tool.name, tool.description])
+          .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].length > 0),
+      );
 
       // No prefill for tool-use loops: prefill biases the model to output JSON
       // immediately instead of calling tools to gather information first.
       const messages: Anthropic.MessageParam[] = [
         { role: 'user', content: prompt },
       ];
-
-      setGenAiInputMessagesAttr(span, messages);
 
       const usages: UsageStats[] = [];
       // Accumulate raw API usage across iterations so setGenAiResponseAttrs
@@ -338,23 +347,59 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
         },
       };
 
-      function setFinalSpanAttrs(stopReason?: string | null, responseText?: string): void {
-        setGenAiResponseAttrs(span, cumulativeUsage, stopReason, responseText);
+      function setFinalSpanAttrs(stopReason?: string | null): void {
+        setGenAiResponseAttrs(span, cumulativeUsage, stopReason);
       }
 
       function currentUsage(): UsageStats {
         return usages.length > 0 ? aggregateUsage(usages) : emptyUsage();
       }
 
+      async function runModelIteration(): Promise<Anthropic.Message> {
+        const inputMessages = [...messages];
+        return startTracedSpan(
+          {
+            op: 'gen_ai.chat',
+            name: genAiSpanName('chat', model),
+            parentSpan: span,
+            attributes: {
+              'gen_ai.operation.name': 'chat',
+              'gen_ai.provider.name': 'anthropic',
+              ...(agentName ? { 'gen_ai.agent.name': agentName } : {}),
+              ...(task ? { 'warden.ai.task': task } : {}),
+              'gen_ai.request.model': model,
+              'gen_ai.request.max_tokens': maxTokens,
+              'gen_ai.output.type': 'json',
+            },
+          },
+          async (chatSpan) => {
+            setGenAiInputMessagesAttr(chatSpan, inputMessages);
+            try {
+              const response = await client.messages.create({
+                model,
+                max_tokens: maxTokens,
+                messages: inputMessages,
+                tools,
+              });
+              setGenAiResponseAttrs(chatSpan, response.usage, response.stop_reason);
+              setGenAiOutputMessagesAttrFromMessages(chatSpan, [{
+                role: response.role,
+                content: response.content,
+                finishReason: response.stop_reason,
+              }]);
+              return response;
+            } catch (error) {
+              chatSpan.setAttribute('error.type', error instanceof Error ? error.name : '_OTHER');
+              throw error;
+            }
+          },
+        );
+      }
+
       for (let iteration = 0; iteration < maxIterations; iteration++) {
         let response: Anthropic.Message;
         try {
-          response = await client.messages.create({
-            model,
-            max_tokens: maxTokens,
-            messages,
-            tools,
-          });
+          response = await runModelIteration();
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           span.setAttribute('error.type', error instanceof Error ? error.name : '_OTHER');
@@ -388,10 +433,12 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
               {
                 op: 'gen_ai.execute_tool',
                 name: `execute_tool ${block.name}`,
+                parentSpan: span,
                 attributes: genAiToolCallAttributes({
                   agentName,
                   task,
                   toolName: block.name,
+                  toolDescription: toolDescriptions.get(block.name),
                   toolCallId: block.id,
                   toolType: 'function',
                   arguments: block.input,
@@ -438,7 +485,7 @@ export async function callHaikuWithTools<T>(options: CallHaikuWithToolsOptions<T
           return { success: false, error: 'No text in final response', usage: aggregateUsage(usages) };
         }
 
-        setFinalSpanAttrs(response.stop_reason, textBlock.text);
+        setFinalSpanAttrs(response.stop_reason);
 
         const jsonStr = extractJson(textBlock.text);
         if (!jsonStr) {

--- a/packages/warden/src/sdk/otel.ts
+++ b/packages/warden/src/sdk/otel.ts
@@ -7,9 +7,20 @@ interface SpanLike {
   ): unknown;
 }
 
-interface GenAiMessage {
+/**
+ * Provider-neutral message envelope used before writing OTel GenAI attributes.
+ *
+ * Runtime adapters pass raw provider content blocks here. This module owns the
+ * conversion to the current `gen_ai.*.messages` schema so Claude, Pi, and
+ * Anthropic API shapes do not leak into trace consumers.
+ */
+export interface GenAiMessage {
   role: string;
   content: unknown;
+  /** Tool result messages from some runtimes carry the call ID outside content. */
+  toolCallId?: string;
+  /** Provider finish/stop reason, emitted as OTel `finish_reason`. */
+  finishReason?: string | null;
 }
 
 type GenAiUsageAttributes = Record<string, number>;
@@ -39,6 +50,12 @@ export function genAiProviderName(runtime: string | undefined, model: string | u
   return providerFromModel(model) ?? (runtime === 'pi' ? 'pi' : 'anthropic');
 }
 
+/** Build OTel GenAI span names as `<operation> <semantic target>`, when known. */
+export function genAiSpanName(operationName: string, targetName: string | undefined): string {
+  const trimmedTarget = targetName?.trim();
+  return trimmedTarget ? `${operationName} ${trimmedTarget}` : operationName;
+}
+
 /** Build current OpenTelemetry GenAI usage attributes from normalized usage. */
 export function genAiUsageAttributes(usage: UsageStats): GenAiUsageAttributes {
   return {
@@ -62,11 +79,18 @@ function stringifyGenAiAttribute(value: unknown): string | undefined {
   }
 }
 
-/** Build OpenTelemetry GenAI attributes for an executed tool call span. */
+/**
+ * Build OpenTelemetry GenAI attributes for an executed tool call span.
+ *
+ * Tool arguments and results are opt-in content attributes in OTel. Sentry span
+ * data and Warden's local trace schema only preserve primitive attributes, so
+ * structured values are JSON-encoded at this boundary.
+ */
 export function genAiToolCallAttributes(args: {
   agentName?: string;
   task?: string;
   toolName: string;
+  toolDescription?: string;
   toolCallId?: string;
   toolType?: string;
   arguments?: unknown;
@@ -78,6 +102,7 @@ export function genAiToolCallAttributes(args: {
     ...(args.agentName ? { 'gen_ai.agent.name': args.agentName } : {}),
     ...(args.task ? { 'warden.ai.task': args.task } : {}),
     'gen_ai.tool.name': args.toolName,
+    ...(args.toolDescription ? { 'gen_ai.tool.description': args.toolDescription } : {}),
     ...(args.toolCallId ? { 'gen_ai.tool.call.id': args.toolCallId } : {}),
     ...(args.toolType ? { 'gen_ai.tool.type': args.toolType } : {}),
   };
@@ -126,41 +151,101 @@ function normalizeContentPart(part: unknown): Record<string, unknown> {
       arguments: block['input'],
     };
   }
+  if (block['type'] === 'toolCall') {
+    return {
+      type: 'tool_call',
+      id: block['id'],
+      name: block['name'],
+      arguments: block['arguments'],
+    };
+  }
   if (block['type'] === 'tool_result') {
     return {
       type: 'tool_call_response',
       id: block['tool_use_id'],
-      result: block['content'],
+      result: normalizeToolResultContent(block['content']),
     };
   }
 
   return { ...block };
 }
 
+function normalizeToolResultContent(content: unknown): unknown {
+  if (Array.isArray(content)) {
+    const normalized = content.map(normalizeContentPart);
+    if (
+      normalized.length === 1
+      && normalized[0]?.['type'] === 'text'
+      && typeof normalized[0]?.['content'] === 'string'
+    ) {
+      return normalized[0]['content'];
+    }
+    return normalized;
+  }
+
+  return content;
+}
+
+function finishReasonAttrs(message: GenAiMessage): Record<string, string> {
+  return message.finishReason ? { finish_reason: message.finishReason } : {};
+}
+
 function normalizeMessage(message: GenAiMessage): Record<string, unknown> {
   const { role, content } = message;
+  if ((role === 'tool' || role === 'toolResult') && message.toolCallId) {
+    return {
+      role: 'tool',
+      parts: [{
+        type: 'tool_call_response',
+        id: message.toolCallId,
+        result: normalizeToolResultContent(content),
+      }],
+    };
+  }
+
+  const contentParts = Array.isArray(content) ? content : undefined;
+  // Anthropic tool results arrive as user messages; OTel records them as tool
+  // messages so trace readers can reconstruct the request/result pairing.
+  const normalizedRole = role === 'toolResult'
+    || (
+      role === 'user'
+      && contentParts?.length
+      && contentParts.every((part) =>
+        Boolean(part && typeof part === 'object' && (part as Record<string, unknown>)['type'] === 'tool_result')
+      )
+    )
+    ? 'tool'
+    : role;
   if (typeof content === 'string') {
     return {
-      role,
+      role: normalizedRole,
       parts: [{ type: 'text', content }],
+      ...finishReasonAttrs(message),
     };
   }
   if (Array.isArray(content)) {
     return {
-      role,
+      role: normalizedRole,
       parts: content.map(normalizeContentPart),
+      ...finishReasonAttrs(message),
     };
   }
 
   return {
-    role,
+    role: normalizedRole,
     parts: [normalizeContentPart(content)],
+    ...finishReasonAttrs(message),
   };
 }
 
-/** Set OpenTelemetry GenAI input message attributes using the current schema. */
+/** Set OTel GenAI input messages from raw runtime transcript messages. */
 export function setGenAiInputMessagesAttr(span: SpanLike, messages: GenAiMessage[]): void {
   span.setAttribute('gen_ai.input.messages', JSON.stringify(messages.map(normalizeMessage)));
+}
+
+/** Set OTel GenAI output messages from raw runtime response messages. */
+export function setGenAiOutputMessagesAttrFromMessages(span: SpanLike, messages: GenAiMessage[]): void {
+  span.setAttribute('gen_ai.output.messages', JSON.stringify(messages.map(normalizeMessage)));
 }
 
 /** Set OpenTelemetry GenAI output message attributes for text responses. */

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -16,16 +16,18 @@
  * - Claude-specific result subtypes normalize to Warden-owned statuses.
  */
 import type Anthropic from '@anthropic-ai/sdk';
-import { query, type EffortLevel, type SDKResultMessage } from '@anthropic-ai/claude-agent-sdk';
+import { query, type EffortLevel, type SDKResultMessage, type SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { ToolConfig, ToolName } from '../../config/schema.js';
-import { Sentry } from '../../sentry.js';
 import { recordTracedSpan, startInactiveTracedSpan, startTracedSpan } from '../../sentry-trace.js';
 import { callHaiku, callHaikuWithTools } from '../haiku.js';
 import {
+  type GenAiMessage,
+  genAiSpanName,
   genAiToolCallAttributes,
   genAiUsageAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
+  setGenAiOutputMessagesAttrFromMessages,
   setGenAiSystemInstructionsAttr,
   setGenAiUsageAttrs,
 } from '../otel.js';
@@ -47,6 +49,8 @@ import type {
 
 /** Buffered data for a single SDK turn, flushed into gen_ai.chat child spans. */
 interface TurnData {
+  /** Raw assistant message content for this turn, normalized only in sdk/otel.ts. */
+  outputMessage: GenAiMessage;
   toolUses: { id: string; name: string; input?: unknown }[];
   inputTokens: number;
   outputTokens: number;
@@ -218,6 +222,55 @@ function turnUsageToStats(turn: TurnData) {
   });
 }
 
+function claudeUserMessage(message: SDKUserMessage): GenAiMessage {
+  if (message.tool_use_result !== undefined && message.parent_tool_use_id) {
+    return {
+      role: 'tool',
+      content: message.tool_use_result,
+      toolCallId: message.parent_tool_use_id,
+    };
+  }
+
+  return {
+    role: message.message.role,
+    content: message.message.content,
+  };
+}
+
+function toolResultBlockContent(content: unknown, toolCallId: string): unknown {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  for (const part of content) {
+    if (!part || typeof part !== 'object') {
+      continue;
+    }
+
+    const block = part as Record<string, unknown>;
+    if (block['type'] === 'tool_result' && block['tool_use_id'] === toolCallId) {
+      return block['content'];
+    }
+  }
+
+  return undefined;
+}
+
+function toolResultForCall(messages: GenAiMessage[], toolCallId: string): unknown {
+  for (const message of messages) {
+    if ((message.role === 'tool' || message.role === 'toolResult') && message.toolCallId === toolCallId) {
+      return message.content;
+    }
+
+    const blockContent = toolResultBlockContent(message.content, toolCallId);
+    if (blockContent !== undefined) {
+      return blockContent;
+    }
+  }
+
+  return undefined;
+}
+
 function reconcileStreamedUsage(args: {
   result: SDKResultMessage;
   streamedUsage?: ReturnType<typeof turnUsageToStats>;
@@ -307,17 +360,16 @@ export const claudeRuntime: Runtime = {
     const { maxTurns = 50, model, effort, abortController } = options;
     const { pathToClaudeCodeExecutable } = getClaudeProviderOptions(providerOptions);
     const skillTools = resolveClaudeSkillTools(tools, allowMutatingTools);
-    const modelId = model ?? 'unknown';
 
     return startTracedSpan(
       {
         op: 'gen_ai.invoke_agent',
-        name: `invoke_agent ${skillName}`,
+        name: genAiSpanName('invoke_agent', skillName),
         attributes: {
           'gen_ai.operation.name': 'invoke_agent',
           'gen_ai.provider.name': 'anthropic',
           'gen_ai.agent.name': skillName,
-          'gen_ai.request.model': modelId,
+          ...(model ? { 'gen_ai.request.model': model } : {}),
           'warden.request.max_turns': maxTurns,
         },
       },
@@ -360,12 +412,18 @@ export const claudeRuntime: Runtime = {
         const turnUsages: ReturnType<typeof turnUsageToStats>[] = [];
         const responseModels = new Set<string>();
         const pendingToolProgress = new Map<string, number>();
+        const conversationMessages: GenAiMessage[] = [{ role: 'user', content: userPrompt }];
+        // Tool-result user messages can arrive after the assistant event they
+        // answer, so hold them until that turn span has been flushed.
+        const pendingFollowUpMessages: GenAiMessage[] = [];
 
         function flushPendingTurn(): void {
           if (!pendingTurn) return;
           turnCount++;
           const turn = pendingTurn;
           const toolProgress = new Map(pendingToolProgress);
+          const inputMessages = [...conversationMessages];
+          const followUpMessages = [...pendingFollowUpMessages];
           pendingTurn = null;
           pendingToolProgress.clear();
           turnUsages.push(turnUsageToStats(turn));
@@ -387,55 +445,62 @@ export const claudeRuntime: Runtime = {
             startTracedSpan(
               {
                 op: 'gen_ai.chat',
-                name: `chat ${skillName} turn ${turnCount}`,
+                name: genAiSpanName('chat', model),
+                parentSpan: span,
                 attributes: {
                   'gen_ai.operation.name': 'chat',
                   'gen_ai.provider.name': 'anthropic',
                   'gen_ai.agent.name': skillName,
-                  'gen_ai.request.model': modelId,
+                  ...(model ? { 'gen_ai.request.model': model } : {}),
                   'gen_ai.response.model': turn.model,
                   ...usageAttrs,
                 },
               },
-              () => {
-                for (const toolUse of turn.toolUses) {
-                  const elapsed = toolProgress.get(toolUse.id);
-                  const attributes = genAiToolCallAttributes({
-                    agentName: skillName,
-                    toolName: toolUse.name,
-                    toolCallId: toolUse.id,
-                    toolType: 'function',
-                    arguments: toolUse.input,
-                  });
-
-                  if (elapsed !== undefined) {
-                    const endTime = Date.now() / 1000;
-                    const parentSpan = Sentry.getActiveSpan();
-                    const span = startInactiveTracedSpan({
-                      op: 'gen_ai.execute_tool',
-                      name: `execute_tool ${toolUse.name}`,
-                      ...(parentSpan && { parentSpan }),
-                      startTime: Math.max(0, endTime - elapsed),
-                      attributes,
-                    });
-                    span.end(endTime);
-                    recordTracedSpan(span);
-                  } else {
-                    startTracedSpan(
-                      {
-                        op: 'gen_ai.execute_tool',
-                        name: `execute_tool ${toolUse.name}`,
-                        attributes,
-                      },
-                      () => undefined
-                    );
-                  }
-                }
-              }
+              (chatSpan) => {
+                setGenAiInputMessagesAttr(chatSpan, inputMessages);
+                setGenAiOutputMessagesAttrFromMessages(chatSpan, [turn.outputMessage]);
+              },
             );
+
+            for (const toolUse of turn.toolUses) {
+              const elapsed = toolProgress.get(toolUse.id);
+              const attributes = genAiToolCallAttributes({
+                agentName: skillName,
+                toolName: toolUse.name,
+                toolCallId: toolUse.id,
+                toolType: 'function',
+                arguments: toolUse.input,
+                result: toolResultForCall(followUpMessages, toolUse.id),
+              });
+
+              if (elapsed !== undefined) {
+                const endTime = Date.now() / 1000;
+                const toolSpan = startInactiveTracedSpan({
+                  op: 'gen_ai.execute_tool',
+                  name: `execute_tool ${toolUse.name}`,
+                  parentSpan: span,
+                  startTime: Math.max(0, endTime - elapsed),
+                  attributes,
+                });
+                toolSpan.end(endTime);
+                recordTracedSpan(toolSpan);
+              } else {
+                startTracedSpan(
+                  {
+                    op: 'gen_ai.execute_tool',
+                    name: `execute_tool ${toolUse.name}`,
+                    parentSpan: span,
+                    attributes,
+                  },
+                  () => undefined,
+                );
+              }
+            }
           } catch {
             // Telemetry should never break the workflow.
           }
+          conversationMessages.push(turn.outputMessage, ...followUpMessages);
+          pendingFollowUpMessages.length = 0;
         }
 
         try {
@@ -449,6 +514,11 @@ export const claudeRuntime: Runtime = {
                 .filter((block): block is typeof block & { type: 'tool_use' } => block.type === 'tool_use')
                 .map(({ id, name, input }) => ({ id, name, input }));
               pendingTurn = {
+                outputMessage: {
+                  role: msg.role,
+                  content: msg.content,
+                  finishReason: msg.stop_reason,
+                },
                 toolUses,
                 inputTokens: msg.usage?.input_tokens ?? 0,
                 outputTokens: msg.usage?.output_tokens ?? 0,
@@ -459,6 +529,13 @@ export const claudeRuntime: Runtime = {
                 webSearchRequests: msg.usage?.server_tool_use?.web_search_requests ?? 0,
                 model: msg.model,
               };
+            } else if (message.type === 'user') {
+              const userMessage = claudeUserMessage(message);
+              if (pendingTurn) {
+                pendingFollowUpMessages.push(userMessage);
+              } else {
+                conversationMessages.push(userMessage);
+              }
             } else if (message.type === 'tool_progress') {
               pendingToolProgress.set(message.tool_use_id, message.elapsed_time_seconds);
             } else if (message.type === 'result') {

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -26,8 +26,10 @@ import {
   type Model,
   type TSchema,
   type TextContent,
+  type ToolResultMessage,
   type Usage,
 } from '@earendil-works/pi-ai';
+import type { Span } from '@sentry/node';
 import { z } from 'zod';
 import type { Effort, ToolConfig, ToolName } from '../../config/schema.js';
 import { Sentry } from '../../sentry.js';
@@ -37,10 +39,14 @@ import { bridgeWardenProviderApiKeyEnv } from '../../utils/index.js';
 import { extractJson } from '../haiku.js';
 import { isAuthenticationErrorMessage, sanitizeErrorMessage } from '../errors.js';
 import {
+  type GenAiMessage,
+  genAiSpanName,
   genAiToolCallAttributes,
   genAiProviderName,
+  genAiUsageAttributes,
   setGenAiInputMessagesAttr,
   setGenAiOutputMessagesAttr,
+  setGenAiOutputMessagesAttrFromMessages,
   setGenAiSystemInstructionsAttr,
   setGenAiUsageAttrs,
 } from '../otel.js';
@@ -102,6 +108,9 @@ interface PiPromptOptions {
   maxRetries?: number;
   timeout?: number;
   abortController?: AbortController;
+  toolDescriptions?: Record<string, string>;
+  /** Parent `invoke_agent` span for model-call and tool-execution child spans. */
+  parentSpan?: Span;
 }
 
 function errorMessage(error: unknown): string {
@@ -356,6 +365,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
   let hitMaxTurns = false;
   const startedAt = Date.now();
   const activeToolSpans = new Map<string, PiToolSpan>();
+  const conversationMessages: GenAiMessage[] = [{ role: 'user', content: options.userPrompt }];
 
   const buildToolAttributes = (args: {
     toolName: string;
@@ -367,6 +377,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
     genAiToolCallAttributes({
       agentName: options.agentName,
       toolName: args.toolName,
+      toolDescription: options.toolDescriptions?.[args.toolName],
       toolCallId: args.toolCallId,
       toolType: 'function',
       arguments: args.input,
@@ -376,7 +387,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
 
   function startToolSpan(event: { toolCallId: string; toolName: string; args: unknown }): void {
     try {
-      const parentSpan = Sentry.getActiveSpan();
+      const parentSpan = options.parentSpan ?? Sentry.getActiveSpan();
       const span = startInactiveTracedSpan({
         op: 'gen_ai.execute_tool',
         name: `execute_tool ${event.toolName}`,
@@ -400,7 +411,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
     isError: boolean;
   }): void {
     try {
-      const parentSpan = Sentry.getActiveSpan();
+      const parentSpan = options.parentSpan ?? Sentry.getActiveSpan();
       const span = activeToolSpans.get(event.toolCallId) ?? startInactiveTracedSpan({
         op: 'gen_ai.execute_tool',
         name: `execute_tool ${event.toolName}`,
@@ -434,6 +445,46 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
       }
     }
     activeToolSpans.clear();
+  }
+
+  function recordTurnSpan(
+    message: AssistantMessage,
+    toolResults: ToolResultMessage[] | undefined,
+  ): void {
+    const outputMessage: GenAiMessage = {
+      role: message.role,
+      content: message.content,
+      finishReason: message.stopReason,
+    };
+    const followUpMessages = toolResults ?? [];
+    const requestModel = options.model ?? message.model ?? message.responseModel;
+
+    try {
+      const usageAttrs = genAiUsageAttributes(piUsageToStats(message.usage));
+      startTracedSpan(
+        {
+          op: 'gen_ai.chat',
+          name: genAiSpanName('chat', requestModel),
+          ...(options.parentSpan ? { parentSpan: options.parentSpan } : {}),
+          attributes: {
+            'gen_ai.operation.name': 'chat',
+            'gen_ai.provider.name': message.provider ?? genAiProviderName('pi', options.model),
+            ...(options.agentName ? { 'gen_ai.agent.name': options.agentName } : {}),
+            ...(requestModel ? { 'gen_ai.request.model': requestModel } : {}),
+            'gen_ai.response.model': message.responseModel ?? message.model,
+            ...usageAttrs,
+          },
+        },
+        (span) => {
+          setGenAiInputMessagesAttr(span, conversationMessages);
+          setGenAiOutputMessagesAttrFromMessages(span, [outputMessage]);
+        },
+      );
+    } catch {
+      // Telemetry should never break the workflow.
+    }
+
+    conversationMessages.push(outputMessage, ...followUpMessages);
   }
 
   try {
@@ -474,6 +525,9 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
       } else if (event.type === 'tool_execution_end') {
         finishToolSpan(event);
       } else if (event.type === 'turn_end') {
+        if (isAssistantMessage(event.message)) {
+          recordTurnSpan(event.message, event.toolResults);
+        }
         numTurns++;
         if (
           options.maxTurns !== undefined
@@ -569,6 +623,18 @@ function toPiCustomTools(
   }));
 }
 
+function toolDescriptionsByName(tools: AuxiliaryTool[] | undefined): Record<string, string> | undefined {
+  const descriptions = Object.fromEntries(
+    (tools ?? [])
+      .filter((tool): tool is AuxiliaryTool & { description: string } =>
+        typeof tool.description === 'string' && tool.description.length > 0
+      )
+      .map((tool) => [tool.name, tool.description]),
+  );
+
+  return Object.keys(descriptions).length > 0 ? descriptions : undefined;
+}
+
 async function runStructured<T>(
   request: {
     kind: 'auxiliary' | 'synthesis';
@@ -589,17 +655,18 @@ async function runStructured<T>(
   const customTools = toPiCustomTools(request.tools, request.executeTool);
   const systemPrompt = toStructuredPrompt(request.kind, request.task, request.schema);
   const toolNames = customTools?.map((tool) => tool.name) ?? [];
+  const toolDescriptions = toolDescriptionsByName(request.tools);
 
   return startTracedSpan(
     {
-      op: 'gen_ai.chat',
-      name: `chat ${request.model ?? 'pi-default'}`,
+      op: 'gen_ai.invoke_agent',
+      name: genAiSpanName('invoke_agent', request.agentName),
       attributes: {
-        'gen_ai.operation.name': 'chat',
+        'gen_ai.operation.name': 'invoke_agent',
         'gen_ai.provider.name': genAiProviderName('pi', request.model),
         ...(request.agentName ? { 'gen_ai.agent.name': request.agentName } : {}),
         ...(request.task ? { 'warden.ai.task': request.task } : {}),
-        'gen_ai.request.model': request.model ?? 'default',
+        ...(request.model ? { 'gen_ai.request.model': request.model } : {}),
         'gen_ai.output.type': 'json',
       },
     },
@@ -617,9 +684,11 @@ async function runStructured<T>(
           legacyAnthropicApiKey: request.apiKey,
           toolNames,
           customTools,
+          toolDescriptions,
           maxTurns: request.maxIterations,
           maxRetries: request.maxRetries,
           timeout: request.timeout,
+          parentSpan: span,
         });
         const result = normalizePiResult(run);
         if (!result) {
@@ -691,12 +760,12 @@ export const piRuntime: Runtime = {
     return startTracedSpan(
       {
         op: 'gen_ai.invoke_agent',
-        name: `invoke_agent ${skillName}`,
+        name: genAiSpanName('invoke_agent', skillName),
         attributes: {
           'gen_ai.operation.name': 'invoke_agent',
           'gen_ai.provider.name': genAiProviderName('pi', model),
           'gen_ai.agent.name': skillName,
-          'gen_ai.request.model': model ?? 'default',
+          ...(model ? { 'gen_ai.request.model': model } : {}),
           'warden.request.max_turns': maxTurns,
         },
       },
@@ -716,6 +785,7 @@ export const piRuntime: Runtime = {
             maxTurns,
             effort,
             abortController,
+            parentSpan: span,
           });
           run.warnings.unshift(...skillTools.warnings);
           const result = normalizePiResult(run);


### PR DESCRIPTION
Warden trace dumps now preserve enough GenAI content to reconstruct what a run did, not just the high-level metadata. Runtime traces include model turn messages and tool call payloads across Claude, Pi, and Haiku paths.

**Runtime Trace Content**

Claude and Pi runs now record per-turn input and output messages through the shared OTel normalizer, including tool call requests and tool result responses.

**Haiku Tool Loops**

Haiku tool-use calls now trace the local orchestration as an agent invocation, with each Anthropic request represented as its own chat span and each application-executed tool represented as an execute-tool span.

**OTel Normalization**

Provider-specific Anthropic and Pi message blocks are normalized in one place before writing GenAI span attributes, and structured tool arguments/results are JSON-encoded where Sentry span attributes require primitive values.