### PR TITLE
fix(warden): Capture runtime child spans in traces

### DIFF
--- a/packages/warden/src/cli/main-cwd.test.ts
+++ b/packages/warden/src/cli/main-cwd.test.ts
@@ -16,6 +16,7 @@ vi.mock('../sentry.js', () => ({
   setRepositoryScope: vi.fn(),
   emitRunMetric: vi.fn(),
   getTraceId: vi.fn(() => undefined),
+  initSentry: vi.fn(),
 }));
 
 vi.mock('./commands/build.js', () => ({

--- a/packages/warden/src/cli/main.ts
+++ b/packages/warden/src/cli/main.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
-import { Sentry, flushSentry, setRepositoryScope, emitRunMetric, getTraceId } from '../sentry.js';
+import { Sentry, flushSentry, setRepositoryScope, emitRunMetric, getTraceId, initSentry } from '../sentry.js';
 import { emptyToUndefined, loadWardenConfigFile, resolveSkillConfigs } from '../config/loader.js';
 import type { SkillDefinition, WardenConfig, Effort } from '../config/schema.js';
 import { verifyAuth, type WardenAuthenticationError, type SkillRunnerOptions, type ChunkAnalysisResult } from '../sdk/runner.js';
@@ -1738,6 +1738,7 @@ export async function main(): Promise<void> {
     // Not in a git repo - use cwd
   }
   loadEnvFiles(envDir);
+  initSentry('cli');
 
   // Show header (unless JSON output or quiet)
   if (!options.json) {

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -529,6 +529,67 @@ describe('analyzeFile', () => {
     }));
   });
 
+  it('passes the hunk span to runtimes so runtime spans are captured in traces', async () => {
+    const runSkill = vi.fn(async (request: Parameters<Runtime['runSkill']>[0]) => {
+      expect(request.parentSpan).toBeDefined();
+      return startTracedSpan(
+        {
+          op: 'gen_ai.invoke_agent',
+          name: 'invoke_agent security-review',
+          parentSpan: request.parentSpan,
+          attributes: {
+            'gen_ai.operation.name': 'invoke_agent',
+            'gen_ai.agent.name': 'security-review',
+          },
+        },
+        () => ({
+          result: {
+            status: 'success',
+            text: JSON.stringify({ findings: [] }),
+            errors: [],
+            usage: makeUsage(),
+            responseId: 'resp-parented',
+            responseModel: 'claude-test',
+            sessionId: 'session-parented',
+            durationMs: 1200,
+            numTurns: 1,
+          },
+        }),
+      );
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const result = await analyzeFile(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makePreparedFile(),
+      '/tmp/repo',
+      {
+        runtime: 'claude',
+        captureTraces: true,
+      },
+    );
+
+    const trace = result.traces?.[0];
+    expect(trace?.spans).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        op: 'gen_ai.invoke_agent',
+        parentSpanId: trace?.spanId,
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'invoke_agent',
+        }),
+      }),
+    ]));
+  });
+
   it('counts provider failures once per hunk after retries are exhausted', async () => {
     const controller = new AbortController();
     const circuitBreaker = new ProviderFailureCircuitBreaker({

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -2,7 +2,7 @@ import type { Span } from '@sentry/node';
 import type { SkillDefinition } from '../config/schema.js';
 import type { ErrorCode, Finding, RetryConfig } from '../types/index.js';
 import { getHunkLineRange, type HunkWithContext } from '../diff/index.js';
-import { Sentry, emitExtractionMetrics, emitRetryMetric, emitSkillMetrics } from '../sentry.js';
+import { Sentry, emitExtractionMetrics, emitRetryMetric, emitSkillMetrics, ensureLocalTracing } from '../sentry.js';
 import { SkillRunnerError, WardenAuthenticationError, isRetryableError, isAuthenticationError, isAuthenticationErrorMessage, isSubprocessError, classifyError, mapExtractionErrorCode, sanitizeErrorMessage } from './errors.js';
 import type { CircuitBreakerReason } from './circuit-breaker.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
@@ -287,6 +287,10 @@ async function analyzeHunk(
   callbacks?: HunkAnalysisCallbacks,
   prContext?: PRPromptContext
 ): Promise<HunkAnalysisResult> {
+  if (options.captureTraces) {
+    ensureLocalTracing();
+  }
+
   const lineRange = callbacks?.lineRange ?? formatHunkLineRange(hunkCtx);
 
   return Sentry.startSpan(
@@ -382,6 +386,8 @@ async function analyzeHunk(
             repoPath,
             skillName: skill.name,
             tools: skill.tools,
+            parentSpan: span,
+            traceRecorder,
             options: {
               maxTurns: options.maxTurns,
               model: options.model,

--- a/packages/warden/src/sdk/runtimes/claude.test.ts
+++ b/packages/warden/src/sdk/runtimes/claude.test.ts
@@ -1,12 +1,30 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from 'vitest';
 import { query, type SDKMessage, type SDKResultError, type SDKResultSuccess } from '@anthropic-ai/claude-agent-sdk';
 import { claudeRuntime } from './claude.js';
+import { Sentry } from '../../sentry.js';
+import { startTraceRecorder } from '../../sentry-trace.js';
+import type { TraceSpan } from '../../types/index.js';
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: vi.fn(),
 }));
 
 const mockQuery = vi.mocked(query);
+
+beforeAll(() => {
+  Sentry.init({
+    dsn: 'https://public@example.com/1',
+    tracesSampleRate: 1,
+    transport: () => ({
+      send: vi.fn(async () => ({})),
+      flush: vi.fn(async () => true),
+    }),
+  });
+});
+
+afterAll(async () => {
+  await Sentry.close(0);
+});
 
 function successResult(overrides: Partial<SDKResultSuccess> = {}): SDKResultSuccess {
   return {
@@ -302,6 +320,100 @@ describe('claudeRuntime.runSkill', () => {
       cacheCreationInputTokens: 100,
     });
     expect(result.result?.usage.costUSD).toBeCloseTo(0.023645, 6);
+  });
+
+  it('records Claude runtime spans under the provided hunk trace parent', async () => {
+    mockQuery.mockReturnValue(mockStream([
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-test',
+          content: [
+            { type: 'text', text: 'checking file' },
+            { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } },
+          ],
+          stop_reason: 'tool_use',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 10 },
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 30,
+            server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
+            service_tier: 'standard',
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: '00000000-0000-4000-8000-000000000012',
+        session_id: 'session-1',
+      } as unknown as SDKMessage,
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-1',
+              content: 'file contents',
+              is_error: false,
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+        uuid: '00000000-0000-4000-8000-000000000013',
+        session_id: 'session-1',
+      } as unknown as SDKMessage,
+      successResult(),
+    ]));
+
+    let spans: TraceSpan[] | undefined;
+    await Sentry.startSpan({ op: 'skill.analyze_hunk', name: 'analyze hunk src/example.ts:1' }, async (span) => {
+      const traceRecorder = startTraceRecorder(span);
+      await claudeRuntime.runSkill({
+        systemPrompt: 'system',
+        userPrompt: 'user',
+        repoPath: '/repo',
+        skillName: 'test-skill',
+        parentSpan: span,
+        traceRecorder,
+        options: {
+          model: 'claude-test',
+        },
+      });
+      spans = traceRecorder?.snapshot();
+    });
+
+    expect(spans).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        op: 'gen_ai.invoke_agent',
+        name: 'invoke_agent test-skill',
+      }),
+      expect.objectContaining({
+        op: 'gen_ai.chat',
+        name: 'chat claude-test',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'chat',
+          'gen_ai.response.model': 'claude-test',
+        }),
+      }),
+      expect.objectContaining({
+        op: 'gen_ai.execute_tool',
+        name: 'execute_tool Read',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.tool.name': 'Read',
+          'gen_ai.tool.call.id': 'tool-1',
+          'gen_ai.tool.call.arguments': JSON.stringify({ file_path: 'README.md' }),
+          'gen_ai.tool.call.result': JSON.stringify('file contents'),
+        }),
+      }),
+    ]));
+    expect(spans?.every((traceSpan) => traceSpan.traceId === spans?.[0]?.traceId)).toBe(true);
   });
 
   it('allows read-only web tools when a skill explicitly opts in', async () => {

--- a/packages/warden/src/sdk/runtimes/claude.ts
+++ b/packages/warden/src/sdk/runtimes/claude.ts
@@ -372,6 +372,7 @@ export const claudeRuntime: Runtime = {
       {
         op: 'gen_ai.invoke_agent',
         name: genAiSpanName('invoke_agent', skillName),
+        ...(request.parentSpan ? { parentSpan: request.parentSpan } : {}),
         attributes: {
           'gen_ai.operation.name': 'invoke_agent',
           'gen_ai.provider.name': 'anthropic',
@@ -468,6 +469,7 @@ export const claudeRuntime: Runtime = {
                 setGenAiInputMessagesAttr(chatSpan, inputMessages);
                 setGenAiOutputMessagesAttrFromMessages(chatSpan, [turn.outputMessage]);
               },
+              request.traceRecorder,
             );
 
             for (const toolUse of turn.toolUses) {
@@ -491,7 +493,7 @@ export const claudeRuntime: Runtime = {
                   attributes,
                 });
                 toolSpan.end(endTime);
-                recordTracedSpan(toolSpan);
+                recordTracedSpan(toolSpan, request.traceRecorder);
               } else {
                 startTracedSpan(
                   {
@@ -501,6 +503,7 @@ export const claudeRuntime: Runtime = {
                     attributes,
                   },
                   () => undefined,
+                  request.traceRecorder,
                 );
               }
             }
@@ -634,6 +637,7 @@ export const claudeRuntime: Runtime = {
           stderr,
         };
       },
+      request.traceRecorder,
     );
   },
 

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -33,7 +33,7 @@ import type { Span } from '@sentry/node';
 import { z } from 'zod';
 import type { Effort, ToolConfig, ToolName } from '../../config/schema.js';
 import { Sentry } from '../../sentry.js';
