### PR TITLE
fix(docs): correct apostrophe in 'It's Just Skills' heading

### DIFF
--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -94,7 +94,7 @@ vulnerabilities in code changes for Warden's baseline security skill.
   </section>
 
   <section class="section skill-showcase" id="whats-a-skill">
-    <h2>Its Just Skills</h2>
+    <h2>It's Just Skills</h2>
     <p>The PR feedback above comes from skills. Warden ships with <code>security-review</code> for baseline AppSec coverage and <code>code-review</code> for correctness bugs. They are first passes, and they are still just SKILL.md files telling Warden what to look for.</p>
     <Terminal title="built-in security-review/SKILL.md">
       <Code


### PR DESCRIPTION
Fixes a missing apostrophe in the homepage heading.

**Change:** `Its Just Skills` → `It's Just Skills`

One-line typo fix in `packages/docs/src/pages/index.astro`.