### PR TITLE
feat(config): Add per-skill verification overrides

### DIFF
--- a/packages/docs/src/content/docs/benchmarking/running.mdx
+++ b/packages/docs/src/content/docs/benchmarking/running.mdx
@@ -344,8 +344,10 @@ Record:
 
 Warden's finding verifier is enabled by default. Benchmark runs should leave it
 enabled unless they are deliberately testing verifier-off behavior. It is
-disabled only when `defaults.verification.enabled = false` is set in
-`warden.toml`. Record this as `findingVerification.enabled` in the result JSON.
+disabled when the effective `verification.enabled` setting is `false` in
+`warden.toml`, with trigger settings overriding skill settings and skill settings
+overriding defaults. Record this as `findingVerification.enabled` in the result
+JSON.
 
 Verifier calls are part of Warden's analysis pipeline, not benchmark scoring.
 They can add provider cost, and runs with more candidate findings generally do

--- a/packages/docs/src/content/docs/config/skills.mdx
+++ b/packages/docs/src/content/docs/config/skills.mdx
@@ -65,6 +65,13 @@ Skills define what Warden analyzes and when.
     </dt>
     <dd>Optional max agentic turns per hunk.</dd>
   </div>
+  <div>
+    <dt>
+      <code>verification</code>
+      <span class="sentry-property-meta">optional</span>
+    </dt>
+    <dd>Override candidate finding verification for this skill. Set <code>enabled = false</code> to skip the second-pass check. Overrides <code>defaults.verification</code>; overridable per trigger.</dd>
+  </div>
 </dl>
 
 ## Filters

--- a/packages/docs/src/content/docs/config/triggers.mdx
+++ b/packages/docs/src/content/docs/config/triggers.mdx
@@ -94,6 +94,13 @@ Triggers can override output settings and the main agent model.
     </dt>
     <dd>Override max agentic turns.</dd>
   </div>
+  <div>
+    <dt>
+      <code>verification</code>
+      <span class="sentry-property-meta">optional</span>
+    </dt>
+    <dd>Override candidate finding verification for this trigger. See <a href="/config/skills/">Skill Entries</a>.</dd>
+  </div>
 </dl>
 
 ## Pull Request Actions

