### PR TITLE
fix(sdk): Enable Pi provider retries

### DIFF
--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -188,7 +188,10 @@ describe('piRuntime.runSkill', () => {
     expect(SessionManager.inMemory).toHaveBeenCalledWith('/repo');
     expect(SettingsManager.inMemory).toHaveBeenCalledWith(expect.objectContaining({
       compaction: { enabled: false },
-      retry: expect.objectContaining({ enabled: false }),
+      retry: expect.objectContaining({
+        enabled: true,
+        provider: expect.objectContaining({ maxRetries: 2 }),
+      }),
     }));
     expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
       cwd: '/repo',
@@ -514,6 +517,7 @@ describe('piRuntime structured calls', () => {
 
     expect(SettingsManager.inMemory).toHaveBeenCalledWith(expect.objectContaining({
       retry: expect.objectContaining({
+        enabled: true,
         provider: expect.objectContaining({ maxRetries: 4 }),
       }),
     }));

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -69,6 +69,7 @@ import type {
 const READ_ONLY_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob'];
 const MUTATING_TOOLS: ToolName[] = ['Write', 'Edit', 'Bash'];
 const UNSUPPORTED_TOOLS: ToolName[] = ['WebFetch', 'WebSearch'];
+const DEFAULT_PI_PROVIDER_MAX_RETRIES = 2;
 const PI_TOOL_NAMES: Record<Exclude<ToolName, 'WebFetch' | 'WebSearch'>, string[]> = {
   Read: ['read'],
   Write: ['write'],
@@ -282,13 +283,14 @@ function normalizePiResult(run: PiPromptResult): SkillRunResult | undefined {
 }
 
 function buildSettingsManager(timeout: number | undefined, maxRetries: number | undefined): SettingsManager {
+  const providerMaxRetries = maxRetries ?? DEFAULT_PI_PROVIDER_MAX_RETRIES;
   return SettingsManager.inMemory({
     compaction: { enabled: false },
     retry: {
-      enabled: false,
+      enabled: providerMaxRetries > 0,
       provider: {
         ...(timeout !== undefined ? { timeoutMs: timeout } : {}),
-        ...(maxRetries !== undefined ? { maxRetries } : {}),
+        maxRetries: providerMaxRetries,
       },
     },
   });


### PR DESCRIPTION
Pi now owns transient provider retries before Warden sees a final runtime failure. This keeps Warden circuit breaking focused on exhausted chunk failures instead of individual provider flakes.

**Pi retry settings**

The Pi runtime enables provider retries with a small default of two attempts. Structured Pi calls continue to pass through their configured maxRetries value.

**Circuit breaker behavior**

Warden still records provider_unavailable only after Pi returns a final provider error, so the existing run-wide circuit breaker remains the outer safety stop.