### PR TITLE
fix(action): Attribute startup telemetry to repositories

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -21,7 +21,7 @@ when telemetry is enabled.
 | -------------- | ------------- | ----- | ------- | --------- |
 | `trace_id` from CLI summary, JSONL, or `Workflow initialized` | Sentry Traces and Logs | `span_id` | full run timeline, slow/error span | inspect skill or workflow span |
 | Sentry `event_id` | Sentry Issues/Event | `trace_id`, `operation`, `warden.trigger.name`, `gen_ai.agent.name` | exception context and owning workflow | query trace logs |
-| GitHub repository or Action run | Sentry Logs and Metrics | `vcs.owner.name`, `vcs.repository.name`, `cicd.pipeline.run.id`, `github.event.name` | recent Warden runs and trigger count | open matching trace |
+| GitHub repository or Action run | Sentry Spans, Logs, and Metrics | `vcs.owner.name`, `vcs.repository.name`, `cicd.pipeline.run.id`, `github.event.name` | startup outcome, failure stage, and recent runs | open matching trace |
 | Skill or trigger name | Sentry Spans, Issues, Metrics | `gen_ai.agent.name`, `warden.trigger.name` | failing skill, model cost, finding count | inspect hunk or agent spans |
 | File path or hunk | Sentry Spans | `code.file.path`, `warden.hunk.line_range` | hunk analysis state and extraction failures | inspect agent span |
 | Model, tool, or token symptom | Sentry Spans | `gen_ai.*`, `gen_ai.tool.name` | Claude turn, tool, cost, and token behavior | inspect child spans |
@@ -34,12 +34,12 @@ when telemetry is enabled.
 | `trace_id` | one Warden run trace | CLI verbose summary, JSONL, logs, issues, spans | open trace |
 | `span_id` | one workflow, skill, hunk, model, or tool span | logs, spans | inspect span |
 | `event_id` | captured Sentry error | Sentry issue/event | open event |
-| `vcs.repository.name` | repository name | global attributes, logs, metrics, spans | repo runs |
-| `vcs.owner.name` | repository owner or org | global attributes, logs, metrics, spans | repo runs |
-| `vcs.repository.url.full` | canonical repository URL | global attributes, logs, metrics, spans | exact repo runs |
-| `github.event.name` | Action event name | `workflow.run` span | action entry |
-| `cicd.pipeline.run.id` | GitHub Actions run ID | global attributes, logs, metrics, spans | action run |
-| `cicd.pipeline.run.url.full` | GitHub Actions run URL | global attributes, logs, metrics, spans | action run |
+| `vcs.repository.name` | repository name | Action root span, logs, metrics | repo runs |
+| `vcs.owner.name` | repository owner or org | Action root span, logs, metrics | repo runs |
+| `vcs.repository.url.full` | canonical repository URL | Action root span, logs, metrics | exact repo runs |
+| `github.event.name` | Action event name | `cicd.workflow` root span, logs, metrics | action entry |
+| `cicd.pipeline.run.id` | GitHub Actions run ID | Action root span, logs, metrics | action run |
+| `cicd.pipeline.run.url.full` | GitHub Actions run URL | Action root span, logs, metrics | action run |
 | `warden.trigger.name` | matched Warden trigger | trigger exceptions | trigger failures |
 | `gen_ai.agent.name` | configured or resolved skill/agent | spans, issues, metrics | skill timeline |
 | `code.file.path` | file being analyzed or judged | hunk/file/fix spans | file analysis |
@@ -57,7 +57,8 @@ fields=timestamp,level,message,trace_id,span_id,vcs.owner.name,vcs.repository.na
 sort=timestamp
 ```
 
-Recent GitHub Action runs for a repository.
+Recent initialized GitHub Action workflows for a repository. Startup failures
+that occur before workflow initialization appear in the root-span recipe below.
 
 ```text
 dataset=logs query='message:"Workflow initialized" vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
@@ -65,11 +66,20 @@ fields=timestamp,trace_id,github.event.name,cicd.pipeline.run.id,cicd.pipeline.r
 sort=-timestamp
 ```
 
-Workflow run spans for a repository.
+GitHub Action root spans, including input and environment startup failures.
 
 ```text
-dataset=spans query='span.op:workflow.run vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
-fields=timestamp,trace,span_id,span.duration,github.event.name,cicd.pipeline.run.id,cicd.pipeline.run.url.full,warden.trigger.count,warden.finding.count,error.type
+dataset=spans query='span.op:cicd.workflow vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
+fields=timestamp,trace,span_id,span.duration,github.event.name,cicd.pipeline.run.id,cicd.pipeline.run.url.full,warden.action.outcome,warden.action.stage,warden.error.code,error.type
+sort=-timestamp
+```
+
+Analysis workflow child span after finding the Action root and copying its
+trace ID.
+
+```text
+dataset=spans query='trace:"<trace_id>" span.op:workflow.run'
+fields=timestamp,trace,span_id,span.duration,warden.trigger.count,warden.finding.count,error.type
 sort=-timestamp
 ```
 
@@ -131,8 +141,8 @@ sort=-timestamp
 Repository-level health and cost.
 
 ```text
