### PR TITLE
fix(reporting): resolve SkillReport.model from the actual API response

### DIFF
--- a/packages/warden/src/cli/output/tasks.test.ts
+++ b/packages/warden/src/cli/output/tasks.test.ts
@@ -1287,6 +1287,88 @@ describe('runSkillTask model lanes', () => {
     );
     expect(result.report?.runtime).toBe('pi');
   });
+
+  it('reports the model that actually answered when no model override is configured', async () => {
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+    const finding = makeFinding();
+
+    vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+      responseModels: ['claude-sonnet-4-5-20260929'],
+    } satisfies FileAnalysisResult);
+    vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
+      findings: [finding],
+      auxiliaryUsage: [],
+    });
+
+    const result = await runSkillTask({
+      name: 'lane-skill',
+      resolveSkill: async () =>
+        ({ name: 'lane-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+      runnerOptions: {
+        runtime: 'pi',
+      },
+    }, 1, noopCallbacks());
+
+    expect(result.report?.model).toBe('claude-sonnet-4-5-20260929');
+  });
+
+  it('reports the observed model on the error path when post-processing throws after hunks succeed', async () => {
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+    const finding = makeFinding();
+
+    vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+      responseModels: ['claude-sonnet-4-5-20260929'],
+    } satisfies FileAnalysisResult);
+    vi.spyOn(sdkRunner, 'postProcessFindings').mockRejectedValue(new Error('verification blew up'));
+
+    const result = await runSkillTask({
+      name: 'lane-skill',
+      resolveSkill: async () =>
+        ({ name: 'lane-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+      runnerOptions: {
+        runtime: 'pi',
+      },
+    }, 1, noopCallbacks());
+
+    expect(result.report?.error).toBeDefined();
+    expect(result.report?.model).toBe('claude-sonnet-4-5-20260929');
+  });
 });
 
 describe('runSkillTask error capture', () => {

--- a/packages/warden/src/cli/output/tasks.ts
+++ b/packages/warden/src/cli/output/tasks.ts
@@ -14,6 +14,7 @@ import {
   analyzeFile,
   aggregateUsage,
   aggregateAuxiliaryUsage,
+  resolveResponseModel,
   postProcessFindings,
   generateSummary,
   type AuxiliaryUsageEntry,
@@ -47,6 +48,7 @@ interface FileProcessResult {
   hunkFailures: HunkFailure[];
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   traces?: HunkTrace[];
+  responseModels?: string[];
 }
 
 function allAnalysisFailuresHaveCode(
@@ -272,6 +274,7 @@ export async function runSkillTask(
       // report.skill when resolveSkill succeeded but a later step threw.
       // Stays undefined only if resolveSkill itself failed.
       let resolvedSkillName: string | undefined;
+      let resolvedModel: string | undefined;
 
       try {
         let skill: SkillDefinition;
@@ -467,6 +470,7 @@ export async function runSkillTask(
             hunkFailures: result.hunkFailures,
             auxiliaryUsage: result.auxiliaryUsage,
             traces: result.traces,
+            responseModels: result.responseModels,
           };
         };
 
@@ -517,6 +521,8 @@ export async function runSkillTask(
         const allUsage = allResults.map((r) => r.usage).filter((u): u is UsageStats => u !== undefined);
         const allAuxEntries = allResults.flatMap((r) => r.auxiliaryUsage ?? []);
         const allTraces = allResults.flatMap((r) => r.traces ?? []);
+        const allResponseModels = allResults.flatMap((r) => r.responseModels ?? []);
+        resolvedModel = resolveResponseModel(allResponseModels, runnerOptions?.model);
         const totalFailedHunks = allResults.reduce((sum, r) => sum + r.failedHunks, 0);
         const totalFailedExtractions = allResults.reduce((sum, r) => sum + r.failedExtractions, 0);
         const allHunkFailures: HunkFailure[] = allResults.flatMap((r) => r.hunkFailures);
@@ -554,7 +560,7 @@ export async function runSkillTask(
             findings: [],
             usage: aggregateUsage(allUsage),
             durationMs: duration,
-            model: runnerOptions?.model,
+            model: resolvedModel,
             runtime,
             // Preserve per-file metadata (timing, partial usage, attempted
             // filenames) on failure runs too — `warden runs` and JSONL
@@ -627,7 +633,7 @@ export async function runSkillTask(
           findings: finalFindings,
           usage: aggregateUsage(allUsage),
           durationMs: duration,
-          model: runnerOptions?.model,
+          model: resolvedModel,
           runtime,
           files: buildFileReports(
             preparedFiles.map((file, i) => {
@@ -692,7 +698,7 @@ export async function runSkillTask(
           summary: `${skillName}: failed (${code})`,
           findings: [],
           durationMs: Date.now() - startTime,
-          model: runnerOptions?.model,
+          model: resolvedModel ?? runnerOptions?.model,
           runtime,
           error: { code, message, timestamp: new Date().toISOString() },
         };

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -374,6 +374,53 @@ describe('analyzeFile', () => {
     consoleSpy.mockRestore();
   });
 
+  it('preserves the response model when the circuit opens on an SDK-reported provider error', async () => {
+    const controller = new AbortController();
+    const circuitBreaker = new ProviderFailureCircuitBreaker({
+      maxConsecutiveProviderFailures: 1,
+      abortController: controller,
+    });
+    const runSkillMock = vi.fn().mockResolvedValue({
+      result: {
+        status: 'provider_error',
+        text: '',
+        errors: ['upstream provider error'],
+        usage: makeUsage(),
+        responseModel: 'claude-sonnet-4-5-20260929',
+      },
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const result = await analyzeFile(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makePreparedFile(1),
+      '/tmp/repo',
+      {
+        abortController: controller,
+        circuitBreaker,
+        retry: {
+          maxRetries: 0,
+          initialDelayMs: 1,
+          backoffMultiplier: 1,
+          maxDelayMs: 1,
+        },
+      },
+    );
+
+    expect(circuitBreaker.reason?.code).toBe('provider_unavailable');
+    expect(result.failedHunks).toBe(1);
+    expect(result.responseModels).toEqual(['claude-sonnet-4-5-20260929']);
+  });
+
   it('opens the shared circuit after consecutive provider failures', async () => {
     const controller = new AbortController();
     const circuitBreaker = new ProviderFailureCircuitBreaker({
@@ -720,6 +767,116 @@ describe('runSkill', () => {
 
     expect(report.summary).toBe('No code changes to analyze');
     expect(report.runtime).toBe('pi');
+  });
+
+  it('reports the model that actually answered when no model override is configured', async () => {
+    const runSkillMock = vi.fn().mockResolvedValue({
+      result: {
+        status: 'success',
+        text: JSON.stringify({ findings: [] }),
+        errors: [],
+        usage: makeUsage(),
+        responseModel: 'claude-sonnet-4-5-20260929',
+      },
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const report = await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makeContextWithOneHunk(),
+      {},
+    );
+
+    expect(report.model).toBe('claude-sonnet-4-5-20260929');
+  });
+
+  it('falls back to the configured model when hunks report different response models', async () => {
+    const runSkillMock = vi.fn()
+      .mockResolvedValueOnce({
+        result: {
+          status: 'success',
+          text: JSON.stringify({ findings: [] }),
+          errors: [],
+          usage: makeUsage(),
+          responseModel: 'claude-sonnet-4-5-20260929',
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          status: 'success',
+          text: JSON.stringify({ findings: [] }),
+          errors: [],
+          usage: makeUsage(),
+          responseModel: 'claude-opus-4-8-20260601',
+        },
+      });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const report = await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makeContextWithTwoHunks(),
+      { model: 'configured-alias' },
+    );
+
+    expect(report.model).toBe('configured-alias');
+  });
+
+  it('attributes each skill its own response model when multiple skills run concurrently', async () => {
+    const modelBySkill: Record<string, string> = {
+      'skill-a': 'model-a',
+      'skill-b': 'model-b',
+      'skill-c': 'model-c',
+    };
+    const runSkillMock = vi.fn(async ({ skillName }: { skillName: string }) => ({
+      result: {
+        status: 'success',
+        text: JSON.stringify({ findings: [] }),
+        errors: [],
+        usage: makeUsage(),
+        responseModel: modelBySkill[skillName],
+      },
+    }));
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const [reportA, reportB, reportC] = await Promise.all(
+      Object.keys(modelBySkill).map((skillName) =>
+        runSkill(
+          { name: skillName, description: `${skillName} description.`, prompt: 'Return findings as JSON.' },
+          makeContextWithOneHunk(),
+          {},
+        )
+      )
+    );
+
+    expect(reportA!.skill).toBe('skill-a');
+    expect(reportA!.model).toBe('model-a');
+    expect(reportB!.skill).toBe('skill-b');
+    expect(reportB!.model).toBe('model-b');
+    expect(reportC!.skill).toBe('skill-c');
+    expect(reportC!.model).toBe('model-c');
   });
 
   it('preserves candidate findings when verification is interrupted', async () => {

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -6,7 +6,7 @@ import { Sentry, emitExtractionMetrics, emitRetryMetric, emitSkillMetrics, ensur
 import { SkillRunnerError, WardenAuthenticationError, isRetryableError, isAuthenticationError, isAuthenticationErrorMessage, isSubprocessError, classifyError, mapExtractionErrorCode, sanitizeErrorMessage } from './errors.js';
 import type { CircuitBreakerReason } from './circuit-breaker.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
-import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage, aggregateAuxiliaryUsageAttribution } from './usage.js';
+import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage, aggregateAuxiliaryUsageAttribution, resolveResponseModel } from './usage.js';
 import { buildHunkSystemPrompt, buildHunkUserPrompt, type PRPromptContext } from './prompt.js';
 import { extractFindingsJson, extractFindingsWithLLM, validateFindings } from './extract.js';
 import { postProcessFindings } from './post-process.js';
@@ -71,6 +71,7 @@ function hunkFailureFromCircuit(
   usage: UsageStats[],
   attempts: number,
   trace?: HunkTrace,
+  responseModel?: string,
 ): HunkAnalysisResult {
   return {
     findings: [],
@@ -81,6 +82,7 @@ function hunkFailureFromCircuit(
     failureMessage: reason.message,
     attempts,
     trace,
+    responseModel,
   };
 }
 
@@ -473,6 +475,7 @@ async function analyzeHunk(
                   result: resultMessage,
                   traceRecorder,
                 }),
+                resultMessage.responseModel,
               );
             }
             return {
@@ -483,6 +486,7 @@ async function analyzeHunk(
               failureCode,
               failureMessage,
               attempts: attempt + 1,
+              responseModel: resultMessage.responseModel,
               trace: buildHunkTrace({
                 enabled: options.captureTraces,
                 span,
@@ -557,6 +561,7 @@ async function analyzeHunk(
                   runtime: runtimeName,
                 }]
               : undefined,
+            responseModel: resultMessage.responseModel,
             trace: buildHunkTrace({
               enabled: options.captureTraces,
               span,
@@ -784,6 +789,7 @@ export async function analyzeFile(
       const fileAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
       const hunkFailures: HunkFailure[] = [];
       const hunkTraces: HunkTrace[] = [];
+      const fileResponseModels: string[] = [];
       let failedHunks = 0;
       let failedExtractions = 0;
 
@@ -841,6 +847,9 @@ export async function analyzeFile(
         if (result.trace) {
           hunkTraces.push(result.trace);
         }
+        if (result.responseModel) {
+          fileResponseModels.push(result.responseModel);
+        }
         const chunkResult: ChunkAnalysisResult = {
           filename: file.filename,
           model: options.model,
@@ -881,6 +890,7 @@ export async function analyzeFile(
         hunkFailures,
         auxiliaryUsage: fileAuxiliaryUsage.length > 0 ? fileAuxiliaryUsage : undefined,
         traces: hunkTraces.length > 0 ? hunkTraces : undefined,
+        responseModels: fileResponseModels.length > 0 ? fileResponseModels : undefined,
       };
     },
   );
@@ -982,6 +992,7 @@ async function runSkillAnalysis(
   const allUsage: UsageStats[] = [];
   const allAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
   const allTraces: HunkTrace[] = [];
+  const allResponseModels: string[] = [];
 
   // Track failed hunks across all files
   let totalFailedHunks = 0;
@@ -1111,6 +1122,9 @@ async function runSkillAnalysis(
     if (fr.result.traces) {
       allTraces.push(...fr.result.traces);
     }
+    if (fr.result.responseModels) {
+      allResponseModels.push(...fr.result.responseModels);
+    }
   }
 
   // All hunks failed — typically a systemic problem (auth, subprocess, etc).
@@ -1186,7 +1200,7 @@ async function runSkillAnalysis(
     findings: finalFindings,
     usage: totalUsage,
     durationMs: Date.now() - startTime,
-    model: options.model,
+    model: resolveResponseModel(allResponseModels, options.model),
     files: buildFileReports(
       fileResults.map((fr) => ({
         filename: fr.filename,

--- a/packages/warden/src/sdk/runner.ts
+++ b/packages/warden/src/sdk/runner.ts
@@ -22,7 +22,7 @@ export { verifyAuth } from './auth.js';
 export { calculateRetryDelay } from './retry.js';
 
 // Re-export usage utilities
-export { aggregateUsage, aggregateAuxiliaryUsage, mergeAuxiliaryUsage, estimateTokens } from './usage.js';
+export { aggregateUsage, aggregateAuxiliaryUsage, mergeAuxiliaryUsage, estimateTokens, resolveResponseModel } from './usage.js';
 
 // Re-export pricing utilities
 export { anthropicUsageToStats, apiUsageToStats } from './pricing.js';

--- a/packages/warden/src/sdk/types.ts
+++ b/packages/warden/src/sdk/types.ts
@@ -48,6 +48,8 @@ export interface HunkAnalysisResult {
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   /** Optional runtime trace captured for this hunk. */
   trace?: HunkTrace;
+  /** Model that actually answered this hunk, from the live API response. */
+  responseModel?: string;
 }
 
 /** Result from one completed chunk, suitable for durable run logging. */
@@ -223,6 +225,8 @@ export interface FileAnalysisResult {
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   /** Optional runtime traces captured for analyzed hunks. */
   traces?: HunkTrace[];
+  /** Models that actually answered this file's hunks, from the live API responses. */
+  responseModels?: string[];
 }
 
 /**

--- a/packages/warden/src/sdk/usage.ts
+++ b/packages/warden/src/sdk/usage.ts
@@ -113,6 +113,12 @@ function uniqueSorted(values: (string | undefined)[]): string[] | undefined {
   return unique.length > 0 ? unique : undefined;
 }
 
+/** Collapses a run's observed response models to a single value when they agree, or falls back. */
+export function resolveResponseModel(models: string[], fallback?: string): string | undefined {
+  const unique = [...new Set(models)];
+  return unique.length === 1 ? unique[0] : fallback;
+}
+
 function attributionFromEntries(entries: AuxiliaryUsageEntry[]): UsageAttribution | undefined {
   const models = uniqueSorted(entries.map((entry) => entry.model));
   const runtimes = uniqueSorted(entries.map((entry) => entry.runtime));


### PR DESCRIPTION
## Summary
- `SkillReport.model` only ever echoes the caller-configured model (`options.model` / `trigger.model`). If a run doesn't set one at any of the 4 override levels (per-skill, `defaults.agent`, `defaults`, per-trigger) — which is the common case when relying on the runtime's own default — this field is silently `undefined` on every run, even though the runtime already knows exactly which model answered each hunk.
- The runtime already normalizes this as `SkillRunResult.responseModel` (sourced from the live API response, see `runtimes/claude.ts`'s `normalizeResult`), but it only ever fed an opt-in `HunkTrace` object (`captureTraces`) and OTel spans — never the exported `SkillReport.model` that findings-file consumers actually read.
- This threads `responseModel` from `analyzeHunk`'s return paths that have a live API response (including the circuit-breaker-opens-on-an-SDK-error path via `hunkFailureFromCircuit`, which had the value available but was dropping it) up through `analyzeFile` and both independent report-construction sites — `sdk/analyze.ts`'s `runSkillAnalysis` and the CLI's separate `tasks.ts` pipeline (it drives `analyzeFile` directly with its own aggregation rather than calling `runSkillAnalysis`, so both needed the same treatment).
- `tasks.ts` also has a 4th report-construction site — the outer `catch` wrapping the whole skill task, used when something throws after hunks already completed (e.g. `postProcessFindings`/verification). The resolved model is now hoisted to the enclosing scope (mirroring the existing `resolvedSkillName` pattern in the same function) so this error path reports the real observed model too, instead of silently reverting to the same always-undefined behavior this PR fixes everywhere else.
- Collapses to a single value via a new `resolveResponseModel(models, fallback)` helper in `usage.ts` when every hunk in the run agrees, falling back to the configured override when hunks disagree or none reported one — mirrors the existing `model`/`models` singular-vs-plural collapse pattern already used for `auxiliaryUsageAttribution`.
- No schema change — `SkillReportSchema.model` already accepted a string, this only changes which value populates it.

## Real-world verification
This fix has been running in production on our `babylist/warden` fork since 2026-07-21, closing a gap that had been silently present since our findings-file data pipeline's first row:
- Before this fix: our downstream observability platform, which records per-skill-run metadata from the findings-file, had an empty model value on **every one of 3,969 rows** across 6 distinct skills since that pipeline went live — 100% of the time, isolated to this one field while every other field (usage, cost, tokens) was fully populated on the same rows.
- After this fix: verified directly against a real PR run's findings-file artifact (not just schema/theory) — `model` came back populated (e.g. `claude-opus-4-8`) for every skill that ran.
- Also verified there's no cross-skill attribution risk under real concurrency: multiple skills run as independent `executeTrigger` calls, each with its own local aggregation state, so a run with several skills on different models correctly reports each skill's own model rather than any bleeding across skills — added as an explicit regression test below, not just asserted.
- Ran an independent adversarial review (`/fight-me`) against this PR before requesting review, which caught the `tasks.ts` error-path gap described above via a live repro (not just static reading) — fixed and covered by a new regression test rather than left as a known gap.

## Test plan
- `pnpm test -- analyze.test.ts tasks.test.ts` — 5 new tests: the single-model case, the fallback-on-disagreement case, the circuit-breaker-with-a-live-response case, concurrent multi-skill isolation (3 skills run via `Promise.all` with distinct mocked models, asserting no cross-attribution), and the error-path-after-successful-hunks case caught by the adversarial review.
- `pnpm lint && pnpm typecheck && pnpm test` — full repo-wide run, clean (1773 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)