### PR TITLE
fix(action): Replay report results by trigger identity

### DIFF
--- a/packages/warden/src/action/reporting/output.ts
+++ b/packages/warden/src/action/reporting/output.ts
@@ -31,6 +31,7 @@ const TriggerErrorSchema = z.object({
 // skillName. `report.skill` is preserved as report identity and may differ for
 // local path skills with frontmatter names.
 const TriggerRunResultBaseSchema = z.object({
+  triggerId: z.string().optional(),
   triggerName: z.string(),
   skillName: z.string(),
 });
@@ -100,6 +101,7 @@ export const FindingsOutputSchema = z.object({
 export type FindingsOutput = z.infer<typeof FindingsOutputSchema>;
 
 export interface ReplayTriggerResult {
+  triggerId?: string;
   triggerName: string;
   skillName: string;
   report?: SkillReport;
@@ -138,6 +140,7 @@ function serializeReplayReport(report: SkillReport): z.infer<typeof ReplaySkillR
 function serializeTriggerResult(result: ReplayTriggerResult): z.infer<typeof TriggerRunResultSchema> {
   if (result.report) {
     return {
+      triggerId: result.triggerId,
       triggerName: result.triggerName,
       skillName: result.skillName,
       status: 'success',
@@ -146,6 +149,7 @@ function serializeTriggerResult(result: ReplayTriggerResult): z.infer<typeof Tri
   }
 
   return {
+    triggerId: result.triggerId,
     triggerName: result.triggerName,
     skillName: result.skillName,
     status: 'error',

--- a/packages/warden/src/action/triggers/executor.test.ts
+++ b/packages/warden/src/action/triggers/executor.test.ts
@@ -109,6 +109,7 @@ describe('executeTrigger', () => {
   };
 
   const mockTrigger: ResolvedTrigger = {
+    id: 'test-trigger-id',
     name: 'test-trigger',
     skill: 'test-skill',
     type: 'pull_request',

--- a/packages/warden/src/action/triggers/executor.ts
+++ b/packages/warden/src/action/triggers/executor.ts
@@ -91,6 +91,7 @@ export interface TriggerExecutorDeps {
  * Result from executing a single trigger.
  */
 export interface TriggerResult {
+  triggerId?: string;
   triggerName: string;
   skillName: string;
   report?: SkillReport;
@@ -232,6 +233,7 @@ export async function executeTrigger(
 
         logGroupEnd();
         return {
+          triggerId: trigger.id,
           triggerName: trigger.name,
           skillName: trigger.skill,
           report,
@@ -263,7 +265,7 @@ export async function executeTrigger(
 
         console.error(`::warning::Trigger ${trigger.name} failed: ${error}`);
         logGroupEnd();
-        return { triggerName: trigger.name, skillName: trigger.skill, error };
+        return { triggerId: trigger.id, triggerName: trigger.name, skillName: trigger.skill, error };
       }
     },
   );

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -284,6 +284,15 @@ function writeFindingsArtifact(
   return filePath;
 }
 
+function duplicateTriggerId(reportOn: 'high' | 'low'): string {
+  return JSON.stringify({
+    skill: 'test-skill',
+    reportOn,
+    type: 'pull_request',
+    actions: ['opened', 'synchronize'],
+  });
+}
+
 function createExistingWardenComment(overrides: Partial<ExistingComment> = {}): ExistingComment {
   return {
     id: 1,
@@ -587,7 +596,7 @@ describe('runPRWorkflow', () => {
       );
     });
 
-    it('report mode replays duplicate skill trigger results in artifact order', async () => {
+    it('report mode replays duplicate skill trigger results by trigger identity', async () => {
       const highFinding = createFinding({ id: 'high-finding', severity: 'high' });
       const lowFinding = createFinding({ id: 'low-finding', severity: 'low' });
       const highReport = createSkillReport({
@@ -600,11 +609,13 @@ describe('runPRWorkflow', () => {
       });
       const findingsFile = writeFindingsArtifact([highReport, lowReport], [
         {
+          triggerId: duplicateTriggerId('high'),
           triggerName: 'test-skill',
           skillName: 'test-skill',
           report: highReport,
         },
         {
+          triggerId: duplicateTriggerId('low'),
           triggerName: 'test-skill',
           skillName: 'test-skill',
           report: lowReport,
@@ -637,6 +648,48 @@ describe('runPRWorkflow', () => {
           name: 'warden: test-skill',
           output: expect.objectContaining({
             summary: expect.stringContaining('Low report'),
+          }),
+        })
+      );
+    });
+
+    it('report mode rejects legacy duplicate skill trigger replay keys', async () => {
+      const highReport = createSkillReport({ summary: 'High report' });
+      const lowReport = createSkillReport({ summary: 'Low report' });
+      const findingsFile = writeFindingsArtifact([highReport, lowReport], [
+        {
+          triggerName: 'test-skill',
+          skillName: 'test-skill',
+          report: highReport,
+        },
+        {
+          triggerName: 'test-skill',
+          skillName: 'test-skill',
+          report: lowReport,
+        },
+      ]);
+
+      try {
+        await expect(
+          runPRWorkflow(
+            mockOctokit,
+            createDefaultInputs({ mode: 'report', findingsFile }),
+            'pull_request',
+            EVENT_PAYLOAD_PATH,
+            DUPLICATE_TRIGGER_FIXTURES_DIR
+          )
+        ).rejects.toThrow('ambiguous duplicate trigger result');
+      } finally {
+        rmSync(dirname(findingsFile), { recursive: true, force: true });
+      }
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'warden',
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            summary: expect.stringContaining('ambiguous duplicate trigger result'),
           }),
         })
       );

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -1175,8 +1175,21 @@ function resultKey(triggerName: string, skillName: string): string {
   return `${triggerName}\0${skillName}`;
 }
 
+function replayKey(result: { triggerId?: string; triggerName: string; skillName: string }): string {
+  return result.triggerId ?? resultKey(result.triggerName, result.skillName);
+}
+
+function triggerReplayKey(trigger: ResolvedTrigger): string {
+  return trigger.id;
+}
+
+function describeResultKey(result: { triggerName: string; skillName: string }): string {
+  return `${result.triggerName} (${result.skillName})`;
+}
+
 function toReplayTriggerResults(results: TriggerResult[]): ReplayTriggerResult[] {
   return results.map((result) => ({
+    triggerId: result.triggerId,
     triggerName: result.triggerName,
     skillName: result.skillName,
     report: result.report,
@@ -1199,13 +1212,51 @@ function buildReportModeResults(
 
   const outputResults = new Map<string, typeof output.triggerResults>();
   for (const result of output.triggerResults) {
-    const key = resultKey(result.triggerName, result.skillName);
+    const key = replayKey(result);
     const existing = outputResults.get(key);
     if (existing) {
       existing.push(result);
     } else {
       outputResults.set(key, [result]);
     }
+  }
+
+  const duplicateConfiguredResults = new Map<string, ResolvedTrigger[]>();
+  for (const trigger of matchedTriggers) {
+    const key = triggerReplayKey(trigger);
+    const existing = duplicateConfiguredResults.get(key);
+    if (existing) {
+      existing.push(trigger);
+    } else {
+      duplicateConfiguredResults.set(key, [trigger]);
+    }
+  }
+
+  const ambiguousKeys = [
+    ...new Set([
+      ...[...outputResults.entries()]
+        .filter(([, results]) => results.length > 1)
+        .map(([key]) => key),
+      ...[...duplicateConfiguredResults.entries()]
+        .filter(([, triggers]) => triggers.length > 1)
+        .map(([key]) => key),
+    ]),
+  ];
+
+  if (ambiguousKeys.length > 0) {
+    const triggerList = ambiguousKeys
+      .map((key) => {
+        const result = outputResults.get(key)?.[0];
+        const trigger = duplicateConfiguredResults.get(key)?.[0];
+        return result
+          ? describeResultKey(result)
+          : `${trigger?.name ?? 'unknown'} (${trigger?.skill ?? 'unknown'})`;
+      })
+      .join(', ');
+
+    throw new Error(
+      `Findings file contains ambiguous duplicate trigger result(s): ${triggerList}`
+    );
   }
 
   const results = matchedTriggers.map((trigger) => {
@@ -1216,6 +1267,7 @@ function buildReportModeResults(
     const failCheck = trigger.failCheck ?? inputs.failCheck;
     const maxFindings = trigger.maxFindings ?? inputs.maxFindings;
     const baseResult = {
+      triggerId: trigger.id,
       triggerName: trigger.name,
       skillName: trigger.skill,
       failOn,
@@ -1226,7 +1278,9 @@ function buildReportModeResults(
       failCheck,
       maxFindings,
     };
-    const outputResult = outputResults.get(resultKey(trigger.name, trigger.skill))?.shift();
+    const outputResult =
+      outputResults.get(triggerReplayKey(trigger))?.shift() ??
+      outputResults.get(resultKey(trigger.name, trigger.skill))?.shift();
 
     if (!outputResult) {
       return {
@@ -1254,7 +1308,7 @@ function buildReportModeResults(
   const unreportedResults = [...outputResults.values()].flat();
   if (unreportedResults.length > 0) {
     const triggerList = unreportedResults
-      .map((result) => `${result.triggerName} (${result.skillName})`)
+      .map(describeResultKey)
       .join(', ');
     throw new Error(
       `Findings file contains ${unreportedResults.length} result(s) that do not match current config: ${triggerList}`

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -7,6 +7,7 @@ import {
   WardenConfigSchema,
   type WardenConfig,
   type SkillConfig,
+  type SkillTrigger,
   type ScheduleConfig,
   type TriggerType,
   type Defaults,
@@ -335,6 +336,8 @@ export function loadLayeredWardenConfig(
  * Skills with no triggers produce a wildcard entry (type: '*').
  */
 export interface ResolvedTrigger {
+  /** Stable replay identity derived from the skill and trigger configuration */
+  id: string;
   /** Skill name (used for display and deduplication) */
   name: string;
   /** Skill reference (same as name, for downstream compatibility) */
@@ -388,6 +391,29 @@ export interface ResolvedTrigger {
   maxContextFiles?: number;
   /** Schedule-specific configuration */
   schedule?: ScheduleConfig;
+}
+
+function triggerIdentity(skill: SkillConfig, trigger: SkillTrigger | undefined): string {
+  return JSON.stringify({
+    skill: skill.name,
+    remote: skill.remote,
+    paths: skill.paths,
+    ignorePaths: skill.ignorePaths,
+    failOn: trigger?.failOn ?? skill.failOn,
+    reportOn: trigger?.reportOn ?? skill.reportOn,
+    maxFindings: trigger?.maxFindings ?? skill.maxFindings,
+    reportOnSuccess: trigger?.reportOnSuccess ?? skill.reportOnSuccess,
+    requestChanges: trigger?.requestChanges ?? skill.requestChanges,
+    failCheck: trigger?.failCheck ?? skill.failCheck,
+    model: trigger?.model ?? skill.model,
+    maxTurns: trigger?.maxTurns ?? skill.maxTurns,
+    minConfidence: trigger?.minConfidence ?? skill.minConfidence,
+    type: trigger?.type ?? '*',
+    actions: trigger?.actions,
+    draft: trigger?.draft,
+    labels: trigger?.labels,
+    schedule: trigger?.schedule,
+  });
 }
 
 function resolveSkillSource(
@@ -471,6 +497,7 @@ export function resolveSkillConfigs(
     if (!skill.triggers || skill.triggers.length === 0) {
       // Wildcard: no triggers means run everywhere
       result.push({
+        id: triggerIdentity(skill, undefined),
         name: skill.name,
         skill: skill.name,
         type: '*',
@@ -498,6 +525,7 @@ export function resolveSkillConfigs(
     } else {
       for (const trigger of skill.triggers) {
         result.push({
+          id: triggerIdentity(skill, trigger),
           name: skill.name,
           skill: skill.name,
           type: trigger.type,

--- a/packages/warden/src/triggers/matcher.test.ts
+++ b/packages/warden/src/triggers/matcher.test.ts
@@ -137,6 +137,7 @@ describe('matchTrigger', () => {
   };
 
   const baseTrigger: ResolvedTrigger = {
+    id: 'test-trigger-id',
     name: 'test-trigger',
     skill: 'test-skill',
     type: 'pull_request',


### PR DESCRIPTION
Report-mode replay matched findings artifacts by trigger name and skill name. Duplicate triggers for the same skill could be replayed in artifact order, which meant checks and reviews could inherit the wrong per-trigger settings.

This adds a stable trigger identity derived from the resolved trigger configuration, carries it through analyze output, and uses it when report mode joins artifacts back to the current config. Legacy artifacts without trigger IDs are still accepted unless duplicate replay keys make the result ambiguous; those now fail explicitly.