### PR TITLE
fix(ci): Use configured Warden model

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -2,7 +2,6 @@ version = 1
 
 [defaults]
 runtime = "pi"
-model = "anthropic/claude-sonnet-4-6"
 # Fail check on high+ severity findings (critical, high)
 failOn = "high"
 # Show annotations for medium+ severity findings


### PR DESCRIPTION
Warden now uses the workflow's `WARDEN_MODEL` value instead of forcing the removed Anthropic provider configuration. This lets the existing OpenRouter model selection and API key control pull request reviews.