--- a/packages/warden/src/config/loader.test.ts
+++ b/packages/warden/src/config/loader.test.ts
@@ -500,9 +500,6 @@ describe('resolveSkillConfigs', () => {
       const skill: SkillConfig = {
         name: 'test-skill',
         verification: { enabled: false },
-        triggers: [
-          { type: 'pull_request', actions: ['opened'] },
-        ],
       };
 
       const config: WardenConfig = {
@@ -514,6 +511,7 @@ describe('resolveSkillConfigs', () => {
       };
 
       const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.type).toBe('*');
       expect(resolved?.verifyFindings).toBe(false);
     });
 
@@ -540,6 +538,30 @@ describe('resolveSkillConfigs', () => {
 
       const [resolved] = resolveSkillConfigs(config);
       expect(resolved?.verifyFindings).toBe(true);
+    });
+
+    it('includes verification overrides in stable trigger identities', () => {
+      const config: WardenConfig = {
+        version: 1,
+        skills: [{
+          name: 'test-skill',
+          triggers: [
+            {
+              type: 'pull_request',
+              actions: ['opened'],
+              verification: { enabled: false },
+            },
+            {
+              type: 'pull_request',
+              actions: ['opened'],
+              verification: { enabled: true },
+            },
+          ],
+        }],
+      };
+
+      const resolved = resolveSkillConfigs(config);
+      expect(new Set(resolved.map((trigger) => trigger.id)).size).toBe(2);
     });
 
     it('falls back to auxiliary model when synthesis model is unset', () => {

--- a/packages/warden/src/config/loader.test.ts
+++ b/packages/warden/src/config/loader.test.ts
@@ -496,6 +496,52 @@ describe('resolveSkillConfigs', () => {
       expect(resolved?.verifyFindings).toBe(false);
     });
 
+    it('lets skill-level verification override defaults', () => {
+      const skill: SkillConfig = {
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [
+          { type: 'pull_request', actions: ['opened'] },
+        ],
+      };
+
+      const config: WardenConfig = {
+        version: 1,
+        skills: [skill],
+        defaults: {
+          verification: { enabled: true },
+        },
+      };
+
+      const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.verifyFindings).toBe(false);
+    });
+
+    it('lets trigger-level verification override skill and defaults', () => {
+      const skill: SkillConfig = {
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [
+          {
+            type: 'pull_request',
+            actions: ['opened'],
+            verification: { enabled: true },
+          },
+        ],
+      };
+
+      const config: WardenConfig = {
+        version: 1,
+        skills: [skill],
+        defaults: {
+          verification: { enabled: false },
+        },
+      };
+
+      const [resolved] = resolveSkillConfigs(config);
+      expect(resolved?.verifyFindings).toBe(true);
+    });
+
     it('falls back to auxiliary model when synthesis model is unset', () => {
       const config: WardenConfig = {
         ...baseConfig,
@@ -940,6 +986,38 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved[1]?.maxContextFiles).toBeUndefined();
   });
 
+  it('lets a repo-layer skill override inherited base verification defaults', () => {
+    const baseConfig: WardenConfig = {
+      version: 1,
+      defaults: {
+        verification: { enabled: false },
+      },
+      skills: [{
+        name: 'org-skill',
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const repoConfig: WardenConfig = {
+      version: 1,
+      skills: [{
+        name: 'repo-skill',
+        verification: { enabled: true },
+        triggers: [{ type: 'pull_request', actions: ['opened'] }],
+      }],
+    };
+
+    const resolved = resolveLayeredSkillConfigs({
+      config: { version: 1, skills: [] },
+      baseConfig,
+      repoConfig,
+    });
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]?.verifyFindings).toBe(false);
+    expect(resolved[1]?.verifyFindings).toBe(true);
+  });
+
   it('ignores repo layer duplicates when resolving skills', () => {
     const baseConfig: WardenConfig = {
       version: 1,
@@ -1105,6 +1183,26 @@ describe('maxTurns config', () => {
     const result = WardenConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     expect(result.data?.defaults?.verification?.enabled).toBe(false);
+  });
+
+  it('accepts skill- and trigger-level verification overrides', () => {
+    const config = {
+      version: 1,
+      skills: [{
+        name: 'test-skill',
+        verification: { enabled: false },
+        triggers: [{
+          type: 'pull_request',
+          actions: ['opened'],
+          verification: { enabled: true },
+        }],
+      }],
+    };
+
+    const result = WardenConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.skills[0]?.verification?.enabled).toBe(false);
+    expect(result.data?.skills[0]?.triggers?.[0]?.verification?.enabled).toBe(true);
   });
 
   it('rejects unknown runtimes', () => {

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -446,6 +446,18 @@ function triggerIdentity(skill: SkillConfig, trigger: SkillTrigger | undefined):
   });
 }
 
+function resolveVerifyFindings(
+  defaults: Defaults | undefined,
+  skill: SkillConfig,
+  trigger?: SkillTrigger
+): boolean {
+  const merged = mergeNestedConfig(
+    mergeNestedConfig(defaults?.verification, skill.verification),
+    trigger?.verification
+  );
+  return merged?.enabled !== false;
+}
+
 function resolveSkillSource(
   skill: SkillConfig,
   skillRootsByName?: Record<string, string | undefined>
@@ -500,7 +512,6 @@ export function resolveSkillConfigs(
   const auxiliaryMaxRetries =
     defaults?.auxiliary?.maxRetries ??
     defaults?.auxiliaryMaxRetries;
-  const verifyFindings = defaults?.verification?.enabled !== false;
 
   for (const skill of config.skills) {
     const skillSource = resolveSkillSource(skill, skillRootsByName);
@@ -547,7 +558,7 @@ export function resolveSkillConfigs(
         auxiliaryModel,
         synthesisModel,
         auxiliaryMaxRetries,
-        verifyFindings,
+        verifyFindings: resolveVerifyFindings(defaults, skill),
         minConfidence: skill.minConfidence ?? defaults?.minConfidence,
         batchDelayMs: defaults?.batchDelayMs,
         maxContextFiles: defaults?.chunking?.maxContextFiles,
@@ -582,7 +593,7 @@ export function resolveSkillConfigs(
           auxiliaryModel,
           synthesisModel,
           auxiliaryMaxRetries,
-          verifyFindings,
+          verifyFindings: resolveVerifyFindings(defaults, skill, trigger),
           minConfidence: trigger.minConfidence ?? skill.minConfidence ?? defaults?.minConfidence,
           batchDelayMs: defaults?.batchDelayMs,
           maxContextFiles: defaults?.chunking?.maxContextFiles,

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -437,6 +437,7 @@ function triggerIdentity(skill: SkillConfig, trigger: SkillTrigger | undefined):
     failCheck: trigger?.failCheck ?? skill.failCheck,
     model: trigger?.model ?? skill.model,
     maxTurns: trigger?.maxTurns ?? skill.maxTurns,
+    verification: trigger?.verification?.enabled ?? skill.verification?.enabled,
     minConfidence: trigger?.minConfidence ?? skill.minConfidence,
     type: trigger?.type ?? '*',
     actions: trigger?.actions,
@@ -451,11 +452,10 @@ function resolveVerifyFindings(
   skill: SkillConfig,
   trigger?: SkillTrigger
 ): boolean {
-  const merged = mergeNestedConfig(
-    mergeNestedConfig(defaults?.verification, skill.verification),
-    trigger?.verification
-  );
-  return merged?.enabled !== false;
+  return trigger?.verification?.enabled
+    ?? skill.verification?.enabled
+    ?? defaults?.verification?.enabled
+    ?? true;
 }
 
 function resolveSkillSource(

--- a/packages/warden/src/config/schema.ts
+++ b/packages/warden/src/config/schema.ts
@@ -101,6 +101,8 @@ export const SkillTriggerSchema = z.object({
   failCheck: z.boolean().optional(),
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
+  /** Candidate finding verification. Overrides skill/defaults verification. */
+  verification: VerificationConfigSchema.optional(),
   /** Minimum confidence level for findings. Findings below this are filtered from output. */
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Schedule-specific configuration. Only used when type is 'schedule'. */
@@ -146,6 +148,8 @@ export const SkillConfigSchema = z.object({
   model: z.string().optional(),
   /** Maximum agentic turns (API round-trips) per hunk analysis. Overrides defaults.maxTurns. */
   maxTurns: z.number().int().positive().optional(),
+  /** Candidate finding verification. Overrides defaults.verification. */
+  verification: VerificationConfigSchema.optional(),
   /** Minimum confidence level for findings. Findings below this are filtered from output. */
   minConfidence: ConfidenceThresholdSchema.optional(),
   /** Triggers defining when/where this skill runs. Omit to run everywhere (wildcard). */

--- a/packages/warden/src/config/writer.test.ts
+++ b/packages/warden/src/config/writer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
 import { generateSkillToml } from './writer.js';
-import type { SkillConfig } from './schema.js';
+import { WardenConfigSchema, type SkillConfig } from './schema.js';
 
 describe('generateSkillToml', () => {
   it('generates basic skill TOML with trigger', () => {
@@ -181,6 +182,22 @@ describe('generateSkillToml', () => {
     expect(triggerSection).toContain('failOn = "high"');
     expect(triggerSection).toContain('reportOn = "high"');
     expect(triggerSection).toContain('maxFindings = 5');
+  });
+
+  it('round-trips skill- and trigger-level verification overrides', () => {
+    const result = generateSkillToml({
+      name: 'security-review',
+      verification: { enabled: false },
+      triggers: [{
+        type: 'pull_request',
+        actions: ['opened'],
+        verification: { enabled: true },
+      }],
+    });
+
+    const config = WardenConfigSchema.parse(parseToml(`version = 1\n\n${result}`));
+    expect(config.skills[0]?.verification?.enabled).toBe(false);
+    expect(config.skills[0]?.triggers?.[0]?.verification?.enabled).toBe(true);
   });
 
   it('includes reportOnSuccess when present', () => {

--- a/packages/warden/src/config/writer.ts
+++ b/packages/warden/src/config/writer.ts
@@ -59,6 +59,12 @@ export function generateSkillToml(skill: SkillConfig): string {
     lines.push(`minConfidence = "${skill.minConfidence}"`);
   }
 
+  if (skill.verification?.enabled !== undefined) {
+    lines.push('');
+    lines.push('[skills.verification]');
+    lines.push(`enabled = ${skill.verification.enabled}`);
+  }
+
   // Nested triggers
   if (skill.triggers) {
     for (const trigger of skill.triggers) {
@@ -115,6 +121,12 @@ export function generateSkillToml(skill: SkillConfig): string {
 
       if (trigger.minConfidence !== undefined) {
         lines.push(`minConfidence = "${trigger.minConfidence}"`);
+      }
+
+      if (trigger.verification?.enabled !== undefined) {
+        lines.push('');
+        lines.push('[skills.triggers.verification]');
+        lines.push(`enabled = ${trigger.verification.enabled}`);
       }
 
       if (trigger.schedule) {


### PR DESCRIPTION
Warden can now override candidate-finding verification at the skill and trigger scope, using trigger settings over skill settings over defaults. Omitting the setting preserves the existing default of enabled verification.

Generated TOML retains both override levels, and stable trigger identities distinguish runs with different verification policies so split analyze/report workflows replay the correct result.

Supersedes and closes #429.
