### PR TITLE
fix(scan): Skip changed-line budget for explicit file scans

### DIFF
--- a/packages/docs/src/content/docs/config/scan.mdx
+++ b/packages/docs/src/content/docs/config/scan.mdx
@@ -41,7 +41,7 @@ maxFileLines = 3000
       <code>maxChangedLines</code>
       <span class="sentry-property-meta">number</span>
     </dt>
-    <dd>Max changed lines to analyze after ignores are applied. Default: <code>10000</code>.</dd>
+    <dd>Max changed lines to analyze for PR and diff-based scans after ignores are applied. Explicit local file-target runs do not enforce this budget. Default: <code>10000</code>.</dd>
   </div>
   <div>
     <dt>
@@ -59,6 +59,7 @@ maxFileLines = 3000
   </div>
 </dl>
 
-When a run exceeds `maxFiles` or `maxChangedLines`, Warden scans files in the
-existing diff order until the budget is exhausted and records the remaining
-files as skipped.
+When a PR or diff-based run exceeds `maxFiles` or `maxChangedLines`, Warden
+scans files in the existing diff order until the budget is exhausted and records
+the remaining files as skipped. Explicit local file-target runs still enforce
+`maxFiles`, but not `maxChangedLines`.

--- a/packages/warden/src/cli/context.ts
+++ b/packages/warden/src/cli/context.ts
@@ -150,6 +150,7 @@ export async function buildFileEventContext(options: FileContextOptions): Promis
       files,
     },
     diffContextSource: { type: 'working-tree' },
+    explicitFileTargets: true,
     repoPath: cwd,
   };
 }

--- a/packages/warden/src/sdk/prepare.test.ts
+++ b/packages/warden/src/sdk/prepare.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, it, expect } from 'vitest';
 import { prepareFiles } from './prepare.js';
 import type { EventContext, FileChange } from '../types/index.js';
-import { buildLocalEventContext } from '../cli/context.js';
+import { buildFileEventContext, buildLocalEventContext } from '../cli/context.js';
 
 function makeContext(
   files: {
@@ -281,6 +281,43 @@ describe('prepareFiles', () => {
       filename: 'src/two.ts',
       reason: 'limit:changed_lines',
     });
+  });
+
+  it('does not apply changed-line budget to explicit file targets', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'warden-file-targets-'));
+    tempDirs.push(repoPath);
+    mkdirSync(join(repoPath, 'src'), { recursive: true });
+    writeFileSync(join(repoPath, 'src/one.ts'), 'one\ntwo\nthree');
+    writeFileSync(join(repoPath, 'src/two.ts'), 'one\ntwo\nthree');
+
+    const context = await buildFileEventContext({
+      patterns: ['src/*.ts'],
+      cwd: repoPath,
+    });
+
+    const result = prepareFiles(context, {
+      scan: { maxChangedLines: 3 },
+    });
+
+    expect(result.files.map((file) => file.filename)).toEqual(['src/one.ts', 'src/two.ts']);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('keeps file-count budget for explicit file targets', () => {
+    const context = makeContext([
+      { filename: 'src/one.ts', patch: '@@ -0,0 +1,1 @@\n+one', additions: 1 },
+      { filename: 'src/two.ts', patch: '@@ -0,0 +1,1 @@\n+two', additions: 1 },
+    ]);
+    context.explicitFileTargets = true;
+
+    const result = prepareFiles(context, {
+      scan: { maxFiles: 1, maxChangedLines: 1 },
+    });
+
+    expect(result.files.map((file) => file.filename)).toEqual(['src/one.ts']);
+    expect(result.skippedFiles).toEqual([
+      { filename: 'src/two.ts', reason: 'limit:file_count' },
+    ]);
   });
 
   it('skips patchless files before applying changed-line budget', () => {

--- a/packages/warden/src/sdk/prepare.ts
+++ b/packages/warden/src/sdk/prepare.ts
@@ -58,6 +58,7 @@ export function prepareFiles(
     ignore: options.ignore,
     scan: options.scan,
     diffContextSource: context.diffContextSource,
+    enforceChangedLineBudget: context.explicitFileTargets !== true,
   });
   skippedFiles.push(...scanPolicy.skippedFiles);
 

--- a/packages/warden/src/sdk/scan-policy.ts
+++ b/packages/warden/src/sdk/scan-policy.ts
@@ -83,6 +83,8 @@ export interface ScanPolicyOptions {
   ignore?: IgnoreConfig;
   scan?: ScanConfig;
   diffContextSource?: DiffContextSource;
+  /** Whether to enforce PR/diff changed-line scan budgets. Defaults to true. */
+  enforceChangedLineBudget?: boolean;
 }
 
 export type ScannableFileChange = FileChange & { patch: string };
@@ -387,6 +389,7 @@ export function applyScanPolicy(
 ): ApplyScanPolicyResult {
   const scan = effectiveScanConfig(options.scan);
   const diffContextSource = options.diffContextSource ?? { type: 'working-tree' };
+  const enforceChangedLineBudget = options.enforceChangedLineBudget ?? true;
   const skippedFiles: SkippedFile[] = [];
   const eligible: ScannableFileChange[] = [];
 
@@ -418,7 +421,7 @@ export function applyScanPolicy(
     }
 
     const fileChangedLines = changedLines(file);
-    if (consumedChangedLines + fileChangedLines > scan.maxChangedLines) {
+    if (enforceChangedLineBudget && consumedChangedLines + fileChangedLines > scan.maxChangedLines) {
       skippedFiles.push({ filename: file.filename, reason: 'limit:changed_lines' });
       continue;
     }

--- a/packages/warden/src/triggers/matcher.test.ts
+++ b/packages/warden/src/triggers/matcher.test.ts
@@ -460,10 +460,18 @@ describe('filterContextByPaths', () => {
   });
 
   it('preserves other context fields', () => {
-    const result = filterContextByPaths(baseContext, { paths: ['src/**/*.ts'] });
-    expect(result.eventType).toBe(baseContext.eventType);
-    expect(result.repository).toBe(baseContext.repository);
-    expect(result.repoPath).toBe(baseContext.repoPath);
+    const context: EventContext = {
+      ...baseContext,
+      diffContextSource: { type: 'working-tree' },
+      explicitFileTargets: true,
+    };
+
+    const result = filterContextByPaths(context, { paths: ['src/**/*.ts'] });
+    expect(result.eventType).toBe(context.eventType);
+    expect(result.repository).toBe(context.repository);
+    expect(result.repoPath).toBe(context.repoPath);
+    expect(result.diffContextSource).toBe(context.diffContextSource);
+    expect(result.explicitFileTargets).toBe(true);
     expect(result.pullRequest!.title).toBe('Test PR');
   });
 });

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -446,6 +446,7 @@ export const EventContextSchema = z.object({
   pullRequest: PullRequestContextSchema.optional(),
   repoPath: z.string(),
   diffContextSource: DiffContextSourceSchema.optional(),
+  explicitFileTargets: z.boolean().optional(),
 });
 export type EventContext = z.infer<typeof EventContextSchema>;
 


### PR DESCRIPTION
Explicit local file-target scans now ignore `maxChangedLines`, so a user-supplied target list is not partially skipped by the PR/diff changed-line safety budget. PR and diff-based scans still enforce that budget, and explicit file-target scans still enforce the existing file count, file size, ignore, generated-file, and chunking limits.

The regression coverage exercises explicit file targets bypassing `maxChangedLines`, verifies `maxFiles` still applies, and checks trigger path filtering preserves the explicit-target context marker. The scan config docs now describe `maxChangedLines` as a PR/diff scan budget.

Fixes #419