-import { recordTracedSpan, startInactiveTracedSpan, startTracedSpan } from '../../sentry-trace.js';
+import { recordTracedSpan, startInactiveTracedSpan, startTracedSpan, type TraceRecorder } from '../../sentry-trace.js';
 import type { UsageStats } from '../../types/index.js';
 import { bridgeWardenProviderApiKeyEnv } from '../../utils/index.js';
 import { extractJson } from '../haiku.js';
@@ -111,6 +111,8 @@ interface PiPromptOptions {
   toolDescriptions?: Record<string, string>;
   /** Parent `invoke_agent` span for model-call and tool-execution child spans. */
   parentSpan?: Span;
+  /** Recorder used to persist runtime child spans in structured traces. */
+  traceRecorder?: TraceRecorder;
 }
 
 function errorMessage(error: unknown): string {
@@ -428,7 +430,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
         span.setAttribute('error.type', 'tool_error');
       }
       span.end();
-      recordTracedSpan(span);
+      recordTracedSpan(span, options.traceRecorder);
     } catch {
       // Telemetry should never break the workflow.
     }
@@ -439,7 +441,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
       try {
         span.setAttribute('error.type', errorType);
         span.end();
-        recordTracedSpan(span);
+        recordTracedSpan(span, options.traceRecorder);
       } catch {
         // Telemetry should never break the workflow.
       }