-dataset=metrics query='metric:warden.workflow.runs OR metric:warden.skill.duration OR metric:warden.gen_ai.cost.usd vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
-fields=timestamp,metric,vcs.owner.name,vcs.repository.name,cicd.pipeline.run.id,gen_ai.agent.name,gen_ai.request.model,value
+dataset=metrics query='metric:warden.action.runs OR metric:warden.workflow.runs OR metric:warden.skill.duration OR metric:warden.gen_ai.cost.usd vcs.owner.name:"<owner>" vcs.repository.name:"<repo>"'
+fields=timestamp,metric,vcs.owner.name,vcs.repository.name,cicd.pipeline.run.id,warden.action.outcome,warden.action.stage,warden.error.code,gen_ai.agent.name,gen_ai.request.model,value
 sort=-timestamp
 ```
 
@@ -185,13 +195,16 @@ building repository context.
 
 Events: `Workflow initialized`, top-level CLI/action fatal error
 
-Spans: `workflow.run`, `workflow.init`, `config.load`
+Spans: `cicd.workflow`, `workflow.run`, `workflow.init`, `config.load`
+
+Metrics: `warden.action.runs`, `warden.workflow.runs`
 
 Attributes: `trace_id`, `vcs.owner.name`, `vcs.repository.name`,
 `vcs.repository.url.full`, `warden.source`, `github.event.name`,
 `cicd.pipeline.name`, `cicd.pipeline.run.id`,
 `cicd.pipeline.run.url.full`, `warden.trigger.count`,
-`warden.finding.count`
+`warden.finding.count`, `warden.action.outcome`, `warden.action.stage`,
+`warden.error.code`
 
 ### Trigger And GitHub Review
 

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -52,6 +52,7 @@
     "@earendil-works/pi-coding-agent": "^0.80.6",
     "@inquirer/select": "^5.1.5",
     "@octokit/rest": "^22.0.1",
+    "@sentry/core": "^10.53.1",
     "@sentry/dotagents-lib": "^1.17.0",
     "@sentry/node": "^10.53.1",
     "chalk": "^5.6.2",

--- a/packages/warden/src/action/run.ts
+++ b/packages/warden/src/action/run.ts
@@ -5,7 +5,7 @@
  * module. Workflow modules own trigger-level error handling.
  */
 
-import { initSentry, Sentry, flushSentry } from '../sentry.js';
+import { initSentry, flushSentry } from '../sentry.js';
 import { ActionFailedError } from './workflow/base.js';
 import { runAction } from './runner.js';
 
@@ -16,7 +16,6 @@ runAction()
     if (error instanceof ActionFailedError) {
       console.error(`::error::${error.message}`);
     } else {
-      Sentry.captureException(error);
       console.error(`::error::Unexpected error: ${error}`);
     }
     await flushSentry();

--- a/packages/warden/src/action/runner.test.ts
+++ b/packages/warden/src/action/runner.test.ts
@@ -1,19 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ErrorEvent, TransactionEvent } from '@sentry/core';
 import type { ActionInputs } from './inputs.js';
+import { initSentry, Sentry } from '../sentry.js';
 
-const mocks = vi.hoisted(() => ({
-  octokit: {},
-  parseActionInputs: vi.fn(),
-  validateInputs: vi.fn(),
-  setupAuthEnv: vi.fn(),
-  setFailed: vi.fn((message: string): never => {
-    throw new Error(message);
-  }),
-  runPRWorkflow: vi.fn(() => Promise.resolve()),
-  runScheduleWorkflow: vi.fn(() => Promise.resolve()),
-  setGitHubActionScope: vi.fn(),
-  setRepositoryScope: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  return {
+    octokit: {},
+    parseActionInputs: vi.fn(),
+    validateInputs: vi.fn(),
+    setupAuthEnv: vi.fn(),
+    runPRWorkflow: vi.fn(() => Promise.resolve()),
+    runScheduleWorkflow: vi.fn(() => Promise.resolve()),
+    classifyError: vi.fn(() => ({ code: 'unknown', message: 'test error' })),
+  };
+});
 
 vi.mock('@octokit/rest', () => ({
   Octokit: vi.fn(function Octokit() {
@@ -21,19 +21,14 @@ vi.mock('@octokit/rest', () => ({
   }),
 }));
 
-vi.mock('../sentry.js', () => ({
-  setGitHubActionScope: mocks.setGitHubActionScope,
-  setRepositoryScope: mocks.setRepositoryScope,
+vi.mock('../sdk/errors.js', () => ({
+  classifyError: mocks.classifyError,
 }));
 
 vi.mock('./inputs.js', () => ({
   parseActionInputs: mocks.parseActionInputs,
   validateInputs: mocks.validateInputs,
   setupAuthEnv: mocks.setupAuthEnv,
-}));
-
-vi.mock('./workflow/base.js', () => ({
-  setFailed: mocks.setFailed,
 }));
 
 vi.mock('./workflow/pr-workflow.js', () => ({
@@ -56,14 +51,75 @@ const baseInputs: ActionInputs = {
   parallel: 4,
 };
 
-describe('runAction', () => {
-  beforeEach(() => {
+const capturedTransactions: TransactionEvent[] = [];
+const capturedEvents: ErrorEvent[] = [];
+
+function spyOnClientEmit() {
+  const client = Sentry.getClient();
+  if (!client) throw new Error('Sentry test client was not initialized');
+  return vi.spyOn(client, 'emit');
+}
+
+describe('runAction without telemetry', () => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    delete process.env['WARDEN_SENTRY_DSN'];
+    await Sentry.close(0);
     process.env['GITHUB_EVENT_NAME'] = 'schedule';
     process.env['GITHUB_EVENT_PATH'] = '/tmp/event.json';
     process.env['GITHUB_WORKSPACE'] = '/tmp/workspace';
     process.env['GITHUB_REPOSITORY'] = 'getsentry/warden';
     mocks.parseActionInputs.mockReturnValue({ ...baseInputs });
+  });
+
+  it('dispatches safely without an initialized Sentry client', async () => {
+    await runAction();
+
+    expect(mocks.runScheduleWorkflow).toHaveBeenCalledWith(
+      mocks.octokit,
+      baseInputs,
+      '/tmp/workspace'
+    );
+  });
+});
+
+describe('runAction', () => {
+  beforeAll(() => {
+    process.env['WARDEN_SENTRY_DSN'] = 'https://public@example.com/1';
+    initSentry('action', {
+      transport: () => ({
+        send: async () => ({}),
+        flush: async () => true,
+      }),
+      beforeSendTransaction: (event) => {
+        capturedTransactions.push(event);
+        return event;
+      },
+      beforeSend: (event) => {
+        capturedEvents.push(event);
+        return event;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    capturedTransactions.length = 0;
+    capturedEvents.length = 0;
+    Sentry.getGlobalScope().clear();
+    Sentry.getIsolationScope().clear();
+    process.env['GITHUB_EVENT_NAME'] = 'schedule';
+    process.env['GITHUB_EVENT_PATH'] = '/tmp/event.json';
+    process.env['GITHUB_WORKSPACE'] = '/tmp/workspace';
+    process.env['GITHUB_REPOSITORY'] = 'getsentry/warden';
+    process.env['GITHUB_RUN_ID'] = '12345';
+    mocks.parseActionInputs.mockReturnValue({ ...baseInputs });
+  });
+
+  afterAll(async () => {
+    delete process.env['WARDEN_SENTRY_DSN'];
+    await Sentry.close(0);
   });
 
   it.each(['analyze', 'report'] as const)(
@@ -105,8 +161,10 @@ describe('runAction', () => {
 
   it('keeps legacy run mode dispatching non-schedule workflows', async () => {
     process.env['GITHUB_EVENT_NAME'] = 'push';
+    const emit = spyOnClientEmit();
 
     await runAction();
+    await Sentry.flush(1000);
 
     expect(mocks.runScheduleWorkflow).not.toHaveBeenCalled();
     expect(mocks.runPRWorkflow).toHaveBeenCalledWith(
@@ -115,6 +173,188 @@ describe('runAction', () => {
       'push',
       '/tmp/event.json',
       '/tmp/workspace'
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.action.runs',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.action.outcome': 'success',
+          'warden.action.stage': 'dispatch',
+        }),
+      })
+    );
+    expect(capturedTransactions).toContainEqual(
+      expect.objectContaining({
+        transaction: 'run Warden action',
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            op: 'cicd.workflow',
+            status: 'ok',
+            data: expect.objectContaining({ 'warden.action.outcome': 'success' }),
+          }),
+        }),
+      })
+    );
+  });
+
+  it('attributes input parsing failures before capturing them', async () => {
+    const error = new Error('Invalid mode "later"');
+    const setTag = vi.spyOn(Sentry.getIsolationScope(), 'setTag');
+    const emit = spyOnClientEmit();
+    mocks.parseActionInputs.mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(runAction()).rejects.toBe(error);
+    await Sentry.flush(1000);
+
+    expect(setTag).toHaveBeenCalledWith('repository', 'getsentry/warden');
+    expect(setTag.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.parseActionInputs.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.action.runs',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.action.outcome': 'failure',
+          'warden.action.stage': 'input',
+          'warden.error.code': 'unknown',
+        }),
+      })
+    );
+    expect(capturedTransactions).toContainEqual(
+      expect.objectContaining({
+        transaction: 'run Warden action',
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            op: 'cicd.workflow',
+            status: 'internal_error',
+            data: expect.objectContaining({
+              'warden.action.outcome': 'failure',
+              'warden.action.stage': 'input',
+              'warden.error.code': 'unknown',
+              'vcs.repository.name': 'warden',
+              'cicd.pipeline.run.id': '12345',
+            }),
+          }),
+        }),
+      })
+    );
+    const rootTraceId = capturedTransactions.find(
+      (event) => event.transaction === 'run Warden action'
+    )?.contexts?.trace?.trace_id;
+    expect(rootTraceId).toBeTruthy();
+    expect(capturedEvents).toContainEqual(
+      expect.objectContaining({
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({ trace_id: rootTraceId }),
+          github_actions: expect.objectContaining({
+            repository: 'getsentry/warden',
+            event: 'schedule',
+            run_id: '12345',
+          }),
+        }),
+        tags: expect.objectContaining({
+          repository: 'getsentry/warden',
+          'github.event.name': 'schedule',
+          'cicd.pipeline.run.id': '12345',
+          'warden.error.code': 'unknown',
+          'warden.action.stage': 'input',
+        }),
+      })
+    );
+  });
+
+  it('records expected environment failures without creating an issue', async () => {
+    delete process.env['GITHUB_WORKSPACE'];
+    const emit = spyOnClientEmit();
+
+    await expect(runAction()).rejects.toThrow(
+      'This action must be run in a GitHub Actions environment'
+    );
+    await Sentry.flush(1000);
+
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.action.runs',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.action.outcome': 'failure',
+          'warden.action.stage': 'environment',
+          'warden.error.code': 'unknown',
+        }),
+      })
+    );
+    expect(capturedEvents).toEqual([]);
+    expect(capturedTransactions).toContainEqual(
+      expect.objectContaining({
+        transaction: 'run Warden action',
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            op: 'cicd.workflow',
+            status: 'internal_error',
+            data: expect.objectContaining({
+              'warden.action.outcome': 'failure',
+              'warden.action.stage': 'environment',
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  it('records classified dispatch failures on the span, metric, and issue', async () => {
+    const error = new Error('Provider is unavailable');
+    const emit = spyOnClientEmit();
+    mocks.runScheduleWorkflow.mockRejectedValueOnce(error);
+    mocks.classifyError.mockReturnValueOnce({
+      code: 'provider_unavailable',
+      message: 'Provider is unavailable',
+    });
+
+    await expect(runAction()).rejects.toBe(error);
+    await Sentry.flush(1000);
+
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.action.runs',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.action.outcome': 'failure',
+          'warden.action.stage': 'dispatch',
+          'warden.error.code': 'provider_unavailable',
+        }),
+      })
+    );
+    expect(capturedTransactions).toContainEqual(
+      expect.objectContaining({
+        transaction: 'run Warden action',
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            op: 'cicd.workflow',
+            status: 'internal_error',
+            data: expect.objectContaining({
+              'warden.action.outcome': 'failure',
+              'warden.action.stage': 'dispatch',
+              'warden.error.code': 'provider_unavailable',
+            }),
+          }),
+        }),
+      })
+    );
+    expect(capturedEvents).toContainEqual(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          'warden.error.code': 'provider_unavailable',
+          'warden.action.stage': 'dispatch',
+        }),
+      })
     );
   });
 });

--- a/packages/warden/src/action/runner.ts
+++ b/packages/warden/src/action/runner.ts
@@ -6,9 +6,11 @@
  */
 
 import { Octokit } from '@octokit/rest';
-import { setGitHubActionScope, setRepositoryScope } from '../sentry.js';
+import { SPAN_STATUS_ERROR, SPAN_STATUS_OK } from '@sentry/core';
+import { classifyError } from '../sdk/errors.js';
+import { emitActionRunMetric, setGitHubActionScope, Sentry } from '../sentry.js';
 import { parseActionInputs, setupAuthEnv, validateInputs } from './inputs.js';
-import { setFailed } from './workflow/base.js';
+import { ActionFailedError, setFailed } from './workflow/base.js';
 import { runPRWorkflow } from './workflow/pr-workflow.js';
 import { runScheduleWorkflow } from './workflow/schedule.js';
 
@@ -18,34 +20,64 @@ function isPullRequestEvent(eventName: string): boolean {
 
 /** Run the GitHub Action dispatcher once. */
 export async function runAction(): Promise<void> {
-  const inputs = parseActionInputs();
-  validateInputs(inputs);
-
   const eventName = process.env['GITHUB_EVENT_NAME'];
-  const eventPath = process.env['GITHUB_EVENT_PATH'];
-  const repoPath = process.env['GITHUB_WORKSPACE'];
+  const actionAttributes = setGitHubActionScope(eventName);
 
-  if (!eventName || !eventPath || !repoPath) {
-    setFailed('This action must be run in a GitHub Actions environment');
-  }
+  return Sentry.startSpan(
+    { op: 'cicd.workflow', name: 'run Warden action', attributes: actionAttributes },
+    async (span) => {
+      // Advance this before each phase so failures retain their startup stage.
+      let stage: 'input' | 'environment' | 'dispatch' = 'input';
+      try {
+        const inputs = parseActionInputs();
+        validateInputs(inputs);
 
-  setGitHubActionScope(eventName);
-  setRepositoryScope(process.env['GITHUB_REPOSITORY']);
+        stage = 'environment';
+        const eventPath = process.env['GITHUB_EVENT_PATH'];
+        const repoPath = process.env['GITHUB_WORKSPACE'];
 
-  setupAuthEnv(inputs);
+        if (!eventName || !eventPath || !repoPath) {
+          setFailed('This action must be run in a GitHub Actions environment');
+        }
 
-  const octokit = new Octokit({ auth: inputs.githubToken });
+        setupAuthEnv(inputs);
+        const octokit = new Octokit({ auth: inputs.githubToken });
 
-  if (eventName === 'schedule' || eventName === 'workflow_dispatch') {
-    if (inputs.mode !== 'run') {
-      setFailed(`${inputs.mode} mode is only supported for pull request workflows`);
+        stage = 'dispatch';
+        if (eventName === 'schedule' || eventName === 'workflow_dispatch') {
+          if (inputs.mode !== 'run') {
+            setFailed(`${inputs.mode} mode is only supported for pull request workflows`);
+          }
+          await runScheduleWorkflow(octokit, inputs, repoPath);
+        } else {
+          if (inputs.mode !== 'run' && !isPullRequestEvent(eventName)) {
+            setFailed(`${inputs.mode} mode is only supported for pull request workflows`);
+          }
+          await runPRWorkflow(octokit, inputs, eventName, eventPath, repoPath);
+        }
+
+        span.setAttribute('warden.action.outcome', 'success');
+        span.setStatus({ code: SPAN_STATUS_OK });
+        emitActionRunMetric('success', stage);
+      } catch (error) {
+        const { code } = classifyError(error);
+        span.setAttribute('warden.action.outcome', 'failure');
+        span.setAttribute('warden.action.stage', stage);
+        span.setAttribute('warden.error.code', code);
+        span.setStatus({ code: SPAN_STATUS_ERROR, message: code });
+        emitActionRunMetric('failure', stage, code);
+
+        // Expected action failures are outcomes, not Sentry Issues.
+        if (!(error instanceof ActionFailedError)) {
+          Sentry.captureException(error, {
+            tags: {
+              'warden.error.code': code,
+              'warden.action.stage': stage,
+            },
+          });
+        }
+        throw error;
+      }
     }
-    return runScheduleWorkflow(octokit, inputs, repoPath);
-  }
-
-  if (inputs.mode !== 'run' && !isPullRequestEvent(eventName)) {
-    setFailed(`${inputs.mode} mode is only supported for pull request workflows`);
-  }
-
-  return runPRWorkflow(octokit, inputs, eventName, eventPath, repoPath);
+  );
 }

--- a/packages/warden/src/action/triggers/executor.test.ts
+++ b/packages/warden/src/action/triggers/executor.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Octokit } from '@octokit/rest';
+import type { ErrorEvent } from '@sentry/core';
 import {
   executeTrigger,
   type TriggerCheckCompleteOptions,
@@ -8,26 +9,7 @@ import {
 import type { ResolvedTrigger } from '../../config/loader.js';
 import type { EventContext, SkillReport } from '../../types/index.js';
 import type { RenderResult } from '../../output/types.js';
-
-const sentryMocks = vi.hoisted(() => ({
-  captureException: vi.fn(),
-  startSpan: vi.fn((_ctx: unknown, callback: (span: { setAttribute: (key: string, value: unknown) => void }) => unknown) =>
-    callback({ setAttribute: vi.fn() })
-  ),
-}));
-
-vi.mock('../../sentry.js', async (importOriginal) => {
-  const actual: Record<string, unknown> = await importOriginal();
-  const actualSentry = actual['Sentry'] as Record<string, unknown>;
-  return {
-    ...actual,
-    Sentry: {
-      ...actualSentry,
-      captureException: sentryMocks.captureException,
-      startSpan: sentryMocks.startSpan,
-    },
-  };
-});
+import { initSentry, Sentry } from '../../sentry.js';
 
 // Mock dependencies
 vi.mock('../../skills/loader.js', () => ({
@@ -58,12 +40,37 @@ import { renderSkillReport } from '../../output/renderer.js';
 import { resolveSkillAsync } from '../../skills/loader.js';
 import { InvalidPiModelSelectorError } from '../../sdk/runtimes/model-selectors.js';
 
+const capturedEvents: ErrorEvent[] = [];
+
 describe('executeTrigger', () => {
+  beforeAll(() => {
+    process.env['WARDEN_SENTRY_DSN'] = 'https://public@example.com/1';
+    initSentry('action', {
+      transport: () => ({
+        send: async () => ({}),
+        flush: async () => true,
+      }),
+      beforeSend: (event) => {
+        capturedEvents.push(event);
+        return event;
+      },
+    });
+  });
+
   // Suppress console output during tests
   beforeEach(() => {
+    vi.restoreAllMocks();
+    capturedEvents.length = 0;
+    Sentry.getGlobalScope().clear();
+    Sentry.getIsolationScope().clear();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    delete process.env['WARDEN_SENTRY_DSN'];
+    await Sentry.close(0);
   });
 
   const mockOctokit = {} as Octokit;
@@ -309,6 +316,7 @@ describe('executeTrigger', () => {
       runtime: 'pi',
       model: 'claude-sonnet-4-5',
     }, mockDeps);
+    await Sentry.flush(1000);
 
     expect(runSkillTask).not.toHaveBeenCalled();
     expect(result.triggerName).toBe('test-trigger');
@@ -322,8 +330,7 @@ describe('executeTrigger', () => {
       }),
       { owner: 'test-owner', repo: 'test-repo', headSha: 'abc123' }
     );
-    expect(sentryMocks.captureException).toHaveBeenCalledWith(
-      expect.any(InvalidPiModelSelectorError),
+    expect(capturedEvents).toContainEqual(
       expect.objectContaining({
         tags: expect.objectContaining({
           'warden.error.code': 'invalid_model_selector',

--- a/packages/warden/src/cli/main-cwd.test.ts
+++ b/packages/warden/src/cli/main-cwd.test.ts
@@ -6,19 +6,6 @@ import { cleanupArtifacts } from './log-cleanup.js';
 import { runBuild } from './commands/build.js';
 import { main } from './main.js';
 
-vi.mock('../sentry.js', () => ({
-  Sentry: {
-    startSpan: vi.fn(async (_span, callback: (span: { setAttribute: (key: string, value: string) => void }) => unknown) => {
-      return callback({ setAttribute: () => undefined });
-    }),
-  },
-  flushSentry: vi.fn(async () => undefined),
-  setRepositoryScope: vi.fn(),
-  emitRunMetric: vi.fn(),
-  getTraceId: vi.fn(() => undefined),
-  initSentry: vi.fn(),
-}));
-
 vi.mock('./commands/build.js', () => ({
   runBuild: vi.fn(async () => 0),
 }));
@@ -34,9 +21,11 @@ describe('main --cwd', () => {
   const originalArgv = process.argv.slice();
   const originalCwd = process.cwd();
   const originalExit = process.exit;
+  const originalSentryDsn = process.env['WARDEN_SENTRY_DSN'];
   let tempDir: string;
 
   beforeEach(() => {
+    delete process.env['WARDEN_SENTRY_DSN'];
     tempDir = mkdtempSync(join(tmpdir(), 'warden-main-cwd-'));
     process.exit = vi.fn() as never;
     runBuildMock.mockReset();
@@ -49,6 +38,11 @@ describe('main --cwd', () => {
     process.argv = originalArgv.slice();
     process.chdir(originalCwd);
     process.exit = originalExit;
+    if (originalSentryDsn === undefined) {
+      delete process.env['WARDEN_SENTRY_DSN'];
+    } else {
+      process.env['WARDEN_SENTRY_DSN'] = originalSentryDsn;
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/packages/warden/src/sentry.test.ts
+++ b/packages/warden/src/sentry.test.ts
@@ -1,40 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-const sentryMocks = vi.hoisted(() => {
-  const setAttributes = vi.fn();
-
-  return {
-    init: vi.fn(),
-    setTag: vi.fn(),
-    getGlobalScope: vi.fn(() => ({ setAttributes })),
-    consoleLoggingIntegration: vi.fn(() => ({ name: 'console' })),
-    anthropicAIIntegration: vi.fn(() => ({ name: 'anthropic' })),
-    httpIntegration: vi.fn(() => ({ name: 'http' })),
-    metrics: {
-      count: vi.fn(),
-      distribution: vi.fn(),
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      fmt: (strings: TemplateStringsArray, ...values: unknown[]) =>
-        strings.reduce((message, chunk, index) => `${message}${String(values[index - 1] ?? '')}${chunk}`),
-    },
-    getActiveSpan: vi.fn(),
-    flush: vi.fn(async () => true),
-    setAttributes,
-  };
-});
-
-vi.mock('@sentry/node', () => sentryMocks);
-
-async function loadInitializedSentry() {
-  vi.resetModules();
-  const sentry = await import('./sentry.js');
-  sentry.initSentry('action');
-  return sentry;
-}
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emitActionRunMetric,
+  emitFixEvalVerdictMetric,
+  emitSkillMetrics,
+  initSentry,
+  setGitHubActionScope,
+  setRepositoryScope,
+  Sentry,
+} from './sentry.js';
 
 function clearTelemetryEnv(): void {
   delete process.env['WARDEN_SENTRY_DSN'];
@@ -43,35 +16,86 @@ function clearTelemetryEnv(): void {
   delete process.env['GITHUB_SERVER_URL'];
   delete process.env['GITHUB_WORKFLOW'];
   delete process.env['GITHUB_JOB'];
+  delete process.env['GITHUB_RUN_ATTEMPT'];
+  delete process.env['GITHUB_REF'];
+  delete process.env['GITHUB_SHA'];
+}
+
+function spyOnClientEmit() {
+  const client = Sentry.getClient();
+  if (!client) throw new Error('Sentry test client was not initialized');
+  return vi.spyOn(client, 'emit');
 }
 
 describe('sentry telemetry scope', () => {
+  beforeAll(() => {
+    process.env['WARDEN_SENTRY_DSN'] = 'https://public@example.com/1';
+    initSentry('action', {
+      transport: () => ({
+        send: async () => ({}),
+        flush: async () => true,
+      }),
+    });
+  });
+
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     clearTelemetryEnv();
     process.env['WARDEN_SENTRY_DSN'] = 'https://public@example.com/1';
+    Sentry.getGlobalScope().clear();
+    Sentry.getIsolationScope().clear();
   });
 
   afterEach(() => {
     clearTelemetryEnv();
   });
 
+  afterAll(async () => {
+    await Sentry.close(0);
+  });
+
   it('uses the GitHub Actions server URL for repository and run URLs', async () => {
     process.env['GITHUB_SERVER_URL'] = 'https://github.enterprise.example/';
     process.env['GITHUB_REPOSITORY'] = 'acme/widget';
     process.env['GITHUB_RUN_ID'] = '12345';
+    process.env['GITHUB_RUN_ATTEMPT'] = '2';
+    process.env['GITHUB_REF'] = 'refs/pull/42/merge';
+    process.env['GITHUB_SHA'] = 'abc123';
+    process.env['GITHUB_WORKFLOW'] = 'Warden';
+    process.env['GITHUB_JOB'] = 'review';
 
-    const sentry = await loadInitializedSentry();
+    const setAttributes = vi.spyOn(Sentry.getGlobalScope(), 'setAttributes');
+    const isolationScope = Sentry.getIsolationScope();
+    const setTag = vi.spyOn(isolationScope, 'setTag');
+    const setContext = vi.spyOn(isolationScope, 'setContext');
 
-    sentry.setRepositoryScope('acme/widget');
-    sentry.setGitHubActionScope('pull_request');
+    const actionAttributes = setGitHubActionScope('pull_request');
 
-    expect(sentryMocks.setAttributes).toHaveBeenCalledWith(
+    expect(setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
         'vcs.repository.url.full': 'https://github.enterprise.example/acme/widget',
       })
     );
-    expect(sentryMocks.setAttributes).toHaveBeenCalledWith(
+    expect(actionAttributes).toEqual(expect.objectContaining({
+      'vcs.owner.name': 'acme',
+      'vcs.repository.name': 'widget',
+      'github.event.name': 'pull_request',
+      'cicd.pipeline.run.id': '12345',
+    }));
+    expect(setTag).toHaveBeenCalledWith('repository', 'acme/widget');
+    expect(setTag).toHaveBeenCalledWith('cicd.pipeline.run.id', '12345');
+    expect(setContext).toHaveBeenCalledWith('github_actions', {
+      repository: 'acme/widget',
+      event: 'pull_request',
+      workflow: 'Warden',
+      job: 'review',
+      run_id: '12345',
+      run_attempt: '2',
+      run_url: 'https://github.enterprise.example/acme/widget/actions/runs/12345',
+      ref: 'refs/pull/42/merge',
+      sha: 'abc123',
+    });
+    expect(setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
         'github.event.name': 'pull_request',
         'cicd.pipeline.run.url.full':
@@ -84,17 +108,17 @@ describe('sentry telemetry scope', () => {
     process.env['GITHUB_REPOSITORY'] = 'getsentry/warden';
     process.env['GITHUB_RUN_ID'] = '67890';
 
-    const sentry = await loadInitializedSentry();
+    const setAttributes = vi.spyOn(Sentry.getGlobalScope(), 'setAttributes');
 
-    sentry.setRepositoryScope('getsentry/warden');
-    sentry.setGitHubActionScope('push');
+    setRepositoryScope('getsentry/warden');
+    setGitHubActionScope('push');
 
-    expect(sentryMocks.setAttributes).toHaveBeenCalledWith(
+    expect(setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
         'vcs.repository.url.full': 'https://github.com/getsentry/warden',
       })
     );
-    expect(sentryMocks.setAttributes).toHaveBeenCalledWith(
+    expect(setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
         'cicd.pipeline.run.url.full': 'https://github.com/getsentry/warden/actions/runs/67890',
       })
@@ -102,23 +126,49 @@ describe('sentry telemetry scope', () => {
   });
 
   it('emits fix evaluation verdict metrics with fallback attribution', async () => {
-    const sentry = await loadInitializedSentry();
+    const emit = spyOnClientEmit();
 
-    sentry.emitFixEvalVerdictMetric('eval_error', 'security-review', { usedFallback: true });
+    emitFixEvalVerdictMetric('eval_error', 'security-review', { usedFallback: true });
 
-    expect(sentryMocks.metrics.count).toHaveBeenCalledWith('warden.fix_eval.verdict', 1, {
-      attributes: {
-        'warden.fix_eval.verdict': 'eval_error',
-        'warden.fix_eval.used_fallback': true,
-        'gen_ai.agent.name': 'security-review',
-      },
-    });
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.fix_eval.verdict',
+        type: 'counter',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.fix_eval.verdict': 'eval_error',
+          'warden.fix_eval.used_fallback': true,
+          'gen_ai.agent.name': 'security-review',
+        }),
+      })
+    );
+  });
+
+  it('emits action failures with startup stage and stable error code', async () => {
+    const emit = spyOnClientEmit();
+
+    emitActionRunMetric('failure', 'input', 'auth_failed');
+
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.action.runs',
+        type: 'counter',
+        value: 1,
+        attributes: expect.objectContaining({
+          'warden.action.outcome': 'failure',
+          'warden.action.stage': 'input',
+          'warden.error.code': 'auth_failed',
+        }),
+      })
+    );
   });
 
   it('emits GenAI token metrics with runtime-derived provider attribution', async () => {
-    const sentry = await loadInitializedSentry();
+    const emit = spyOnClientEmit();
 
-    sentry.emitSkillMetrics({
+    emitSkillMetrics({
       skill: 'security-review',
       summary: 'No findings',
       findings: [],
@@ -137,22 +187,28 @@ describe('sentry telemetry scope', () => {
       },
     });
 
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('gen_ai.client.token.usage', 10, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'gen_ai.operation.name': 'invoke_agent',
-        'gen_ai.provider.name': 'x_ai',
-        'gen_ai.request.model': 'xai/grok-test',
-        'gen_ai.token.type': 'input',
-        'warden.runtime.name': 'pi',
-      }),
-    });
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'gen_ai.client.token.usage',
+        type: 'distribution',
+        value: 10,
+        unit: '{token}',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.provider.name': 'x_ai',
+          'gen_ai.request.model': 'xai/grok-test',
+          'gen_ai.token.type': 'input',
+          'warden.runtime.name': 'pi',
+        }),
+      })
+    );
   });
 
   it('emits Warden token and cost components for cached-token accounting', async () => {
-    const sentry = await loadInitializedSentry();
+    const emit = spyOnClientEmit();
 
-    sentry.emitSkillMetrics({
+    emitSkillMetrics({
       skill: 'security-review',
       summary: 'No findings',
       findings: [],
@@ -171,67 +227,94 @@ describe('sentry telemetry scope', () => {
       },
     });
 
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('gen_ai.client.token.usage', 1500, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'gen_ai.token.type': 'input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 1000, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'warden.gen_ai.token.category': 'standard_input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 200, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'warden.gen_ai.token.category': 'cache_read_input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 100, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'warden.gen_ai.token.category': 'cache_creation_5m_input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.token.usage', 200, {
-      unit: '{token}',
-      attributes: expect.objectContaining({
-        'warden.gen_ai.token.category': 'cache_creation_1h_input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith('warden.gen_ai.cost.component.usd', 0.00002, {
-      attributes: expect.objectContaining({
-        'warden.gen_ai.cost.component': 'cache_read_input',
-      }),
-    });
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith(
-      'warden.gen_ai.cost.component.usd',
-      expect.closeTo(0.000125, 10),
-      {
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'gen_ai.client.token.usage',
+        value: 1500,
+        unit: '{token}',
+        attributes: expect.objectContaining({ 'gen_ai.token.type': 'input' }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.token.usage',
+        value: 1000,
+        attributes: expect.objectContaining({
+          'warden.gen_ai.token.category': 'standard_input',
+        }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.token.usage',
+        value: 200,
+        attributes: expect.objectContaining({
+          'warden.gen_ai.token.category': 'cache_read_input',
+        }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.token.usage',
+        value: 100,
+        attributes: expect.objectContaining({
+          'warden.gen_ai.token.category': 'cache_creation_5m_input',
+        }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.token.usage',
+        value: 200,
+        attributes: expect.objectContaining({
+          'warden.gen_ai.token.category': 'cache_creation_1h_input',
+        }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.cost.component.usd',
+        value: 0.00002,
+        attributes: expect.objectContaining({
+          'warden.gen_ai.cost.component': 'cache_read_input',
+        }),
+      })
+    );
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.cost.component.usd',
+        value: expect.closeTo(0.000125, 10),
         attributes: expect.objectContaining({
           'warden.gen_ai.cost.component': 'cache_creation_5m_input',
         }),
-      }
+      })
     );
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith(
-      'warden.gen_ai.cost.component.usd',
-      0.0004,
-      {
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.cost.component.usd',
+        value: 0.0004,
         attributes: expect.objectContaining({
           'warden.gen_ai.cost.component': 'cache_creation_1h_input',
         }),
-      }
+      })
     );
-    expect(sentryMocks.metrics.distribution).toHaveBeenCalledWith(
-      'warden.gen_ai.cost.component.usd',
-      0.02,
-      {
+    expect(emit).toHaveBeenCalledWith(
+      'processMetric',
+      expect.objectContaining({
+        name: 'warden.gen_ai.cost.component.usd',
+        value: 0.02,
         attributes: expect.objectContaining({
           'warden.gen_ai.cost.component': 'web_search',
         }),
-      }
+      })
     );
   });
 });

--- a/packages/warden/src/sentry.test.ts
+++ b/packages/warden/src/sentry.test.ts
@@ -240,7 +240,9 @@ describe('sentry telemetry scope', () => {
       'processMetric',
       expect.objectContaining({
         name: 'warden.gen_ai.token.usage',
+        type: 'distribution',
         value: 1000,
+        unit: '{token}',
         attributes: expect.objectContaining({
           'warden.gen_ai.token.category': 'standard_input',
         }),
@@ -250,7 +252,9 @@ describe('sentry telemetry scope', () => {
       'processMetric',
       expect.objectContaining({
         name: 'warden.gen_ai.token.usage',
+        type: 'distribution',
         value: 200,
+        unit: '{token}',
         attributes: expect.objectContaining({
           'warden.gen_ai.token.category': 'cache_read_input',
         }),
@@ -260,7 +264,9 @@ describe('sentry telemetry scope', () => {
       'processMetric',
       expect.objectContaining({
         name: 'warden.gen_ai.token.usage',
+        type: 'distribution',
         value: 100,
+        unit: '{token}',
         attributes: expect.objectContaining({
           'warden.gen_ai.token.category': 'cache_creation_5m_input',
         }),
@@ -270,7 +276,9 @@ describe('sentry telemetry scope', () => {
       'processMetric',
       expect.objectContaining({
         name: 'warden.gen_ai.token.usage',
+        type: 'distribution',
         value: 200,
+        unit: '{token}',
         attributes: expect.objectContaining({
           'warden.gen_ai.token.category': 'cache_creation_1h_input',
         }),

--- a/packages/warden/src/sentry.ts
+++ b/packages/warden/src/sentry.ts
@@ -1,11 +1,17 @@
 import * as Sentry from '@sentry/node';
-import type { Severity, SkillReport } from './types/index.js';
+import type { NodeOptions } from '@sentry/node';
+import type { ErrorCode, Severity, SkillReport } from './types/index.js';
 import { SEVERITY_ORDER } from './types/index.js';
 import { getVersion } from './utils/index.js';
 import { genAiProviderName } from './sdk/otel.js';
 import { estimateUsageCostBreakdown } from './sdk/pricing.js';
 
 export type SentryContext = 'cli' | 'action';
+
+type SentryInitOptions = Pick<
+  NodeOptions,
+  'beforeSend' | 'beforeSendTransaction' | 'transport'
+>;
 
 let initialized = false;
 
@@ -16,7 +22,26 @@ function getGitHubServerUrl(): string {
   return serverUrl.replace(/\/+$/, '');
 }
 
-export function initSentry(context: SentryContext): void {
+function repositoryAttributes(repository: string): TelemetryAttributes {
+  const [owner, name] = repository.split('/');
+  const attrs: TelemetryAttributes = name
+    ? {
+        'vcs.owner.name': owner ?? '',
+        'vcs.repository.name': name,
+      }
+    : {
+        'vcs.repository.name': repository,
+      };
+
+  if (owner && name && owner !== 'local') {
+    attrs['vcs.provider.name'] = 'github';
+    attrs['vcs.repository.url.full'] = `${getGitHubServerUrl()}/${owner}/${name}`;
+  }
+  return attrs;
+}
+
+/** Initialize production telemetry, with optional SDK hooks for local observation. */
+export function initSentry(context: SentryContext, options: SentryInitOptions = {}): void {
   const dsn = process.env['WARDEN_SENTRY_DSN'];
   if (!dsn || initialized) return;
   initialized = true;
@@ -27,6 +52,7 @@ export function initSentry(context: SentryContext): void {
     environment: context === 'action' ? 'github-action' : 'cli',
     tracesSampleRate: 1.0,
     enableLogs: true,
+    ...options,
     integrations: [
       Sentry.consoleLoggingIntegration({ levels: ['warn', 'error'] }),
       Sentry.anthropicAIIntegration({ recordInputs: true, recordOutputs: true }),
@@ -58,7 +84,7 @@ export const { logger } = Sentry;
 
 /**
  * Set attributes on the global Sentry scope.
- * These automatically apply to ALL metrics and spans.
+ * These apply to logs and metrics. Pass them explicitly when starting spans.
  */
 export function setGlobalAttributes(attrs: TelemetryAttributes): void {
   if (!initialized) return;
@@ -74,35 +100,28 @@ export function setGlobalAttributes(attrs: TelemetryAttributes): void {
  */
 export function setRepositoryScope(repository: string | undefined): void {
   if (!repository || !initialized) return;
-  const [owner, name] = repository.split('/');
-  const attrs: TelemetryAttributes = name
-    ? {
-        'vcs.owner.name': owner ?? '',
-        'vcs.repository.name': name,
-      }
-    : {
-        'vcs.repository.name': repository,
-      };
+  const attrs = repositoryAttributes(repository);
 
-  if (owner && name && owner !== 'local') {
-    const serverUrl = getGitHubServerUrl();
-    attrs['vcs.provider.name'] = 'github';
-    attrs['vcs.repository.url.full'] = `${serverUrl}/${owner}/${name}`;
+  try {
+    Sentry.setTag('repository', repository);
+  } catch {
+    // Never break the workflow
   }
 
   setGlobalAttributes(attrs);
 }
 
 /**
- * Set GitHub Actions metadata on the global Sentry scope.
+ * Set GitHub Actions metadata on the global Sentry scope and return the
+ * attributes that must be passed explicitly to the action's root span.
  */
-export function setGitHubActionScope(eventName: string | undefined): void {
-  if (!initialized) return;
-
+export function setGitHubActionScope(eventName: string | undefined): TelemetryAttributes {
   const repository = process.env['GITHUB_REPOSITORY'];
   const runId = process.env['GITHUB_RUN_ID'];
   const serverUrl = getGitHubServerUrl();
   const attrs: TelemetryAttributes = {};
+
+  if (repository) Object.assign(attrs, repositoryAttributes(repository));
 
   if (eventName) {
     attrs['github.event.name'] = eventName;
@@ -120,9 +139,37 @@ export function setGitHubActionScope(eventName: string | undefined): void {
     attrs['cicd.pipeline.task.name'] = process.env['GITHUB_JOB'];
   }
 
-  if (Object.keys(attrs).length > 0) {
-    setGlobalAttributes(attrs);
+  if (!initialized) return attrs;
+
+  setGlobalAttributes(attrs);
+
+  try {
+    if (repository) Sentry.setTag('repository', repository);
+    if (eventName) Sentry.setTag('github.event.name', eventName);
+    if (process.env['GITHUB_WORKFLOW']) {
+      Sentry.setTag('cicd.pipeline.name', process.env['GITHUB_WORKFLOW']);
+    }
+    if (runId) Sentry.setTag('cicd.pipeline.run.id', runId);
+    if (process.env['GITHUB_JOB']) {
+      Sentry.setTag('cicd.pipeline.task.name', process.env['GITHUB_JOB']);
+    }
+
+    Sentry.setContext('github_actions', {
+      repository,
+      event: eventName,
+      workflow: process.env['GITHUB_WORKFLOW'],
+      job: process.env['GITHUB_JOB'],
+      run_id: runId,
+      run_attempt: process.env['GITHUB_RUN_ATTEMPT'],
+      run_url: repository && runId ? `${serverUrl}/${repository}/actions/runs/${runId}` : undefined,
+      ref: process.env['GITHUB_REF'],
+      sha: process.env['GITHUB_SHA'],
+    });
+  } catch {
+    // Never break the workflow
   }
+
+  return attrs;
 }
 
 /**
@@ -239,6 +286,22 @@ function emitCostComponentMetrics(
 export function emitRunMetric(): void {
   safeEmit(() => {
     Sentry.metrics.count('warden.workflow.runs', 1);
+  });
+}
+
+/** Emit the final outcome of a GitHub Action invocation, including startup failures. */
+export function emitActionRunMetric(
+  outcome: 'success' | 'failure',
+  stage: 'input' | 'environment' | 'dispatch',
+  errorCode?: ErrorCode
+): void {
+  safeEmit(() => {
+    const attrs: TelemetryAttributes = {
+      'warden.action.outcome': outcome,
+      'warden.action.stage': stage,
+    };
+    if (errorCode) attrs['warden.error.code'] = errorCode;
+    Sentry.metrics.count('warden.action.runs', 1, { attributes: attrs });
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@sentry/core':
+        specifier: ^10.53.1
+        version: 10.53.1
       '@sentry/dotagents-lib':
         specifier: ^1.17.0
         version: 1.17.0

--- a/specs/telemetry.md
+++ b/specs/telemetry.md
@@ -28,15 +28,17 @@ Observability via Sentry: tracing, error context, and business metrics. All tele
 
 ### Global Attributes
 
-Set via `Sentry.getGlobalScope().setAttributes()`. These propagate automatically to all metrics and spans.
+Set via `Sentry.getGlobalScope().setAttributes()`. These propagate to logs and
+metrics. The GitHub Action root span receives the same attributes explicitly
+because current Sentry scope attributes do not decorate spans.
 
 | Attribute | Set when | Value |
 |-----------|----------|-------|
 | `warden.source` | `initSentry()` | `github-action` or `cli` |
-| `vcs.owner.name` | After context built | repository owner/org (e.g. `getsentry`) |
-| `vcs.repository.name` | After context built | repository name (e.g. `sentry`) |
-| `vcs.provider.name` | After context built for GitHub repos | `github` |
-| `vcs.repository.url.full` | After context built for GitHub repos | canonical repository URL |
+| `vcs.owner.name` | Repository context or Action startup | repository owner/org (e.g. `getsentry`) |
+| `vcs.repository.name` | Repository context or Action startup | repository name (e.g. `sentry`) |
+| `vcs.provider.name` | Repository context or Action startup for GitHub repos | `github` |
+| `vcs.repository.url.full` | Repository context or Action startup for GitHub repos | canonical repository URL |
 | `github.event.name` | GitHub Actions only | Action event name (GitHub-specific; no OTel equivalent) |
 | `cicd.pipeline.name` | GitHub Actions only | GitHub workflow name |
 | `cicd.pipeline.run.id` | GitHub Actions only | GitHub workflow run ID |
@@ -73,31 +75,33 @@ The Anthropic integration records inputs and outputs (`recordInputs: true, recor
 Spans follow [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) where applicable, with Sentry-specific extensions for AI agent visibility.
 
 ```
-workflow.run "review pull_request"
-  workflow.init "initialize workflow"
-  workflow.setup "setup github state"
-  workflow.execute "execute triggers"
-    skill.run "run {skill}"                    ← existing
-      skill.analyze_file "analyze file {path}"
-        skill.analyze_hunk "analyze hunk {path}:{range}"
-          gen_ai.invoke_agent "invoke_agent {skill}"   ← Sentry AI dashboard
-            gen_ai.chat "chat {skill} turn 1"          ← per-turn from SDK stream
-              gen_ai.execute_tool "Read"                ← tool use from SDK stream
-              gen_ai.execute_tool "Grep"
-            gen_ai.chat "chat {skill} turn 2"
-            gen_ai.chat "chat {skill} turn 3"
-              gen_ai.execute_tool "Read"
-  workflow.review "post reviews"
-  workflow.resolve "resolve stale comments"
-    fix_eval.run "evaluate fix attempts"
-      fix_eval.evaluate "evaluate fix {path}:{line}"
-        (auto: anthropic chat spans via integration)
+cicd.workflow "run Warden action"              ← GitHub Action only
+  workflow.run "review pull_request"
+    workflow.init "initialize workflow"
+    workflow.setup "setup github state"
+    workflow.execute "execute triggers"
+      skill.run "run {skill}"                    ← existing
+        skill.analyze_file "analyze file {path}"
+          skill.analyze_hunk "analyze hunk {path}:{range}"
+            gen_ai.invoke_agent "invoke_agent {skill}"   ← Sentry AI dashboard
+              gen_ai.chat "chat {skill} turn 1"          ← per-turn from SDK stream
+                gen_ai.execute_tool "Read"                ← tool use from SDK stream
+                gen_ai.execute_tool "Grep"
+              gen_ai.chat "chat {skill} turn 2"
+              gen_ai.chat "chat {skill} turn 3"
+                gen_ai.execute_tool "Read"
+    workflow.review "post reviews"
+    workflow.resolve "resolve stale comments"
+      fix_eval.run "evaluate fix attempts"
+        fix_eval.evaluate "evaluate fix {path}:{line}"
+          (auto: anthropic chat spans via integration)
 ```
 
 ### Span ops
 
 | `op` | Scope | Notes |
 |------|-------|-------|
