### PR TITLE
feat(config): add per-skill verification override

### DIFF
--- a/packages/docs/src/content/docs/config/skills.mdx
+++ b/packages/docs/src/content/docs/config/skills.mdx
@@ -65,6 +65,13 @@ Skills define what Warden analyzes and when.
     </dt>
     <dd>Optional max agentic turns per hunk.</dd>
   </div>
+  <div>
+    <dt>
+      <code>verification</code>
+      <span class="sentry-property-meta">optional</span>
+    </dt>
+    <dd>Override candidate finding verification for this skill. Set <code>enabled = false</code> to skip the second-pass check. Overrides <code>defaults.verification</code>; overridable per trigger.</dd>
+  </div>
 </dl>
 
 ## Filters

--- a/packages/docs/src/content/docs/config/triggers.mdx
+++ b/packages/docs/src/content/docs/config/triggers.mdx
@@ -94,6 +94,13 @@ Triggers can override output settings and the main agent model.
     </dt>
     <dd>Override max agentic turns.</dd>
   </div>
+  <div>
+    <dt>
+      <code>verification</code>
+      <span class="sentry-property-meta">optional</span>
+    </dt>
+    <dd>Override candidate finding verification for this trigger. See <a href="/config/skills/">Skill Entries</a>.</dd>
+  </div>
 </dl>
 
 ## Pull Request Actions

--- a/packages/warden/src/config/loader.test.ts
+++ b/packages/warden/src/config/loader.test.ts
@@ -496,6 +496,52 @@ describe('resolveSkillConfigs', () => {
       expect(resolved?.verifyFindings).toBe(false);
     });
 
+    it('lets skill-level verification override defaults', () => {
+      const skill: SkillConfig = {
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [
+          { type: 'pull_request', actions: ['opened'] },
+        ],
+      };
+
+      const config: WardenConfig = {
+        version: 1,
+        skills: [skill],
+        defaults: {
+          verification: { enabled: true },
+        },
+      };
+
+      const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.verifyFindings).toBe(false);
+    });
+
+    it('lets trigger-level verification override skill and defaults', () => {
+      const skill: SkillConfig = {
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [
+          {
+            type: 'pull_request',
+            actions: ['opened'],
+            verification: { enabled: true },
+          },
+        ],
+      };
+
+      const config: WardenConfig = {
+        version: 1,
+        skills: [skill],
+        defaults: {
+          verification: { enabled: false },
+        },
+      };
+
+      const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.verifyFindings).toBe(true);
+    });
+
     it('falls back to auxiliary model when synthesis model is unset', () => {
       const config: WardenConfig = {
         ...baseConfig,
@@ -940,6 +986,38 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved[1]?.maxContextFiles).toBeUndefined();
   });
 
