### PR TITLE
fix(sdk): Force short Claude prompt cache TTL

### DIFF
--- a/packages/warden/src/sdk/runtimes/claude.test.ts
+++ b/packages/warden/src/sdk/runtimes/claude.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { query, type SDKMessage, type SDKResultError, type SDKResultSuccess } from '@anthropic-ai/claude-agent-sdk';
 import { claudeRuntime } from './claude.js';
 
@@ -116,6 +116,10 @@ describe('claudeRuntime.runSkill', () => {
     mockQuery.mockReset();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('passes read-only Claude tools and normalizes the result', async () => {
     mockQuery.mockReturnValue(mockStream([successResult()]));
     const options = {
@@ -181,6 +185,29 @@ describe('claudeRuntime.runSkill', () => {
       options: expect.objectContaining({
         effort: 'medium',
         thinking: { type: 'adaptive' },
+      }),
+    });
+  });
+
+  it('forces Claude Code to use the short prompt-cache TTL by default', async () => {
+    vi.stubEnv('WARDEN_TEST_INHERITED_ENV', 'present');
+    mockQuery.mockReturnValue(mockStream([successResult()]));
+
+    await claudeRuntime.runSkill({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      repoPath: '/repo',
+      skillName: 'test-skill',
+      options: {},
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith({
+      prompt: 'user',
+      options: expect.objectContaining({
+        env: expect.objectContaining({
+          FORCE_PROMPT_CACHING_5M: '1',
+          WARDEN_TEST_INHERITED_ENV: 'present',
+        }),
       }),
     });
   });

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -72,6 +72,13 @@ const MUTATING_TOOLS = ['Write', 'Edit', 'Bash'] as const;
 const CLAUDE_AGENT_TOOLS = ['Task', 'TodoWrite'] as const;
 const DEFAULT_CLAUDE_EFFORT: EffortLevel = 'high';
 
+function claudeEnv(): Record<string, string | undefined> {
+  return {
+    ...process.env,
+    FORCE_PROMPT_CACHING_5M: '1',
+  };
+}
+
 function getClaudeProviderOptions(providerOptions: unknown): ClaudeProviderOptions {
   if (!providerOptions || typeof providerOptions !== 'object') {
     return {};
@@ -392,6 +399,7 @@ export const claudeRuntime: Runtime = {
             permissionMode: 'bypassPermissions',
             // Prevent SDK from writing session .jsonl files and polluting Claude Code's session index.
             persistSession: false,
+            env: claudeEnv(),
             model,
             ...effortOptions(effort),
             abortController,


### PR DESCRIPTION
Force Warden's Claude runtime to request the five-minute prompt-cache TTL so automated reviews keep the cheaper API-key default and stay aligned with Pi's short-cache behavior.

**Runtime Environment**

The spawned Claude Code process now receives the inherited environment plus `FORCE_PROMPT_CACHING_5M=1`, preserving auth and path setup while overriding subscription-style one-hour TTL selection.