+| `cicd.workflow` | Entire GitHub Action invocation | Root span includes failures before workflow initialization |
 | `gen_ai.invoke_agent` | Claude Code SDK subprocess | Required prefix for Sentry AI Agents dashboard |
 | `gen_ai.chat` | Per-turn API call within SDK | Created from `SDKAssistantMessage` stream events; child of `invoke_agent` |
 | `gen_ai.execute_tool` | Tool execution within a turn | Created from `SDKAssistantMessage` tool_use blocks + `SDKToolProgressMessage`; child of `gen_ai.chat` |
@@ -203,6 +207,17 @@ The Claude Code SDK runs as a subprocess via `query()`. It is not an `@anthropic
 
 ## Internal Span Attributes
 
+### `cicd.workflow`
+
+The GitHub Action root span receives the `vcs.*`, `github.event.name`, and
+`cicd.*` attributes listed under **Global Attributes** at creation.
+
+| Attribute | Type | When set |
+|-----------|------|----------|
+| `warden.action.outcome` | string | Completion (`success` or `failure`) |
+| `warden.action.stage` | string | Failure (`input`, `environment`, or `dispatch`) |
+| `warden.error.code` | string | Failure, using the stable `ErrorCode` taxonomy |
+
 ### `workflow.run`
 
 | Attribute | Type | When set |
@@ -276,7 +291,12 @@ Retries add a breadcrumb (`category: 'retry'`) with attempt number, error messag
 
 Non-fatal errors (the workflow continues despite the failure) are still real errors. A GitHub API call that 500s is an error whether or not we can recover from it.
 
-`setFailed()` throws `ActionFailedError`, which propagates out of `Sentry.startSpan()` callbacks so spans end cleanly before the process exits. The top-level catch handler in `packages/warden/src/action/main.ts` distinguishes `ActionFailedError` (expected failure: threshold exceeded, missing env, CLI not found) from unexpected errors. Only unexpected errors call `captureException`. Both paths call `flushSentry()` then `process.exit(1)`.
+`setFailed()` throws `ActionFailedError`, which propagates out of
+`Sentry.startSpan()` callbacks so spans end cleanly before the process exits.
+The dispatcher records expected failures on the root span and action-run metric
+without creating an Issue. Unexpected errors are captured inside the active
+root span. The top-level catch handler in `packages/warden/src/action/run.ts`
+prints the failure, flushes Sentry, and exits.
 
 ### Operation tags
 
@@ -296,7 +316,10 @@ All `captureException` calls include an `operation` tag for filtering in Sentry 
 | `update_core_check` | `finalizeWorkflow` | Updating check run with summary |
 | `fetch_fix_context` | `evaluateFixAttempts` | Fetching code at finding location |
 
-Untagged `captureException` calls exist at top-level catch handlers in `packages/warden/src/cli/index.ts`, `packages/warden/src/action/main.ts`, and `packages/warden/src/action/triggers/executor.ts` (tagged with `warden.trigger.name` and `gen_ai.agent.name` instead).
+Untagged `captureException` calls exist in `packages/warden/src/cli/index.ts`.
+The Action dispatcher tags unexpected startup errors with `warden.error.code`
+and `warden.action.stage`; the trigger executor tags failures with
+`warden.trigger.name` and `gen_ai.agent.name` instead.
 
 ---
 
@@ -313,6 +336,15 @@ All metrics inherit `warden.source`, repository attributes, and GitHub Actions a
 | `warden.workflow.runs` | count | -- (inherits globals) |
 
 Called once per analysis workflow execution (CLI run or GitHub Action workflow).
+
+### Action run count (`emitActionRunMetric`)
+
+| Metric | Type | Per-metric attributes |
+|--------|------|-----------------------|
+| `warden.action.runs` | count | `warden.action.outcome`, `warden.action.stage`, `warden.error.code` (failures only) |
+
+Called once per GitHub Action invocation, including failures during input
+parsing or environment validation before an analysis workflow exists.
 
 ### Skill-level (`emitSkillMetrics`)
 
@@ -418,6 +450,7 @@ Called from `evaluateFixesAndResolveStale` when stale comments are resolved. Emi
 | `packages/warden/src/sdk/analyze.ts` | `executeQuery` (gen AI span), `analyzeFile` / `analyzeHunk` (workflow spans), extraction + retry + dedup metrics |
 | `packages/warden/src/action/fix-evaluation/index.ts` | `evaluateFixAttempts` / per-comment spans, fix eval metrics |
 | `packages/warden/src/action/workflow/base.ts` | `ActionFailedError` sentinel, `setFailed()` |
-| `packages/warden/src/action/main.ts` | Top-level catch handler, Sentry flush, `process.exit` |
+| `packages/warden/src/action/runner.ts` | Action root span, startup outcome metric, unexpected error capture |
+| `packages/warden/src/action/run.ts` | Top-level catch handler, Sentry flush, `process.exit` |
 | `packages/warden/src/action/workflow/pr-workflow.ts` | Error context tags, stale resolution metrics |
 | `packages/warden/src/cli/output/tasks.ts` | Dedup metrics (CLI code path) |


### PR DESCRIPTION
GitHub Action failures now attach repository and workflow identity before input
parsing, so startup errors can be traced to the originating repository and run.
A `cicd.workflow` root transaction and `warden.action.runs` counter record the
outcome, failure stage, and stable error code. Expected action failures remain
out of Issues, while unexpected errors stay linked to the root trace.

Telemetry tests now exercise the real Sentry SDK with a no-network transport
and SDK observation hooks. This removes every Sentry module mock and covers
disabled telemetry, processed Issue context, transaction status, and trace
linkage. The telemetry runbook now starts repository investigations at the
Action root before pivoting to child workflow spans.

`@sentry/core` is a direct dependency only for the SDK's `SPAN_STATUS_*`
constants, kept at the same version as `@sentry/node`.