@@ -479,6 +481,7 @@ async function runPiPrompt(options: PiPromptOptions): Promise<PiPromptResult> {
           setGenAiInputMessagesAttr(span, conversationMessages);
           setGenAiOutputMessagesAttrFromMessages(span, [outputMessage]);
         },
+        options.traceRecorder,
       );
     } catch {
       // Telemetry should never break the workflow.
@@ -761,6 +764,7 @@ export const piRuntime: Runtime = {
       {
         op: 'gen_ai.invoke_agent',
         name: genAiSpanName('invoke_agent', skillName),
+        ...(request.parentSpan ? { parentSpan: request.parentSpan } : {}),
         attributes: {
           'gen_ai.operation.name': 'invoke_agent',
           'gen_ai.provider.name': genAiProviderName('pi', model),
@@ -786,6 +790,7 @@ export const piRuntime: Runtime = {
             effort,
             abortController,
             parentSpan: span,
+            traceRecorder: request.traceRecorder,
           });
           run.warnings.unshift(...skillTools.warnings);
           const result = normalizePiResult(run);
@@ -833,6 +838,7 @@ export const piRuntime: Runtime = {
           throw error;
         }
       },
+      request.traceRecorder,
     );
   },
 

--- a/packages/warden/src/sdk/runtimes/types.ts
+++ b/packages/warden/src/sdk/runtimes/types.ts
@@ -13,7 +13,9 @@
  * hunk parsing, extraction repair, deduplication, fix gates, or reporting.
  */
 import { z } from 'zod';
+import type { Span } from '@sentry/node';
 import type { Effort, ToolConfig } from '../../config/schema.js';
+import type { TraceRecorder } from '../../sentry-trace.js';
 import type { UsageStats } from '../../types/index.js';
 
 export const RuntimeNameSchema = z.enum(['claude', 'pi']);
@@ -49,6 +51,10 @@ export interface SkillRunRequest {
    * Normal skill analysis keeps this false so hunks remain read-only.
    */
   allowMutatingTools?: boolean;
+  /** Optional parent span used to attach runtime telemetry to a hunk trace. */
+  parentSpan?: Span;
+  /** Optional recorder used to persist runtime child spans in structured traces. */
+  traceRecorder?: TraceRecorder;
   /** Provider-specific settings consumed only by the selected runtime adapter. */
   providerOptions?: unknown;
 }

