### PR TITLE
fix(action): Replay split reports from artifacts

### DIFF
--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -611,8 +611,10 @@ without creating checks or comments. Then run `mode: report` with
 `findings-file` to create completed checks and post comments. For GitHub App
 runs, create the app token between those steps so reporting uses fresh write
 credentials. Pass the intended `config-path`, `base-config-path`,
-`base-skill-root`, and action-level reporting inputs to the report step; report
-mode reloads config and applies the report step's inputs.
+`base-skill-root`, and action-level reporting inputs to the analyze step.
+Analyze mode writes the resolved trigger and reporting settings into the
+findings file. Report mode validates that file against the workflow event, then
+publishes the stored results without reloading trigger config.
 
 ```yaml
 - name: Analyze

--- a/packages/docs/src/content/docs/github/workflow.mdx
+++ b/packages/docs/src/content/docs/github/workflow.mdx
@@ -122,9 +122,9 @@ token that was created before Warden starts.
 Use `mode: analyze` first. It runs skills and writes a structured findings file
 without creating checks, posting comments, or resolving stale comments. Then
 create the GitHub App token and run `mode: report` against that findings file.
-Split modes are only supported for pull request workflows. Report mode reloads
-`warden.toml`, applies the report step's current reporting settings, creates
-completed checks, and posts comments.
+Split modes are only supported for pull request workflows. Report mode validates
+the findings file against the workflow event, then creates completed checks and
+posts comments from the stored analyze results.
 
 ```yaml title=".github/workflows/warden.yml"
 jobs:
@@ -158,9 +158,10 @@ jobs:
 
 If you use `config-path`, `base-config-path`, `base-skill-root`, or action-level
 reporting inputs such as `fail-on`, `report-on`, `request-changes`,
-`fail-check`, or `max-findings`, pass the intended values to the report step.
-Report mode reads config again from the checkout and applies the report step's
-inputs; the findings file does not store a copy of `warden.toml`.
+`fail-check`, or `max-findings`, pass the intended values to the analyze step.
+Analyze mode writes the resolved trigger and reporting settings into the
+findings file. Report mode validates that file against the workflow event, then
+publishes the stored results without reloading trigger config from the checkout.
 
 ## Required Status Checks
 

--- a/packages/warden/src/action/reporting/output.test.ts
+++ b/packages/warden/src/action/reporting/output.test.ts
@@ -28,10 +28,20 @@ describe('findings output schema', () => {
     const output = buildFindingsOutput([report], createContext(), [], {
       timestamp: '2026-01-01T00:00:00.000Z',
       runId: '123',
+      workflow: {
+        skippedCoreCheck: {
+          title: 'No warden.toml found',
+          message: 'No warden.toml found. Skipping analysis.',
+        },
+      },
       triggerResults: [
         {
           triggerName: 'test-trigger',
           skillName: 'test-skill',
+          failOn: 'high',
+          reportOn: 'medium',
+          minConfidence: 'medium',
+          requestChanges: true,
           report,
         },
         {
@@ -39,14 +49,30 @@ describe('findings output schema', () => {
           skillName: 'failed-skill',
           error: new Error('Token expired'),
         },
+        {
+          status: 'skipped',
+          triggerName: 'skipped-trigger',
+          skillName: 'skipped-skill',
+          failCheck: false,
+        },
       ],
     });
 
     expect(FindingsOutputSchema.parse(output)).toEqual(output);
+    expect(output.workflow).toEqual({
+      skippedCoreCheck: {
+        title: 'No warden.toml found',
+        message: 'No warden.toml found. Skipping analysis.',
+      },
+    });
     expect(output.triggerResults).toEqual([
       {
         triggerName: 'test-trigger',
         skillName: 'test-skill',
+        failOn: 'high',
+        reportOn: 'medium',
+        minConfidence: 'medium',
+        requestChanges: true,
         status: 'success',
         report,
       },
@@ -58,6 +84,12 @@ describe('findings output schema', () => {
           name: 'Error',
           message: 'Token expired',
         },
+      },
+      {
+        triggerName: 'skipped-trigger',
+        skillName: 'skipped-skill',
+        failCheck: false,
+        status: 'skipped',
       },
     ]);
   });

--- a/packages/warden/src/action/reporting/output.ts
+++ b/packages/warden/src/action/reporting/output.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 import type { EventContext, SkillReport } from '../../types/index.js';
+import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import {
   AuxiliaryUsageMapSchema,
+  ConfidenceThresholdSchema,
   FindingSchema,
   GitHubEventTypeSchema,
   LocationSchema,
+  SeverityThresholdSchema,
   SourceSnippetSchema,
   UsageStatsSchema,
 } from '../../types/index.js';
@@ -27,6 +30,20 @@ const TriggerErrorSchema = z.object({
   message: z.string(),
 });
 
+const WorkflowReplaySchema = z.object({
+  auxiliary: z.object({
+    runtime: z.enum(['claude', 'pi'] satisfies RuntimeName[]).optional(),
+    model: z.string().optional(),
+    maxRetries: z.number().int().nonnegative().optional(),
+  }).optional(),
+  skippedCoreCheck: z.object({
+    title: z.string(),
+    message: z.string(),
+  }).optional(),
+});
+
+export type WorkflowReplay = z.infer<typeof WorkflowReplaySchema>;
+
 // Durable analyze/report replay rows join by triggerName plus configured
 // skillName. `report.skill` is preserved as report identity and may differ for
 // local path skills with frontmatter names.
@@ -34,6 +51,13 @@ const TriggerRunResultBaseSchema = z.object({
   triggerId: z.string().optional(),
   triggerName: z.string(),
   skillName: z.string(),
+  failOn: SeverityThresholdSchema.optional(),
+  reportOn: SeverityThresholdSchema.optional(),
+  minConfidence: ConfidenceThresholdSchema.optional(),
+  reportOnSuccess: z.boolean().optional(),
+  requestChanges: z.boolean().optional(),
+  failCheck: z.boolean().optional(),
+  maxFindings: z.number().int().nonnegative().optional(),
 });
 
 const ReplaySkillReportSchema = z.object({
@@ -56,6 +80,11 @@ export const TriggerRunResultSchema = z.discriminatedUnion('status', [
     status: z.literal('error'),
     report: z.never().optional(),
     error: TriggerErrorSchema,
+  }),
+  TriggerRunResultBaseSchema.extend({
+    status: z.literal('skipped'),
+    report: z.never().optional(),
+    error: z.never().optional(),
   }),
 ]);
 
@@ -86,6 +115,7 @@ export const FindingsOutputSchema = z.object({
     }),
     totalSkills: z.number().int().nonnegative(),
   }),