+  it('lets a repo-layer skill override inherited base verification defaults', () => {
+    const baseConfig: WardenConfig = {
+      version: 1,
+      defaults: {
+        verification: { enabled: false },
+      },
+      skills: [{
+        name: 'org-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const repoConfig: WardenConfig = {
+      version: 1,
+      skills: [{
+        name: 'repo-skill',
+        verification: { enabled: true },
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const resolved = resolveLayeredSkillConfigs({
+      config: { version: 1, skills: [] },
+      baseConfig,
+      repoConfig,
+    });
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]?.verifyFindings).toBe(false);
+    expect(resolved[1]?.verifyFindings).toBe(true);
+  });
+
   it('ignores repo layer duplicates when resolving skills', () => {
     const baseConfig: WardenConfig = {
       version: 1,
@@ -1105,6 +1183,26 @@ describe('maxTurns config', () => {
     const result = WardenConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     expect(result.data?.defaults?.verification?.enabled).toBe(false);
+  });
+
+  it('accepts skill- and trigger-level verification overrides', () => {
+    const config = {
+      version: 1,
+      skills: [{
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [{
+          type: 'pull_request',
+          actions: ['opened'],
+          verification: { enabled: true },
+        }],
+      }],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.skills[0]?.verification?.enabled).toBe(false);
+    expect(result.data?.skills[0]?.triggers?.[0]?.verification?.enabled).toBe(true);
   });
 
   it('rejects unknown runtimes', () => {

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -446,6 +446,18 @@ function triggerIdentity(skill: SkillConfig, trigger: SkillTrigger | undefined):
   });
 }
 
+function resolveVerifyFindings(
+  defaults: Defaults | undefined,
+  skill: SkillConfig,
+  trigger?: SkillTrigger
+): boolean {
+  const merged = mergeNestedConfig(
+    mergeNestedConfig(defaults?.verification, skill.verification),
+    trigger?.verification
+  );
+  return merged?.enabled !== false;
+}
+
 function resolveSkillSource(
   skill: SkillConfig,
   skillRootsByName?: Record<string, string | undefined>
@@ -500,7 +512,6 @@ export function resolveSkillConfigs(
   const auxiliaryMaxRetries =
     defaults?.auxiliary?.maxRetries ??
     defaults?.auxiliaryMaxRetries;
-  const verifyFindings = defaults?.verification?.enabled !== false;
 
   for (const skill of config.skills) {
     const skillSource = resolveSkillSource(skill, skillRootsByName);
@@ -547,7 +558,7 @@ export function resolveSkillConfigs(
         auxiliaryModel,
         synthesisModel,
         auxiliaryMaxRetries,
-        verifyFindings,
+        verifyFindings: resolveVerifyFindings(defaults, skill),
         minConfidence: skill.minConfidence ?? defaults?.minConfidence,
         batchDelayMs: defaults?.batchDelayMs,
         maxContextFiles: defaults?.chunking?.maxContextFiles,
@@ -582,7 +593,7 @@ export function resolveSkillConfigs(
           auxiliaryModel,
           synthesisModel,
           auxiliaryMaxRetries,
-          verifyFindings,
+          verifyFindings: resolveVerifyFindings(defaults, skill, trigger),
           minConfidence: trigger.minConfidence ?? skill.minConfidence ?? defaults?.minConfidence,
           batchDelayMs: defaults?.batchDelayMs,
           maxContextFiles: defaults?.chunking?.maxContextFiles,

--- a/packages/warden/src/config/schema.ts
+++ b/packages/warden/src/config/schema.ts
@@ -101,6 +101,8 @@ export const SkillTriggerSchema = z.object({
   failCheck: z.boolean().optional(),
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
+  /** Candidate finding verification. Overrides skill/defaults verification. */
+  verification: VerificationConfigSchema.optional(),
   /** Minimum confidence level for findings. Findings below this are filtered from output. */
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Schedule-specific configuration. Only used when type is 'schedule'. */
@@ -146,6 +148,8 @@ export const SkillConfigSchema = z.object({
   model: z.string().optional(),
   /** Maximum agentic turns (API round-trips) per hunk analysis. Overrides defaults.maxTurns. */
   maxTurns: z.number().int().positive().optional(),
+  /** Candidate finding verification. Overrides defaults.verification. */
+  verification: VerificationConfigSchema.optional(),
   /** Minimum confidence level for findings. Findings below this are filtered from output. */
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Triggers defining when/where this skill runs. Omit to run everywhere (wildcard). */


### PR DESCRIPTION
## Problem

`verification.enabled` is only configurable at `[defaults.verification]`. Every other per-run tunable — `failOn`, `reportOn`, `maxFindings`, `model`, `maxTurns`, `minConfidence` — already overrides at the skill and trigger level. Verification was the outlier, forcing repos that want to mix verified and unverified skills to maintain two separate `warden.toml` configs.

## Change

Adds `verification` to `SkillConfigSchema` and `SkillTriggerSchema`, and a `resolveVerifyFindings` helper that merges `defaults → skill → trigger` using the existing `mergeNestedConfig` helper — the same merge pattern every sibling field already uses. No new config surface pattern, no breaking change: omitting `verification` anywhere preserves today's behavior (verification on unless explicitly disabled).

```toml
[[skills]]
name = "security-review"
# verification stays on (default) — low false-positive tolerance

[[skills]]
name = "style-lint"
[skills.verification]
enabled = false  # fast/cheap skill, skip the second-pass check
```

## Docs

Adds the `verification` field to the skills and triggers config reference pages for parity with sibling fields.

## Tests

4 cases in `loader.test.ts` covering skill-level override, trigger-level override, layered-config (base + repo layer) inheritance, and schema round-trip.

## Verification

- `pnpm lint && pnpm build && pnpm test` passes on this branch
- Applied this change to a local fork and verified with real PRs