--- a/packages/warden/src/sentry-trace.test.ts
+++ b/packages/warden/src/sentry-trace.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ensureLocalTracing, Sentry } from './sentry.js';
+import { startTraceRecorder, startTracedSpan } from './sentry-trace.js';
+import type { TraceSpan } from './types/index.js';
+
+describe('structured trace capture', () => {
+  beforeEach(async () => {
+    delete process.env['WARDEN_SENTRY_DSN'];
+    await Sentry.close(0);
+  });
+
+  afterEach(async () => {
+    await Sentry.close(0);
+  });
+
+  it('records local child spans when telemetry is not configured', async () => {
+    ensureLocalTracing();
+
+    let parentTraceId: string | undefined;
+    let parentSpanId: string | undefined;
+    let spans: TraceSpan[] | undefined;
+
+    await Sentry.startSpan({ op: 'skill.analyze_hunk', name: 'analyze hunk src/example.ts:1' }, async (span) => {
+      const parentContext = span.spanContext();
+      parentTraceId = parentContext.traceId;
+      parentSpanId = parentContext.spanId;
+      const traceRecorder = startTraceRecorder(span);
+
+      await startTracedSpan(
+        {
+          op: 'gen_ai.invoke_agent',
+          name: 'invoke_agent security-review',
+          parentSpan: span,
+          attributes: {
+            'gen_ai.operation.name': 'invoke_agent',
+          },
+        },
+        () => undefined,
+        traceRecorder,
+      );
+
+      spans = traceRecorder?.snapshot();
+    });
+
+    expect(spans).toEqual([
+      expect.objectContaining({
+        traceId: parentTraceId,
+        parentSpanId,
+        op: 'gen_ai.invoke_agent',
+        name: 'invoke_agent security-review',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'invoke_agent',
+        }),
+      }),
+    ]);
+  });
+});

--- a/packages/warden/src/sentry-trace.ts
+++ b/packages/warden/src/sentry-trace.ts
@@ -123,8 +123,12 @@ function hasFinally(value: unknown): value is Promise<unknown> {
  * Warden-owned, though, so structured run output only depends on spans we
  * explicitly create through this helper.
  */
-export function startTracedSpan<T>(options: SentryStartSpanOptions, callback: (span: Span) => T): T {
-  const recorder = activeTraceRecorder();
+export function startTracedSpan<T>(
+  options: SentryStartSpanOptions,
+  callback: (span: Span) => T,
+  traceRecorder?: TraceRecorder,
+): T {
+  const recorder = traceRecorder ?? activeTraceRecorder();
   let spanRef: Span | undefined;
   const recordSpan = (): void => recorder?.record(spanRef);
 
@@ -150,9 +154,9 @@ export function startInactiveTracedSpan(options: SentryStartSpanOptions): Span {
   return Sentry.startInactiveSpan(options);
 }
 
-/** Record a manually-ended span in the active Warden trace buffer. */
-export function recordTracedSpan(span: Span | undefined): void {
-  activeTraceRecorder()?.record(span);
+/** Record a manually-ended span in Warden's active or explicit trace buffer. */
+export function recordTracedSpan(span: Span | undefined, traceRecorder?: TraceRecorder): void {
+  (traceRecorder ?? activeTraceRecorder())?.record(span);
 }
 
 /** Create a hunk-scoped recorder for Warden-owned spans under a Sentry parent span. */

--- a/packages/warden/src/sentry.ts
+++ b/packages/warden/src/sentry.ts
@@ -40,6 +40,19 @@ export function initSentry(context: SentryContext): void {
   });
 }
 
+/** Ensure local span objects are materialized for structured trace output. */
+export function ensureLocalTracing(): void {
+  if (Sentry.getClient()) return;
+
+  Sentry.init({
+    tracesSampleRate: 1.0,
+    transport: () => ({
+      send: async () => ({}),
+      flush: async () => true,
+    }),
+  });
+}
+
 export { Sentry };
 export const { logger } = Sentry;
 


### PR DESCRIPTION
Structured trace output now includes child spans emitted by runtime implementations.

Analyze passes the active hunk span and recorder into each runtime, and local trace collection now works without a telemetry DSN by using a no-op Sentry client. This makes --traces capture Claude and Pi child spans in the command log as intended.

**Runtime Trace Context**

Claude and Pi runtime spans attach to the hunk parent span and write through the same recorder, so trace JSONL keeps the parent-child relationship needed for benchmark diagnostics.