+  workflow: WorkflowReplaySchema.optional(),
   skills: z.array(z.object({
     name: z.string(),
     summary: z.string(),
@@ -104,6 +134,14 @@ export interface ReplayTriggerResult {
   triggerId?: string;
   triggerName: string;
   skillName: string;
+  status?: 'skipped';
+  failOn?: z.infer<typeof SeverityThresholdSchema>;
+  reportOn?: z.infer<typeof SeverityThresholdSchema>;
+  minConfidence?: z.infer<typeof ConfidenceThresholdSchema>;
+  reportOnSuccess?: boolean;
+  requestChanges?: boolean;
+  failCheck?: boolean;
+  maxFindings?: number;
   report?: SkillReport;
   error?: unknown;
 }
@@ -111,6 +149,7 @@ export interface ReplayTriggerResult {
 interface BuildFindingsOutputOptions {
   timestamp?: string;
   runId?: string;
+  workflow?: z.infer<typeof WorkflowReplaySchema>;
   triggerResults?: ReplayTriggerResult[];
 }
 
@@ -138,20 +177,36 @@ function serializeReplayReport(report: SkillReport): z.infer<typeof ReplaySkillR
 }
 
 function serializeTriggerResult(result: ReplayTriggerResult): z.infer<typeof TriggerRunResultSchema> {
+  const base = {
+    triggerId: result.triggerId,
+    triggerName: result.triggerName,
+    skillName: result.skillName,
+    failOn: result.failOn,
+    reportOn: result.reportOn,
+    minConfidence: result.minConfidence,
+    reportOnSuccess: result.reportOnSuccess,
+    requestChanges: result.requestChanges,
+    failCheck: result.failCheck,
+    maxFindings: result.maxFindings,
+  };
+
+  if (result.status === 'skipped') {
+    return {
+      ...base,
+      status: 'skipped',
+    };
+  }
+
   if (result.report) {
     return {
-      triggerId: result.triggerId,
-      triggerName: result.triggerName,
-      skillName: result.skillName,
+      ...base,
       status: 'success',
       report: serializeReplayReport(result.report),
     };
   }
 
   return {
-    triggerId: result.triggerId,
-    triggerName: result.triggerName,
-    skillName: result.skillName,
+    ...base,
     status: 'error',
     error: serializeTriggerError(result.error ?? 'Trigger did not produce a report'),
   };
@@ -194,6 +249,7 @@ export function buildFindingsOutput(
       },
       totalSkills: reports.length,
     },
+    ...(options.workflow && { workflow: options.workflow }),
     skills: reports.map((r) => ({
       name: r.skill,
       summary: r.summary,

--- a/packages/warden/src/action/triggers/executor.ts
+++ b/packages/warden/src/action/triggers/executor.ts
@@ -288,7 +288,19 @@ export async function executeTrigger(
 
         console.error(`::warning::Trigger ${trigger.name} failed: ${error}`);
         logGroupEnd();
-        return { triggerId: trigger.id, triggerName: trigger.name, skillName: trigger.skill, error };
+        return {
+          triggerId: trigger.id,
+          triggerName: trigger.name,
+          skillName: trigger.skill,
+          failOn,
+          reportOn,
+          minConfidence,
+          reportOnSuccess: trigger.reportOnSuccess,
+          requestChanges,
+          failCheck,
+          maxFindings: trigger.maxFindings ?? deps.globalMaxFindings,
+          error,
+        };
       }
     },
   );

--- a/packages/warden/src/action/workflow/base.ts
+++ b/packages/warden/src/action/workflow/base.ts
@@ -14,7 +14,7 @@ import { isRepoRelativePath, normalizePath } from '../../utils/path.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import type { FindingObservation } from '../reporting/outcomes.js';
 import { buildFindingsOutput } from '../reporting/output.js';
-import type { ReplayTriggerResult } from '../reporting/output.js';
+import type { ReplayTriggerResult, WorkflowReplay } from '../reporting/output.js';
 import { countSeverity } from '../../triggers/matcher.js';
 import type { RuntimeName } from '../../sdk/runtimes/index.js';
 import type { ActionInputs } from '../inputs.js';
@@ -380,10 +380,11 @@ export function writeFindingsOutput(
   reports: SkillReport[],
   context: EventContext,
   findingObservations: FindingObservation[] = [],
-  options: { triggerResults?: ReplayTriggerResult[] } = {}
+  options: { workflow?: WorkflowReplay; triggerResults?: ReplayTriggerResult[] } = {}
 ): string {
   const filePath = getFindingsOutputPath(context.repoPath);
   const output = buildFindingsOutput(reports, context, findingObservations, {
+    workflow: options.workflow,
     triggerResults: options.triggerResults,
   });
 

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -270,13 +270,15 @@ function createEventContext(repoPath: string): EventContext {
 function writeFindingsArtifact(
   reports: SkillReport[],
   triggerResults: NonNullable<Parameters<typeof buildFindingsOutput>[3]>['triggerResults'],
-  mutate?: (output: ReturnType<typeof buildFindingsOutput>) => void
+  mutate?: (output: ReturnType<typeof buildFindingsOutput>) => void,
+  workflow?: NonNullable<Parameters<typeof buildFindingsOutput>[3]>['workflow']
 ): string {
   const tempDir = mkdtempSync(join(tmpdir(), 'warden-report-mode-'));
   const filePath = join(tempDir, 'warden-findings.json');
   const output = buildFindingsOutput(reports, createEventContext(FIXTURES_DIR), [], {
     timestamp: '2026-01-01T00:00:00.000Z',
     runId: '123',
+    workflow,
     triggerResults,
   });
   mutate?.(output);
@@ -364,6 +366,9 @@ describe('runPRWorkflow', () => {
         }),
         [],
         {
+          workflow: {
+            auxiliary: expect.objectContaining({ runtime: 'pi' }),
+          },
           triggerResults: [
             expect.objectContaining({
               triggerName: 'test-skill',
@@ -397,6 +402,37 @@ describe('runPRWorkflow', () => {
       );
       expect(mockOctokit.checks.create).not.toHaveBeenCalled();
       expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
+    });
+
+    it('analyze mode stores the skipped core check when config is missing', async () => {
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs({ mode: 'analyze' }),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        NO_CONFIG_FIXTURES_DIR
+      );
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockOctokit.checks.create).not.toHaveBeenCalled();
+      expect(mockFetchExistingComments).not.toHaveBeenCalled();
+      expect(mockWriteFindingsOutput).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          repository: expect.objectContaining({ fullName: 'test-owner/test-repo' }),
+        }),
+        [],
+        {
+          workflow: {
+            auxiliary: expect.objectContaining({ runtime: 'pi' }),
+            skippedCoreCheck: {
+              title: 'No warden.toml found',
+              message: 'No warden.toml found. Skipping analysis.',
+            },
+          },
+          triggerResults: [],
+        }
+      );
     });
 
     it('report mode publishes completed checks from the findings file without rerunning skills', async () => {
@@ -446,7 +482,113 @@ describe('runPRWorkflow', () => {
       );
     });
 
-    it('report mode renders checks and reviews from report-step inputs', async () => {
+    it('report mode replays the skipped core check from the findings file', async () => {
+      const findingsFile = writeFindingsArtifact(
+        [],
+        [],
+        undefined,
+        {
+          auxiliary: { runtime: 'pi' },
+          skippedCoreCheck: {
+            title: 'No warden.toml found',
+            message: 'No warden.toml found. Skipping analysis.',
+          },
+        }
+      );
+
+      try {
+        await runPRWorkflow(
+          mockOctokit,
+          createDefaultInputs({ mode: 'report', findingsFile }),
+          'pull_request',
+          EVENT_PAYLOAD_PATH,
+          NO_CONFIG_FIXTURES_DIR
+        );
+      } finally {
+        rmSync(dirname(findingsFile), { recursive: true, force: true });
+      }
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockFetchExistingComments).not.toHaveBeenCalled();
+      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'warden',
+          status: 'completed',
+          conclusion: 'neutral',
+          output: expect.objectContaining({
+            title: 'No warden.toml found',
+            summary: expect.stringContaining('No warden.toml found. Skipping analysis.'),
+          }),
+        })
+      );
+      expect(mockWriteFindingsOutput).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          repository: expect.objectContaining({ fullName: 'test-owner/test-repo' }),
+        }),
+        [],
+        {
+          workflow: expect.objectContaining({
+            skippedCoreCheck: {
+              title: 'No warden.toml found',
+              message: 'No warden.toml found. Skipping analysis.',
+            },
+          }),
+          triggerResults: [],
+        }
+      );
+    });
+
+    it('report mode uses workflow auxiliary settings from the findings file', async () => {
+      const report = createSkillReport({ findings: [] });
+      const findingsFile = writeFindingsArtifact(
+        [report],
+        [
+          {
+            triggerName: 'test-skill',
+            skillName: 'test-skill',
+            report,
+          },
+        ],
+        undefined,
+        {
+          auxiliary: {
+            runtime: 'pi',
+            model: 'artifact-aux-model',
+            maxRetries: 9,
+          },
+        }
+      );
+      mockFetchExistingComments.mockResolvedValue([createExistingWardenComment()]);
+
+      try {
+        await runPRWorkflow(
+          mockOctokit,
+          createDefaultInputs({ mode: 'report', findingsFile }),
+          'pull_request',
+          EVENT_PAYLOAD_PATH,
+          LAYERED_AUXILIARY_MODEL_FIXTURES_DIR
+        );
+      } finally {
+        rmSync(dirname(findingsFile), { recursive: true, force: true });
+      }
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockEvaluateFixAttempts).toHaveBeenCalledWith(
+        mockOctokit,
+        expect.arrayContaining([expect.objectContaining({ isWarden: true })]),
+        expect.any(Object),
+        expect.any(Array),
+        'test-api-key',
+        expect.objectContaining({
+          runtime: 'pi',
+          model: 'artifact-aux-model',
+          maxRetries: 9,
+        })
+      );
+    });
+
+    it('report mode renders checks and reviews from artifact settings', async () => {
       const report = createSkillReport({
         findings: [
           createFinding({
@@ -465,6 +607,11 @@ describe('runPRWorkflow', () => {
         {
           triggerName: 'test-skill',
           skillName: 'test-skill',
+          failOn: 'high',
+          reportOn: 'high',
+          failCheck: false,
+          maxFindings: 1,
+          requestChanges: true,
           report,
         },
       ]);
@@ -475,11 +622,11 @@ describe('runPRWorkflow', () => {
           createDefaultInputs({
             mode: 'report',
             findingsFile,
-            failOn: 'high',
-            reportOn: 'high',
-            failCheck: false,
-            maxFindings: 1,
-            requestChanges: true,
+            failOn: 'off',
+            reportOn: 'off',
+            failCheck: true,
+            maxFindings: 2,
+            requestChanges: false,
           }),
           'pull_request',
           EVENT_PAYLOAD_PATH,
@@ -550,26 +697,30 @@ describe('runPRWorkflow', () => {
       );
     });
 
-    it('report mode fails when current config would drop analyze results', async () => {
+    it('report mode replays analyze results when current config would drop them', async () => {
       const report = createSkillReport({ findings: [createFinding()] });
       const findingsFile = writeFindingsArtifact([report], [
         {
+          triggerId: 'analyzed-trigger-id',
           triggerName: 'test-skill',
           skillName: 'test-skill',
+          failOn: 'off',
+          reportOn: 'medium',
+          minConfidence: 'medium',
+          requestChanges: false,
+          failCheck: true,
           report,
         },
       ]);
 
       try {
-        await expect(
-          runPRWorkflow(
-            mockOctokit,
-            createDefaultInputs({ mode: 'report', findingsFile }),
-            'pull_request',
-            EVENT_PAYLOAD_PATH,
-            NO_MATCH_FIXTURES_DIR
-          )
-        ).rejects.toThrow('do not match current config');
+        await runPRWorkflow(
+          mockOctokit,
+          createDefaultInputs({ mode: 'report', findingsFile }),
+          'pull_request',
+          EVENT_PAYLOAD_PATH,
+          NO_MATCH_FIXTURES_DIR
+        );
       } finally {
         rmSync(dirname(findingsFile), { recursive: true, force: true });
       }
@@ -577,12 +728,10 @@ describe('runPRWorkflow', () => {
       expect(mockRunSkillTask).not.toHaveBeenCalled();
       expect(mockOctokit.checks.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'warden',
+          name: 'warden: test-skill',
           status: 'completed',
-          conclusion: 'failure',
           output: expect.objectContaining({
-            title: 'Warden failed',
-            summary: expect.stringContaining('do not match current config'),
+            summary: expect.stringContaining(report.summary),
           }),
         })
       );
@@ -653,48 +802,6 @@ describe('runPRWorkflow', () => {
       );
     });
 
-    it('report mode rejects legacy duplicate skill trigger replay keys', async () => {
-      const highReport = createSkillReport({ summary: 'High report' });
-      const lowReport = createSkillReport({ summary: 'Low report' });
-      const findingsFile = writeFindingsArtifact([highReport, lowReport], [
-        {
-          triggerName: 'test-skill',
-          skillName: 'test-skill',
-          report: highReport,
-        },
-        {
-          triggerName: 'test-skill',
-          skillName: 'test-skill',
-          report: lowReport,
-        },
-      ]);
-
-      try {
-        await expect(
-          runPRWorkflow(
-            mockOctokit,
-            createDefaultInputs({ mode: 'report', findingsFile }),
-            'pull_request',
-            EVENT_PAYLOAD_PATH,
-            DUPLICATE_TRIGGER_FIXTURES_DIR
-          )
-        ).rejects.toThrow('ambiguous duplicate trigger result');
-      } finally {
-        rmSync(dirname(findingsFile), { recursive: true, force: true });
-      }
-
-      expect(mockRunSkillTask).not.toHaveBeenCalled();
-      expect(mockOctokit.checks.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'warden',
-          conclusion: 'failure',
-          output: expect.objectContaining({
-            summary: expect.stringContaining('ambiguous duplicate trigger result'),
-          }),
-        })
-      );
-    });
-
     it('report mode fails GitHub check write errors without creating in-progress checks', async () => {
       const report = createSkillReport({ findings: [createFinding()] });
       const findingsFile = writeFindingsArtifact([report], [
@@ -752,9 +859,16 @@ describe('runPRWorkflow', () => {
       });
       const findingsFile = writeFindingsArtifact([report], [
         {
+          triggerId: 'run-trigger-id',
           triggerName: 'run-skill',
           skillName: 'run-skill',
           report,
+        },
+        {
+          status: 'skipped',
+          triggerId: 'skipped-trigger-id',
+          triggerName: 'skipped-skill',
+          skillName: 'skipped-skill',
         },
       ]);
       vi.mocked(mockOctokit.checks.create).mockRejectedValueOnce(

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -173,6 +173,23 @@ function checkOptionsForPullRequest(context: EventContext): CheckOptions | undef
   };
 }
 
+function setSentryWorkflowContext(context: EventContext): void {
+  if (context.pullRequest) {
+    Sentry.setUser({ username: context.pullRequest.author });
+  }
+  Sentry.setContext('repository', {
+    owner: context.repository.owner,
+    name: context.repository.name,
+  });
+  if (context.pullRequest) {
+    Sentry.setContext('pull_request', {
+      number: context.pullRequest.number,
+      baseBranch: context.pullRequest.baseBranch,
+      headBranch: context.pullRequest.headBranch,
+    });
+  }
+}
+
 function resolveWorkflowAuxiliaryOptions(layered: LoadedLayeredConfig): AuxiliaryWorkflowOptions {
   const baseDefaults = layered.baseConfig?.defaults;
   const repoDefaults = layered.repoConfig?.defaults ?? layered.config.defaults;
@@ -267,6 +284,38 @@ function mergeFixEvaluationResults(
 // Phase Functions
 // -----------------------------------------------------------------------------
 
+function readEventPayload(eventPath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(eventPath, 'utf-8'));
+  } catch (error) {
+    Sentry.captureException(error, { tags: { operation: 'read_event_payload' } });
+    setFailed(`Failed to read event payload: ${error}`);
+  }
+}
+
+async function buildWorkflowContext(
+  octokit: Octokit,
+  eventName: string,
+  eventPath: string,
+  repoPath: string
+): Promise<EventContext> {
+  const eventPayload = readEventPayload(eventPath);
+
+  logGroup('Building event context');
+  console.log(`Event: ${eventName}`);
+  console.log(`Workspace: ${repoPath}`);
+  logGroupEnd();
+
+  try {
+    const context = await buildEventContext(eventName, eventPayload, repoPath, octokit);
+    setRepositoryScope(context.repository.fullName);
+    return context;
+  } catch (error) {
+    Sentry.captureException(error, { tags: { operation: 'build_event_context' } });
+    setFailed(`Failed to build event context: ${error}`);
+  }
+}
+
 /**
  * Parse event payload, build context, load config, match triggers.
  */
@@ -277,27 +326,7 @@ async function initializeWorkflow(
   eventPath: string,
   repoPath: string
 ): Promise<InitResult> {
-  let eventPayload: unknown;
-  try {
-    eventPayload = JSON.parse(readFileSync(eventPath, 'utf-8'));
-  } catch (error) {
-    Sentry.captureException(error, { tags: { operation: 'read_event_payload' } });
-    setFailed(`Failed to read event payload: ${error}`);
-  }
-
-  logGroup('Building event context');
-  console.log(`Event: ${eventName}`);
-  console.log(`Workspace: ${repoPath}`);
-  logGroupEnd();
-
-  let context: EventContext;
-  try {
-    context = await buildEventContext(eventName, eventPayload, repoPath, octokit);
-  } catch (error) {
-    Sentry.captureException(error, { tags: { operation: 'build_event_context' } });
-    setFailed(`Failed to build event context: ${error}`);
-  }
-  setRepositoryScope(context.repository.fullName);
+  const context = await buildWorkflowContext(octokit, eventName, eventPath, repoPath);
 
   logGroup('Loading configuration');
   if (inputs.baseConfigPath) {
@@ -1171,18 +1200,6 @@ function deserializeTriggerError(
   return deserialized;
 }
 
-function resultKey(triggerName: string, skillName: string): string {
-  return `${triggerName}\0${skillName}`;
-}
-
-function replayKey(result: { triggerId?: string; triggerName: string; skillName: string }): string {
-  return result.triggerId ?? resultKey(result.triggerName, result.skillName);
-}
-
-function triggerReplayKey(trigger: ResolvedTrigger): string {
-  return trigger.id;
-}
-
 function describeResultKey(result: { triggerName: string; skillName: string }): string {
   return `${result.triggerName} (${result.skillName})`;
 }
@@ -1192,130 +1209,148 @@ function toReplayTriggerResults(results: TriggerResult[]): ReplayTriggerResult[]
     triggerId: result.triggerId,
     triggerName: result.triggerName,
     skillName: result.skillName,
+    failOn: result.failOn,
+    reportOn: result.reportOn,
+    minConfidence: result.minConfidence,
+    reportOnSuccess: result.reportOnSuccess,
+    requestChanges: result.requestChanges,
+    failCheck: result.failCheck,
+    maxFindings: result.maxFindings,
     report: result.report,
     error: result.error,
   }));
 }
 
-/**
- * Rebuild report-mode trigger results by joining artifact rows to the current
- * configured trigger name and skill identity.
- */
-function buildReportModeResults(
-  output: FindingsOutput,
-  matchedTriggers: ResolvedTrigger[],
+function toReplaySkippedTriggerResults(
+  triggers: ResolvedTrigger[],
   inputs: ActionInputs
-): TriggerResult[] {
+): ReplayTriggerResult[] {
+  return triggers.map((trigger) => ({
+    status: 'skipped',
+    triggerId: trigger.id,
+    triggerName: trigger.name,
+    skillName: trigger.skill,
+    failOn: trigger.failOn ?? inputs.failOn,
+    reportOn: trigger.reportOn ?? inputs.reportOn,
+    minConfidence: trigger.minConfidence ?? 'medium',
+    reportOnSuccess: trigger.reportOnSuccess,
+    requestChanges: trigger.requestChanges ?? inputs.requestChanges,
+    failCheck: trigger.failCheck ?? inputs.failCheck,
+    maxFindings: trigger.maxFindings ?? inputs.maxFindings,
+  }));
+}
+
+function toReplayRows(results: TriggerResult[], skippedTriggers: ResolvedTrigger[], inputs: ActionInputs): ReplayTriggerResult[] {
+  return [...toReplayTriggerResults(results), ...toReplaySkippedTriggerResults(skippedTriggers, inputs)];
+}
+
+function toReplayWorkflow(
+  auxiliaryOptions: AuxiliaryWorkflowOptions,
+  skippedCoreCheck?: SkippedCoreCheck
+): FindingsOutput['workflow'] {
+  return {
+    auxiliary: auxiliaryOptions,
+    ...(skippedCoreCheck && { skippedCoreCheck }),
+  };
+}
+
+/**
+ * Preserve skipped rows as part of the analyze artifact so report mode does not
+ * reload config just to create neutral checks.
+ */
+function toReplayReportRows(results: TriggerResult[], skippedResults: TriggerResult[]): ReplayTriggerResult[] {
+  return [
+    ...toReplayTriggerResults(results),
+    ...skippedResults.map((result) => ({
+      status: 'skipped' as const,
+      triggerId: result.triggerId,
+      triggerName: result.triggerName,
+      skillName: result.skillName,
+      failOn: result.failOn,
+      reportOn: result.reportOn,
+      minConfidence: result.minConfidence,
+      reportOnSuccess: result.reportOnSuccess,
+      requestChanges: result.requestChanges,
+      failCheck: result.failCheck,
+      maxFindings: result.maxFindings,
+    })),
+  ];
+}
+
+/**
+ * Convert a stored analyze row into the report-mode publish shape. Artifact
+ * values are the source of truth; report-step inputs do not fill missing fields.
+ */
+function artifactRowToTriggerResult(
+  result: NonNullable<FindingsOutput['triggerResults']>[number]
+): TriggerResult {
+  const baseResult = {
+    triggerId: result.triggerId,
+    triggerName: result.triggerName,
+    skillName: result.skillName,
+    failOn: result.failOn,
+    reportOn: result.reportOn,
+    minConfidence: result.minConfidence ?? 'medium',
+    reportOnSuccess: result.reportOnSuccess,
+    requestChanges: result.requestChanges,
+    failCheck: result.failCheck,
+    maxFindings: result.maxFindings,
+  };
+
+  if (result.status === 'success') {
+    return {
+      ...baseResult,
+      report: result.report,
+    };
+  }
+
+  if (result.status === 'error') {
+    return {
+      ...baseResult,
+      error: deserializeTriggerError(
+        result.error,
+        `Trigger ${result.triggerName} (${result.skillName}) failed during analysis`
+      ),
+    };
+  }
+
+  setFailed(`Unexpected skipped trigger ${describeResultKey(result)} in report replay results`);
+}
+
+/**
+ * Rebuild skipped checks from artifact rows instead of current config.
+ */
+function buildSkippedReportModeResults(output: FindingsOutput): TriggerResult[] {
+  return (output.triggerResults ?? []).flatMap((result) => {
+    if (result.status !== 'skipped') {
+      return [];
+    }
+
+    return [{
+      triggerId: result.triggerId,
+      triggerName: result.triggerName,
+      skillName: result.skillName,
+      failOn: result.failOn,
+      reportOn: result.reportOn,
+      minConfidence: result.minConfidence ?? 'medium',
+      reportOnSuccess: result.reportOnSuccess,
+      requestChanges: result.requestChanges,
+      failCheck: result.failCheck,
+      maxFindings: result.maxFindings,
+    }];
+  });
+}
+
+/**
+ * Rebuild report-mode trigger results from the analyze artifact.
+ */
+function buildReportModeResults(output: FindingsOutput): TriggerResult[] {
   if (!output.triggerResults) {
     setFailed('Findings file was not produced by mode: analyze; missing triggerResults');
   }
 
-  const outputResults = new Map<string, typeof output.triggerResults>();
-  for (const result of output.triggerResults) {
-    const key = replayKey(result);
-    const existing = outputResults.get(key);
-    if (existing) {
-      existing.push(result);
-    } else {
-      outputResults.set(key, [result]);
-    }
-  }
-
-  const duplicateConfiguredResults = new Map<string, ResolvedTrigger[]>();
-  for (const trigger of matchedTriggers) {
-    const key = triggerReplayKey(trigger);
-    const existing = duplicateConfiguredResults.get(key);
-    if (existing) {
-      existing.push(trigger);
-    } else {
-      duplicateConfiguredResults.set(key, [trigger]);
-    }
-  }
-
-  const ambiguousKeys = [
-    ...new Set([
-      ...[...outputResults.entries()]
-        .filter(([, results]) => results.length > 1)
-        .map(([key]) => key),
-      ...[...duplicateConfiguredResults.entries()]
-        .filter(([, triggers]) => triggers.length > 1)
-        .map(([key]) => key),
-    ]),
-  ];
-
-  if (ambiguousKeys.length > 0) {
-    const triggerList = ambiguousKeys
-      .map((key) => {
-        const result = outputResults.get(key)?.[0];
-        const trigger = duplicateConfiguredResults.get(key)?.[0];
-        return result
-          ? describeResultKey(result)
-          : `${trigger?.name ?? 'unknown'} (${trigger?.skill ?? 'unknown'})`;
-      })
-      .join(', ');
-
-    throw new Error(
-      `Findings file contains ambiguous duplicate trigger result(s): ${triggerList}`
-    );
-  }
-
-  const results = matchedTriggers.map((trigger) => {
-    const failOn = trigger.failOn ?? inputs.failOn;
-    const reportOn = trigger.reportOn ?? inputs.reportOn;
-    const minConfidence = trigger.minConfidence ?? 'medium';
-    const requestChanges = trigger.requestChanges ?? inputs.requestChanges;
-    const failCheck = trigger.failCheck ?? inputs.failCheck;
-    const maxFindings = trigger.maxFindings ?? inputs.maxFindings;
-    const baseResult = {
-      triggerId: trigger.id,
-      triggerName: trigger.name,
-      skillName: trigger.skill,
-      failOn,
-      reportOn,
-      minConfidence,
-      reportOnSuccess: trigger.reportOnSuccess,
-      requestChanges,
-      failCheck,
-      maxFindings,
-    };
-    const outputResult =
-      outputResults.get(triggerReplayKey(trigger))?.shift() ??
-      outputResults.get(resultKey(trigger.name, trigger.skill))?.shift();
-
-    if (!outputResult) {
-      return {
-        ...baseResult,
-        error: new Error(`Findings file has no result for trigger ${trigger.name} (${trigger.skill})`),
-      };
-    }
-
-    if (outputResult.status === 'error' || !outputResult.report) {
-      return {
-        ...baseResult,
-        error: deserializeTriggerError(
-          outputResult.error,
-          `Trigger ${trigger.name} (${trigger.skill}) failed during analysis`
-        ),
-      };
-    }
-
-    return {
-      ...baseResult,
-      report: outputResult.report,
-    };
-  });
-
-  const unreportedResults = [...outputResults.values()].flat();
-  if (unreportedResults.length > 0) {
-    const triggerList = unreportedResults
-      .map(describeResultKey)
-      .join(', ');
-    throw new Error(
-      `Findings file contains ${unreportedResults.length} result(s) that do not match current config: ${triggerList}`
-    );
-  }
-
-  return results;
+  const replayRows = output.triggerResults.filter((result) => result.status !== 'skipped');
+  return replayRows.map((result) => artifactRowToTriggerResult(result));
 }
 
 function withRenderedReviewResult(result: TriggerResult): TriggerResult {
@@ -1386,27 +1421,27 @@ async function createCompletedSkillChecksForReport(
 async function createCompletedSkippedSkillChecks(
   octokit: Octokit,
   context: EventContext,
-  skippedTriggers: ResolvedTrigger[]
+  skippedResults: TriggerResult[]
 ): Promise<void> {
   const options = checkOptionsForPullRequest(context);
-  if (!options || skippedTriggers.length === 0) {
+  if (!options || skippedResults.length === 0) {
     return;
   }
 
-  for (const trigger of skippedTriggers) {
+  for (const result of skippedResults) {
     await createCompletedSkillCheck(
       octokit,
       {
-        skill: trigger.skill,
+        skill: result.skillName,
         summary: 'Trigger did not run for this event.',
         findings: [],
       },
       {
         ...options,
-        failOn: trigger.failOn,
-        reportOn: trigger.reportOn,
-        minConfidence: trigger.minConfidence ?? 'medium',
-        failCheck: trigger.failCheck,
+        failOn: result.failOn,
+        reportOn: result.reportOn,
+        minConfidence: result.minConfidence ?? 'medium',
+        failCheck: result.failCheck,
         conclusion: 'neutral',
         title: 'Skipped',
       }
@@ -1482,6 +1517,8 @@ async function finalizeReportWorkflow(
   context: EventContext,
   previousReviewInfo: BotReviewInfo | null,
   results: TriggerResult[],
+  skippedResults: TriggerResult[],
+  workflow: FindingsOutput['workflow'],
   reports: SkillReport[],
   findingObservations: FindingObservation[],
   shouldFailAction: boolean,
@@ -1504,7 +1541,8 @@ async function finalizeReportWorkflow(
 
   try {
     const findingsPath = writeFindingsOutput(reports, context, findingObservations, {
-      triggerResults: toReplayTriggerResults(results),
+      workflow,
+      triggerResults: toReplayReportRows(results, skippedResults),
     });
     logAction(`Findings written to ${findingsPath}`);
   } catch (error) {
@@ -1616,7 +1654,9 @@ async function runAnalyzeMode(
   const {
     context,
     runnerConcurrency,
+    auxiliaryOptions,
     matchedTriggers,
+    skippedTriggers,
     skipCoreCheck,
   } = initResult;
 
@@ -1625,7 +1665,12 @@ async function runAnalyzeMode(
     setOutput('high-count', 0);
     setOutput('summary', skipCoreCheck?.title ?? 'No triggers matched');
     try {
-      const findingsPath = writeFindingsOutput([], context, [], { triggerResults: [] });
+      const findingsPath = writeFindingsOutput([], context, [], {
+        workflow: toReplayWorkflow(auxiliaryOptions, skipCoreCheck),
+        triggerResults: skipCoreCheck
+          ? []
+          : toReplaySkippedTriggerResults(skippedTriggers, inputs),
+      });
       logAction(`Findings written to ${findingsPath}`);
     } catch (error) {
       setFailed(`Failed to write findings output: ${error}`);
@@ -1650,7 +1695,8 @@ async function runAnalyzeMode(
 
   try {
     const findingsPath = writeFindingsOutput(reports, context, [], {
-      triggerResults: toReplayTriggerResults(results),
+      workflow: toReplayWorkflow(auxiliaryOptions),
+      triggerResults: toReplayRows(results, skippedTriggers, inputs),
     });
     logAction(`Findings written to ${findingsPath}`);
   } catch (error) {
@@ -1663,74 +1709,53 @@ async function runAnalyzeMode(
 
 /**
  * Run the reporting phase without rerunning skills.
- * It replays analyze output against the current PR config and owns GitHub writes.
+ * It validates artifact identity, publishes stored analyze results, and owns
+ * live GitHub writes without recomputing trigger membership from current config.
  */
 async function runReportMode(
   octokit: Octokit,
   inputs: ActionInputs,
-  initResult: InitResult,
+  context: EventContext,
   repoPath: string,
   span: { setAttribute: (name: string, value: number) => void }
 ): Promise<void> {
-  const {
-    context,
-    auxiliaryOptions,
-    matchedTriggers,
-    skippedTriggers,
-    skipCoreCheck,
-  } = initResult;
   const findingsOutput = readFindingsFile(inputs.findingsFile, repoPath);
   validateFindingsMatchContext(findingsOutput, context);
+  const auxiliaryOptions = findingsOutput.workflow?.auxiliary ?? { runtime: 'pi' };
 
   let results: TriggerResult[] = [];
+  let skippedResults: TriggerResult[] = [];
   let previousReviewInfo: BotReviewInfo | null = null;
   let reviewPhase!: ReviewPhaseResult;
   let triggerErrors!: string[];
   let canResolveStale!: boolean;
 
   try {
-    results = buildReportModeResults(findingsOutput, matchedTriggers, inputs);
-    await createCompletedSkippedSkillChecks(octokit, context, skippedTriggers);
+    results = buildReportModeResults(findingsOutput);
+    skippedResults = buildSkippedReportModeResults(findingsOutput);
+    await createCompletedSkippedSkillChecks(octokit, context, skippedResults);
 
-    if (skipCoreCheck) {
-      const outputs = { findingsCount: 0, highCount: 0, summary: skipCoreCheck.title };
-      setWorkflowOutputs(outputs);
-      try {
-        const findingsPath = writeFindingsOutput([], context, [], { triggerResults: [] });
-        logAction(`Findings written to ${findingsPath}`);
-      } catch (error) {
-        warnAction(`Failed to write findings output: ${error}`);
-      }
-      await createCompletedCoreCheckForReport(
-        octokit,
-        context,
-        [],
-        [],
-        false,
-        outputs,
-        {
-          title: skipCoreCheck.title,
-          message: skipCoreCheck.message,
-        },
-        'neutral'
-      );
-      logAction('Analysis complete: 0 total findings');
-      return;
-    }
-
-    if (matchedTriggers.length === 0) {
-      const cleanupFindingObservations = await cleanupOrphanedComments(
-        octokit,
-        context,
-        inputs,
-        auxiliaryOptions,
-        { failOnWriteError: true }
-      );
-      const outputs = { findingsCount: 0, highCount: 0, summary: 'No triggers matched' };
+    if (results.length === 0) {
+      const skippedCoreCheck = findingsOutput.workflow?.skippedCoreCheck;
+      const cleanupFindingObservations = skippedCoreCheck
+        ? []
+        : await cleanupOrphanedComments(
+            octokit,
+            context,
+            inputs,
+            auxiliaryOptions,
+            { failOnWriteError: true }
+          );
+      const coreCheck = skippedCoreCheck ?? {
+        title: 'No triggers matched',
+        message: 'No triggers matched for this event.',
+      };
+      const outputs = { findingsCount: 0, highCount: 0, summary: coreCheck.title };
       setWorkflowOutputs(outputs);
       try {
         const findingsPath = writeFindingsOutput([], context, cleanupFindingObservations, {
-          triggerResults: [],
+          workflow: findingsOutput.workflow,
+          triggerResults: toReplayReportRows(results, skippedResults),
         });
         logAction(`Findings written to ${findingsPath}`);
       } catch (error) {
@@ -1743,10 +1768,7 @@ async function runReportMode(
         [],
         false,
         outputs,
-        {
-          title: 'No triggers matched',
-          message: 'No triggers matched for this event.',
-        },
+        coreCheck,
         'neutral'
       );
       logAction('Analysis complete: 0 total findings');
@@ -1796,7 +1818,7 @@ async function runReportMode(
 
     await finalizeReportWorkflow(
       octokit, context, previousReviewInfo,
-      results, reviewPhase.reports,
+      results, skippedResults, findingsOutput.workflow, reviewPhase.reports,
       reviewPhase.findingObservations,
       reviewPhase.shouldFailAction, reviewPhase.failureReasons,
       canResolveStale,
@@ -1811,7 +1833,7 @@ async function runReportMode(
     throw error;
   }
 
-  handleTriggerErrors(triggerErrors, matchedTriggers.length);
+  handleTriggerErrors(triggerErrors, results.length);
 }
 
 // -----------------------------------------------------------------------------
@@ -1831,6 +1853,21 @@ export async function runPRWorkflow(
   return Sentry.startSpan(
     { op: 'workflow.run', name: 'review pull_request' },
     async (span) => {
+      if (inputs.mode === 'report') {
+        const context = await Sentry.startSpan(
+          { op: 'workflow.init', name: 'initialize report workflow' },
+          () => buildWorkflowContext(octokit, eventName, eventPath, repoPath),
+        );
+        setSentryWorkflowContext(context);
+        span.setAttribute('warden.trigger.count', 0);
+        emitRunMetric();
+        logger.info('Workflow initialized', {
+          'warden.trigger.count': 0,
+          'trace.id': span.spanContext().traceId,
+        });
+        return runReportMode(octokit, inputs, context, repoPath, span);
+      }
+
       const initResult = await Sentry.startSpan(
         { op: 'workflow.init', name: 'initialize workflow' },
         () => initializeWorkflow(octokit, inputs, eventName, eventPath, repoPath),
@@ -1846,21 +1883,7 @@ export async function runPRWorkflow(
       } = initResult;
       span.setAttribute('warden.trigger.count', matchedTriggers.length);
 
-      // Set Sentry context after building event context
-      if (context.pullRequest) {
-        Sentry.setUser({ username: context.pullRequest.author });
-      }
-      Sentry.setContext('repository', {
-        owner: context.repository.owner,
-        name: context.repository.name,
-      });
-      if (context.pullRequest) {
-        Sentry.setContext('pull_request', {
-          number: context.pullRequest.number,
-          baseBranch: context.pullRequest.baseBranch,
-          headBranch: context.pullRequest.headBranch,
-        });
-      }
+      setSentryWorkflowContext(context);
 
       emitRunMetric();
 
@@ -1872,10 +1895,6 @@ export async function runPRWorkflow(
 
       if (inputs.mode === 'analyze') {
         return runAnalyzeMode(inputs, initResult, span);
-      }
-
-      if (inputs.mode === 'report') {
-        return runReportMode(octokit, inputs, initResult, repoPath, span);
       }
 
       const { coreCheckId, previousReviewInfo } = await Sentry.startSpan(


### PR DESCRIPTION
Split report mode now publishes directly from the analyze findings artifact instead of rebuilding trigger state from the report step checkout. Analyze artifacts now carry resolved reporting settings, skipped trigger rows, workflow auxiliary settings, and core skip metadata so report mode stays tied to the PR-relevant analyze run.

This keeps the analyze/report split reliable when config changes between jobs or when the report job has different action inputs. I validated the changed surface with focused workflow/reporting tests, typecheck, lint, docs check, build, and diff whitespace; the full test command still hits the existing real-git remote test timeout in `src/skills/remote.test.ts`.