### PR TITLE
feat(sdk): surface verifierRejections across reports, CLI output, and findings-file export

### DIFF
--- a/packages/warden/src/action/reporting/output.test.ts
+++ b/packages/warden/src/action/reporting/output.test.ts
@@ -167,6 +167,30 @@ describe('findings output schema', () => {
     ).toThrow();
   });
 
+  it('includes verifierRejections when present', () => {
+    const report = createReport({
+      verifierRejections: { count: 1, reasons: ['not reproducible'] },
+    });
+    const output = buildFindingsOutput([report], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(FindingsOutputSchema.parse(output)).toEqual(output);
+    expect(output.skills[0]).toMatchObject({
+      verifierRejections: { count: 1, reasons: ['not reproducible'] },
+    });
+  });
+
+  it('omits verifierRejections when absent', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(output.skills[0]?.verifierRejections).toBeUndefined();
+  });
+
   it('rejects sentinel dedupe comment IDs', () => {
     const output = buildFindingsOutput([createReport()], createContext(), [], {
       timestamp: '2026-01-01T00:00:00.000Z',

--- a/packages/warden/src/action/reporting/output.ts
+++ b/packages/warden/src/action/reporting/output.ts
@@ -8,6 +8,7 @@ import {
   SkillErrorSchema,
   SourceSnippetSchema,
   UsageStatsSchema,
+  VerifierRejectionsSchema,
 } from '../../types/index.js';
 import type { FindingObservation } from './outcomes.js';
 import { FindingObservationSchema } from './outcomes.js';
@@ -96,6 +97,7 @@ export const FindingsOutputSchema = z.object({
     failedHunks: z.number().int().nonnegative().optional(),
     failedExtractions: z.number().int().nonnegative().optional(),
     error: SkillErrorSchema.optional(),
+    verifierRejections: VerifierRejectionsSchema.optional(),
     findings: z.array(ExportedFindingSchema),
   })),
   triggerResults: z.array(TriggerRunResultSchema).optional(),
@@ -207,6 +209,7 @@ export function buildFindingsOutput(
       failedHunks: r.failedHunks,
       failedExtractions: r.failedExtractions,
       error: r.error,
+      verifierRejections: r.verifierRejections,
       findings: r.findings.map((f) => ({
         id: f.id,
         severity: f.severity,

--- a/packages/warden/src/cli/main.test.ts
+++ b/packages/warden/src/cli/main.test.ts
@@ -284,6 +284,88 @@ describe('buildFinalChunkRecords', () => {
     expect(summary.usageBreakdown?.auxiliary?.['verification']?.model).toBe('verify-model');
     expect(summary.usageBreakdown?.total.usage.costUSD).toBeCloseTo(6.5);
   });
+
+  it('survives verifierRejections through the finalized chunk stream and reconstruction', () => {
+    const run = buildRunMetadata({
+      runId: 'run-verifier-rejections',
+      durationMs: 100,
+      timestamp: new Date('2026-06-03T00:00:00.000Z'),
+      cwd: '/repo',
+    });
+    const chunk: JsonlChunkRecord = {
+      schemaVersion: 1,
+      run,
+      skill: 'skill-a',
+      model: 'scan-model',
+      chunk: { file: 'src/app.ts', index: 1, total: 1, lineRange: '10-20' },
+      status: 'ok',
+      findings: [],
+      usageBreakdown: buildJsonlUsageBreakdown(makeUsage(1000, 100, 5), undefined),
+      durationMs: 100,
+    };
+    const log: RunLog = {
+      paths: [],
+      primaryLogPath: '/repo/.warden/logs/run.jsonl',
+      primaryLogWritten: true,
+      outputPath: undefined,
+      startTime: 0,
+      baseRun: run,
+      chunks: [chunk],
+    };
+    const report = makeReport({
+      model: 'scan-model',
+      usage: makeUsage(1000, 100, 5),
+      verifierRejections: { count: 2, reasons: ['not reproducible', 'guarded upstream'] },
+    });
+
+    const records = buildFinalChunkRecords(log, [report], 1000);
+    const postProcessing = records.find((record) => record.chunk.lineRange === 'post-processing');
+    expect(postProcessing?.verifierRejections).toEqual({
+      count: 2,
+      reasons: ['not reproducible', 'guarded upstream'],
+    });
+
+    const parsed = parseJsonlReports(renderJsonlChunkRecords(records));
+    expect(parsed.reports).toHaveLength(1);
+    expect(parsed.reports[0]!.verifierRejections).toEqual({
+      count: 2,
+      reasons: ['not reproducible', 'guarded upstream'],
+    });
+  });
+
+  it('omits a post-processing record when there is no missing usage or verifier rejections', () => {
+    const run = buildRunMetadata({
+      runId: 'run-no-post-processing',
+      durationMs: 100,
+      timestamp: new Date('2026-06-03T00:00:00.000Z'),
+      cwd: '/repo',
+    });
+    const chunk: JsonlChunkRecord = {
+      schemaVersion: 1,
+      run,
+      skill: 'skill-a',
+      model: 'scan-model',
+      chunk: { file: 'src/app.ts', index: 1, total: 1, lineRange: '10-20' },
+      status: 'ok',
+      findings: [],
+      usageBreakdown: buildJsonlUsageBreakdown(makeUsage(1000, 100, 5), undefined),
+      durationMs: 100,
+    };
+    const log: RunLog = {
+      paths: [],
+      primaryLogPath: '/repo/.warden/logs/run.jsonl',
+      primaryLogWritten: true,
+      outputPath: undefined,
+      startTime: 0,
+      baseRun: run,
+      chunks: [chunk],
+    };
+    const report = makeReport({ model: 'scan-model', usage: makeUsage(1000, 100, 5) });
+
+    const records = buildFinalChunkRecords(log, [report], 1000);
+
+    expect(records).toHaveLength(1);
+  });
 });
 
 describe('appendReportToRunLog', () => {

--- a/packages/warden/src/cli/main.ts
+++ b/packages/warden/src/cli/main.ts
@@ -14,7 +14,7 @@ import { mapExtractionErrorCode } from '../sdk/errors.js';
 import { aggregateAuxiliaryUsageAttribution, mergeAuxiliaryUsage } from '../sdk/usage.js';
 import { resolveSkillAsync, SkillLoaderError } from '../skills/loader.js';
 import { matchTrigger, filterContextByPaths, shouldFail, countFindingsAtOrAbove } from '../triggers/matcher.js';
-import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, Finding, UsageStats, AuxiliaryUsageMap } from '../types/index.js';
+import type { SkillReport, SeverityThreshold, ConfidenceThreshold, SkillError, Finding, UsageStats, AuxiliaryUsageMap, VerifierRejections } from '../types/index.js';
 import { filterFindings } from '../types/index.js';
 import { DEFAULT_CONCURRENCY, getAnthropicApiKey } from '../utils/index.js';
 import { isRepoRelativePath, normalizePath, resolveConfigInput } from '../utils/path.js';
@@ -333,6 +333,7 @@ function buildReportChunkRecord(
     durationMs: includeReportResults ? (report.durationMs ?? runDurationMs) : 0,
     error: reportError,
     skippedFiles: report.skippedFiles,
+    verifierRejections: includeReportResults ? report.verifierRejections : undefined,
   };
 }
 
@@ -470,7 +471,8 @@ function buildUsageOnlyChunkRecord(
   log: RunLog,
   report: SkillReport,
   runDurationMs: number,
-  auxiliaryUsage: AuxiliaryUsageMap,
+  auxiliaryUsage: AuxiliaryUsageMap | undefined,
+  verifierRejections: VerifierRejections | undefined,
 ): JsonlChunkRecord {
   return {
     schemaVersion: 1,
@@ -489,6 +491,7 @@ function buildUsageOnlyChunkRecord(
     usageBreakdown: buildJsonlUsageBreakdown(undefined, auxiliaryUsage, {
       auxiliary: report.auxiliaryUsageAttribution,
     }),
+    verifierRejections,
   };
 }
 
@@ -538,8 +541,8 @@ export function buildFinalChunkRecords(
       undefined,
     );
     const missingAuxiliaryUsage = subtractAuxiliaryUsage(report.auxiliaryUsage, recordedAuxiliaryUsage);
-    return missingAuxiliaryUsage
-      ? [buildUsageOnlyChunkRecord(log, report, totalDurationMs, missingAuxiliaryUsage)]
+    return missingAuxiliaryUsage || report.verifierRejections
+      ? [buildUsageOnlyChunkRecord(log, report, totalDurationMs, missingAuxiliaryUsage, report.verifierRejections)]
       : [];
   });
   return [

--- a/packages/warden/src/cli/output/jsonl.test.ts
+++ b/packages/warden/src/cli/output/jsonl.test.ts
@@ -908,6 +908,45 @@ describe('parseJsonlReports', () => {
     expect(report.auxiliaryUsage?.['verification']?.costUSD).toBe(0.0005);
   });
 
+  it('recovers verifierRejections from the post-processing chunk marker', () => {
+    const run = buildRunMetadata({
+      runId: 'chunk-verifier-rejections',
+      durationMs: 100,
+      timestamp: new Date('2026-02-18T14:32:15.123Z'),
+      cwd: '/test',
+    });
+    const chunks: JsonlChunkRecord[] = [
+      {
+        schemaVersion: 1,
+        run,
+        skill: 'security-review',
+        chunk: { file: 'src/api.ts', index: 1, total: 1, lineRange: '10-20' },
+        status: 'ok',
+        findings: [],
+        usageBreakdown: buildJsonlUsageBreakdown({ inputTokens: 100, outputTokens: 10, costUSD: 0.001 }, undefined),
+        durationMs: 100,
+      },
+      {
+        schemaVersion: 1,
+        run,
+        skill: 'security-review',
+        chunk: { file: '', index: 1, total: 1, lineRange: 'post-processing' },
+        status: 'ok',
+        findings: [],
+        durationMs: 0,
+        verifierRejections: { count: 2, reasons: ['not reproducible', 'guarded upstream'] },
+      },
+    ];
+
+    const result = parseJsonlReports(chunks.map((chunk) => renderJsonlChunkLine(chunk)).join(''));
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]!.verifierRejections).toEqual({
+      count: 2,
+      reasons: ['not reproducible', 'guarded upstream'],
+    });
+  });
+
   it('reconstructs trace metadata from chunk records', () => {
     const run = buildRunMetadata({ runId: 'chunk-traces', durationMs: 300 });
     const trace: HunkTrace = {
@@ -1228,6 +1267,7 @@ another bad line
         summary: 'ok',
         findings: [],
         failedExtractions: 1,
+        verifierRejections: { count: 3, reasons: ['a', 'b', 'c'] },
       },
     ];
     const content = renderJsonlString(original, 1000, { runId: 'sum-123' });
@@ -1237,6 +1277,7 @@ another bad line
     expect(summary.failedSkills).toEqual(['skill-a']);
     expect(summary.totalFailedHunks).toBe(2);
     expect(summary.totalFailedExtractions).toBe(1);
+    expect(summary.totalVerifierRejections).toBe(3);
   });
 
   it('omits summary extras when there are no failures', () => {
@@ -1249,6 +1290,7 @@ another bad line
     expect(summary.failedSkills).toBeUndefined();
     expect(summary.totalFailedHunks).toBeUndefined();
     expect(summary.totalFailedExtractions).toBeUndefined();
+    expect(summary.totalVerifierRejections).toBeUndefined();
   });
 
   it('passes through fix-evaluation records without treating them as malformed', () => {

--- a/packages/warden/src/cli/output/jsonl.ts
+++ b/packages/warden/src/cli/output/jsonl.ts
@@ -13,6 +13,7 @@ import {
   SkillErrorSchema,
   SkippedFileSchema,
   HunkTraceSchema,
+  VerifierRejectionsSchema,
 } from '../../types/index.js';
 import type { SkillReport, UsageStats, AuxiliaryUsageMap, AuxiliaryUsageAttributionMap, SkillError, Finding, FileReport, HunkFailure } from '../../types/index.js';
 import { mergeAuxiliaryUsage, mergeAuxiliaryUsageAttribution } from '../../sdk/usage.js';
@@ -120,6 +121,7 @@ export const JsonlChunkRecordSchema = z.object({
   error: SkillErrorSchema.optional(),
   skippedFiles: z.array(SkippedFileSchema).optional(),
   trace: HunkTraceSchema.optional(),
+  verifierRejections: VerifierRejectionsSchema.optional(),
 });
 export type JsonlChunkRecord = z.infer<typeof JsonlChunkRecordSchema>;
 
@@ -200,6 +202,7 @@ export const JsonlSummaryRecordSchema = z.object({
   failedSkills: z.array(z.string()).optional(),
   totalFailedHunks: z.number().int().nonnegative().optional(),
   totalFailedExtractions: z.number().int().nonnegative().optional(),
+  totalVerifierRejections: z.number().int().nonnegative().optional(),
   /**
    * Top-level run error captured before any skill ran (e.g. auth failure,
    * config load error). Skill-level errors live on the SkillRecord; this
@@ -330,6 +333,7 @@ export function buildSummaryJsonlRecord(
   const failedSkills = reports.filter((r) => r.error).map((r) => r.skill);
   const totalFailedHunks = reports.reduce((n, r) => n + (r.failedHunks ?? 0), 0);
   const totalFailedExtractions = reports.reduce((n, r) => n + (r.failedExtractions ?? 0), 0);
+  const totalVerifierRejections = reports.reduce((n, r) => n + (r.verifierRejections?.count ?? 0), 0);
   return {
     run,
     type: 'summary',
@@ -343,6 +347,7 @@ export function buildSummaryJsonlRecord(
     failedSkills: failedSkills.length > 0 ? failedSkills : undefined,
     totalFailedHunks: totalFailedHunks > 0 ? totalFailedHunks : undefined,
     totalFailedExtractions: totalFailedExtractions > 0 ? totalFailedExtractions : undefined,
+    totalVerifierRejections: totalVerifierRejections > 0 ? totalVerifierRejections : undefined,
     error,
   };
 }
@@ -551,6 +556,7 @@ function reportsFromChunks(chunks: JsonlChunkRecord[]): SkillReport[] {
     const failedExtractions = analysisChunkRecords.filter(
       (r) => r.status === 'error' && r.error && isExtractionErrorCode(r.error.code),
     ).length;
+    const verifierRejections = aggregateRecords.find((r) => r.verifierRejections)?.verifierRejections;
     const allChunksFailed =
       analysisChunkRecords.length > 0 &&
       findings.length === 0 &&
@@ -576,6 +582,7 @@ function reportsFromChunks(chunks: JsonlChunkRecord[]): SkillReport[] {
     if (auxiliaryUsageAttribution) report.auxiliaryUsageAttribution = auxiliaryUsageAttribution;
     if (failedHunks > 0) report.failedHunks = failedHunks;
     if (failedExtractions > 0) report.failedExtractions = failedExtractions;
+    if (verifierRejections) report.verifierRejections = verifierRejections;
     if (hunkFailures.length > 0) report.hunkFailures = hunkFailures;
     if (traces.length > 0) report.traces = traces;
     if (skippedFiles.length > 0) report.skippedFiles = skippedFiles;

--- a/packages/warden/src/cli/output/reporter.test.ts
+++ b/packages/warden/src/cli/output/reporter.test.ts
@@ -191,5 +191,32 @@ describe('Reporter', () => {
       expect(errorOutput).not.toContain('failed to analyze');
       expect(errorOutput).not.toContain('Use -v');
     });
+
+    it('shows verifier rejection count in log mode', () => {
+      const reporter = new Reporter(logMode(), Verbosity.Normal);
+      reporter.renderSummary([makeReport({ verifierRejections: { count: 4, reasons: ['a', 'b', 'c', 'd'] } })], 1000);
+
+      const output = errorSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+      expect(output).toContain('WARN: 4 findings rejected by verification');
+    });
+
+    it('shows verifier rejection count in TTY mode', () => {
+      const reporter = new Reporter(ttyMode(), Verbosity.Normal);
+      reporter.renderSummary([makeReport({ verifierRejections: { count: 1, reasons: ['a'] } })], 1000);
+
+      const output = errorSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+      expect(output).toContain('1 finding rejected by verification');
+    });
+
+    it('aggregates verifier rejections across multiple reports', () => {
+      const reporter = new Reporter(logMode(), Verbosity.Normal);
+      reporter.renderSummary([
+        makeReport({ verifierRejections: { count: 1, reasons: ['a'] } }),
+        makeReport({ verifierRejections: { count: 2, reasons: ['b', 'c'] } }),
+      ], 1000);
+
+      const output = errorSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+      expect(output).toContain('WARN: 3 findings rejected by verification');
+    });
   });
 });

--- a/packages/warden/src/cli/output/reporter.ts
+++ b/packages/warden/src/cli/output/reporter.ts
@@ -207,11 +207,13 @@ export class Reporter {
     let totalFailedHunks = 0;
     let totalFailedExtractions = 0;
     let totalSkippedFiles = 0;
+    let totalVerifierRejections = 0;
     for (const report of reports) {
       allFindings.push(...report.findings);
       totalFailedHunks += report.failedHunks ?? 0;
       totalFailedExtractions += report.failedExtractions ?? 0;
       totalSkippedFiles += report.skippedFiles?.length ?? 0;
+      totalVerifierRejections += report.verifierRejections?.count ?? 0;
     }
     const counts = countBySeverity(allFindings);
     const totalUsage = this.aggregateUsage(reports);
@@ -232,6 +234,9 @@ export class Reporter {
       }
       if (totalFailedExtractions > 0) {
         this.log(chalk.yellow(`${figures.warning}  ${totalFailedExtractions} finding ${pluralize(totalFailedExtractions, 'extraction')} failed`));
+      }
+      if (totalVerifierRejections > 0) {
+        this.log(chalk.yellow(`${figures.warning}  ${totalVerifierRejections} ${pluralize(totalVerifierRejections, 'finding')} rejected by verification`));
       }
       if ((totalFailedHunks > 0 || totalFailedExtractions > 0) && this.verbosity < Verbosity.Verbose) {
         this.log(chalk.dim('  Use -v for failure details'));
@@ -255,6 +260,9 @@ export class Reporter {
       }
       if (totalFailedExtractions > 0) {
         this.logPlain(`WARN: ${totalFailedExtractions} finding ${pluralize(totalFailedExtractions, 'extraction')} failed`);
+      }
+      if (totalVerifierRejections > 0) {
+        this.logPlain(`WARN: ${totalVerifierRejections} ${pluralize(totalVerifierRejections, 'finding')} rejected by verification`);
       }
       if ((totalFailedHunks > 0 || totalFailedExtractions > 0) && this.verbosity < Verbosity.Verbose) {
         this.logPlain('Use -v for failure details');

--- a/packages/warden/src/cli/output/tasks.test.ts
+++ b/packages/warden/src/cli/output/tasks.test.ts
@@ -682,6 +682,7 @@ describe('runSkillTasks', () => {
     const postProcessFindings = vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
       findings: [],
       auxiliaryUsage: [],
+      verifierRejections: { count: 1, reasons: ['not reproducible'] },
     });
 
     const results = await runSkillTasks([{
@@ -705,6 +706,55 @@ describe('runSkillTasks', () => {
     expect(results[0]?.report?.files?.[0]?.findings).toBe(0);
     expect(controller.signal.aborted).toBe(false);
     expect(postProcessFindings).toHaveBeenCalled();
+    expect(results[0]?.report?.verifierRejections).toEqual({ count: 1, reasons: ['not reproducible'] });
+
+    prepareFiles.mockRestore();
+    analyzeFile.mockRestore();
+    postProcessFindings.mockRestore();
+  });
+
+  it('omits verifierRejections on the report when nothing is rejected', async () => {
+    const finalFinding = makeFinding();
+    const controller = new AbortController();
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+
+    const prepareFiles = vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    const analyzeFile = vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finalFinding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+    } satisfies FileAnalysisResult);
+    const postProcessFindings = vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
+      findings: [finalFinding],
+      auxiliaryUsage: [],
+    });
+
+    const results = await runSkillTasks([{
+      name: 'verify-skill',
+      resolveSkill: async () =>
+        ({ name: 'verify-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+    }], {
+      mode: logMode(),
+      verbosity: Verbosity.Quiet,
+      concurrency: 1,
+      failFastController: controller,
+    });
+
+    expect(results[0]?.report?.verifierRejections).toBeUndefined();
 
     prepareFiles.mockRestore();
     analyzeFile.mockRestore();

--- a/packages/warden/src/cli/output/tasks.ts
+++ b/packages/warden/src/cli/output/tasks.ts
@@ -660,6 +660,9 @@ export async function runSkillTask(
         if (auxUsage) {
           report.auxiliaryUsage = auxUsage;
         }
+        if (processed.verifierRejections) {
+          report.verifierRejections = processed.verifierRejections;
+        }
         span.setAttribute('warden.finding.count', report.findings.length);
 
         // Emit metrics and log completion

--- a/packages/warden/src/cli/terminal.test.ts
+++ b/packages/warden/src/cli/terminal.test.ts
@@ -347,6 +347,18 @@ describe('renderTerminalReport', () => {
       expect(output).toContain('WARN: 1 finding extraction failed');
     });
 
+    it('renders per-skill verifierRejections warning', () => {
+      const report = createReport({
+        durationMs: 5000,
+        findings: [createFinding({ severity: 'high', title: 'Bug found' })],
+        verifierRejections: { count: 2, reasons: ['not reproducible', 'guarded upstream'] },
+      });
+
+      const output = renderTerminalReport([report], ciMode);
+
+      expect(output).toContain('WARN: 2 findings rejected by verification');
+    });
+
     it('does not render warnings when counts are zero', () => {
       const report = createReport({
         durationMs: 5000,

--- a/packages/warden/src/cli/terminal.ts
+++ b/packages/warden/src/cli/terminal.ts
@@ -238,6 +238,9 @@ function renderSkillCI(report: SkillReport, verbosity: Verbosity = Verbosity.Nor
   if (report.failedExtractions) {
     lines.push(`  WARN: ${report.failedExtractions} finding ${pluralize(report.failedExtractions, 'extraction')} failed`);
   }
+  if (report.verifierRejections) {
+    lines.push(`  WARN: ${report.verifierRejections.count} ${pluralize(report.verifierRejections.count, 'finding')} rejected by verification`);
+  }
   if ((report.failedHunks || report.failedExtractions) && verbosity < Verbosity.Verbose) {
     lines.push('  Use -v for failure details');
   }

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -26,7 +26,7 @@ import {
   type ChunkAnalysisResult,
 } from './types.js';
 import { prepareFiles } from './prepare.js';
-import type { EventContext, SkillReport, UsageStats, HunkFailure, HunkTrace } from '../types/index.js';
+import type { EventContext, SkillReport, UsageStats, HunkFailure, HunkTrace, VerifierRejections } from '../types/index.js';
 import type { SourceSnippet, SourceSnippetLine } from '../types/index.js';
 import { runPool } from '../utils/index.js';
 import { getSpanContext, startTraceRecorder, withTraceRecorder, type TraceRecorder } from '../sentry-trace.js';
@@ -1153,6 +1153,7 @@ async function runSkillAnalysis(
   }
 
   let finalFindings = allFindings;
+  let verifierRejections: VerifierRejections | undefined;
   if (options.postProcessFindings !== false) {
     const processed = await postProcessFindings(allFindings, {
       skill,
@@ -1172,6 +1173,7 @@ async function runSkillAnalysis(
     });
     finalFindings = processed.findings;
     allAuxiliaryUsage.push(...processed.auxiliaryUsage);
+    verifierRejections = processed.verifierRejections;
   }
 
   // Generate summary
@@ -1219,6 +1221,9 @@ async function runSkillAnalysis(
   const auxAttribution = aggregateAuxiliaryUsageAttribution(allAuxiliaryUsage);
   if (auxAttribution) {
     report.auxiliaryUsageAttribution = auxAttribution;
+  }
+  if (verifierRejections) {
+    report.verifierRejections = verifierRejections;
   }
   return report;
 }

--- a/packages/warden/src/sdk/post-process.ts
+++ b/packages/warden/src/sdk/post-process.ts
@@ -1,6 +1,6 @@
 import type { Effort, SkillDefinition } from '../config/schema.js';
 import { emitDedupMetrics } from '../sentry.js';
-import type { Finding } from '../types/index.js';
+import type { Finding, VerifierRejections } from '../types/index.js';
 import { deduplicateFindings, mergeCrossLocationFindings } from './extract.js';
 import type { PromptPRContext } from './prompt-sections.js';
 import type { RuntimeName } from './runtimes/index.js';
@@ -27,6 +27,7 @@ export interface PostProcessFindingsOptions {
 export interface PostProcessFindingsResult {
   findings: Finding[];
   auxiliaryUsage: AuxiliaryUsageEntry[];
+  verifierRejections?: VerifierRejections;
 }
 
 /**
@@ -42,6 +43,7 @@ export async function postProcessFindings(
   emitDedupMetrics(options.skill.name, findings.length, uniqueFindings.length);
 
   let currentFindings = uniqueFindings;
+  let verifierRejections: VerifierRejections | undefined;
   if (options.verifyFindings !== false) {
     const verification = await verifyFindings(currentFindings, {
       repoPath: options.repoPath,
@@ -57,6 +59,7 @@ export async function postProcessFindings(
       onFindingProcessing: options.onFindingProcessing,
     });
     currentFindings = verification.findings;
+    verifierRejections = verification.verifierRejections;
     if (verification.usage) {
       auxiliaryUsage.push({
         agent: 'verification',
@@ -86,5 +89,5 @@ export async function postProcessFindings(
     });
   }
 
-  return { findings: currentFindings, auxiliaryUsage };
+  return { findings: currentFindings, auxiliaryUsage, verifierRejections };
 }

--- a/packages/warden/src/sdk/verify.test.ts
+++ b/packages/warden/src/sdk/verify.test.ts
@@ -106,6 +106,7 @@ describe('verifyFindings', () => {
       reason: 'guarded upstream',
     });
     expect(result.usage).toEqual(expect.objectContaining(makeUsage()));
+    expect(result.verifierRejections).toEqual({ count: 1, reasons: ['guarded upstream'] });
     expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
       repoPath: '/repo',
       skillName: 'test-skill:verification',
@@ -363,5 +364,57 @@ describe('verifyFindings', () => {
     expect(runtime.runSkill).toHaveBeenCalledWith(expect.objectContaining({
       tools: { allowed: ['Read', 'Grep', 'WebFetch'] },
     }));
+  });
+
+  it('omits verifierRejections when nothing is rejected', async () => {
+    const runtime = mockRuntime('{"verdict":"keep"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const result = await verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.verifierRejections).toBeUndefined();
+  });
+
+  it('falls back to a default reason when the verifier rejects without one', async () => {
+    const runtime = mockRuntime('{"verdict":"reject"}');
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const result = await verifyFindings([makeFinding()], {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.verifierRejections).toEqual({ count: 1, reasons: ['No reason provided'] });
+  });
+
+  it('aggregates rejections across multiple findings', async () => {
+    const runtime: Runtime = {
+      name: 'claude',
+      runSkill: vi.fn()
+        .mockResolvedValueOnce({
+          result: { status: 'success', text: '{"verdict":"reject","reason":"first"}', errors: [], usage: makeUsage() },
+        })
+        .mockResolvedValueOnce({
+          result: { status: 'success', text: '{"verdict":"keep"}', errors: [], usage: makeUsage() },
+        })
+        .mockResolvedValueOnce({
+          result: { status: 'success', text: '{"verdict":"reject","reason":"second"}', errors: [], usage: makeUsage() },
+        }),
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime;
+    vi.mocked(getRuntime).mockReturnValue(runtime);
+
+    const findings = [makeFinding({ id: 'A' }), makeFinding({ id: 'B' }), makeFinding({ id: 'C' })];
+    const result = await verifyFindings(findings, {
+      repoPath: '/repo',
+      skill: makeSkill(),
+    });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.verifierRejections).toEqual({ count: 2, reasons: ['first', 'second'] });
   });
 });

--- a/packages/warden/src/sdk/verify.ts
+++ b/packages/warden/src/sdk/verify.ts
@@ -63,6 +63,7 @@ interface VerificationTaskResult {
 
 const JSON_OBJECT_START = /\{/g;
 const VERIFICATION_CONCURRENCY = 4;
+const MAX_REJECTION_REASON_LENGTH = 500;
 
 function isAbortRequested(error: unknown, abortController?: AbortController): boolean {
   return (abortController?.signal.aborted ?? false) || classifyError(error).code === 'aborted';
@@ -280,7 +281,7 @@ export async function verifyFindings(
         const next = applyVerdict(finding, verdict);
         notifyVerdict(options, finding, verdict, next);
         const rejectionReason = verdict?.verdict === 'reject'
-          ? verdict.reason ?? 'No reason provided'
+          ? (verdict.reason ?? 'No reason provided').slice(0, MAX_REJECTION_REASON_LENGTH)
           : undefined;
         return { finding: next ?? undefined, usage: result?.usage, rejectionReason };
       } catch (error) {

--- a/packages/warden/src/sdk/verify.ts
+++ b/packages/warden/src/sdk/verify.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { Effort, SkillDefinition } from '../config/schema.js';
-import { FindingSchema, type Finding, type UsageStats } from '../types/index.js';
+import { FindingSchema, type Finding, type UsageStats, type VerifierRejections } from '../types/index.js';
 import { aggregateUsage } from './usage.js';
 import { extractBalancedJson } from './extract.js';
 import {
@@ -44,6 +44,7 @@ export interface VerifyFindingsOptions {
 export interface VerifyFindingsResult {
   findings: Finding[];
   usage?: UsageStats;
+  verifierRejections?: VerifierRejections;
 }
 
 const VerificationVerdictSchema = z.object({
@@ -57,6 +58,7 @@ type VerificationVerdict = z.infer<typeof VerificationVerdictSchema>;
 interface VerificationTaskResult {
   finding?: Finding;
   usage?: UsageStats;
+  rejectionReason?: string;
 }
 
 const JSON_OBJECT_START = /\{/g;
@@ -277,7 +279,10 @@ export async function verifyFindings(
           : null;
         const next = applyVerdict(finding, verdict);
         notifyVerdict(options, finding, verdict, next);
-        return { finding: next ?? undefined, usage: result?.usage };
+        const rejectionReason = verdict?.verdict === 'reject'
+          ? verdict.reason ?? 'No reason provided'
+          : undefined;
+        return { finding: next ?? undefined, usage: result?.usage, rejectionReason };
       } catch (error) {
         if (isAbortRequested(error, options.abortController)) {
           return keepFindingAfterInterruptedVerification(finding);
@@ -307,9 +312,15 @@ export async function verifyFindings(
 
   const verified = results.flatMap((result) => result.finding ? [result.finding] : []);
   const usage = results.map((result) => result.usage).filter((u): u is UsageStats => u !== undefined);
+  const rejectionReasons = results
+    .map((result) => result.rejectionReason)
+    .filter((reason): reason is string => reason !== undefined);
 
   return {
     findings: verified,
     usage: usage.length > 0 ? aggregateUsage(usage) : undefined,
+    verifierRejections: rejectionReasons.length > 0
+      ? { count: rejectionReasons.length, reasons: rejectionReasons }
+      : undefined,
   };
 }

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -355,6 +355,7 @@ export const SkillReportSchema = z.object({
   traces: z.array(HunkTraceSchema).optional(),
   /** Set when the run cannot complete normally. */
   error: SkillErrorSchema.optional(),
+  /** Findings the verification pass rejected, if any ran. */
   verifierRejections: VerifierRejectionsSchema.optional(),
   /** Usage from auxiliary LLM calls (extraction repair, semantic dedup, etc.) */
   auxiliaryUsage: AuxiliaryUsageMapSchema.optional(),

--- a/packages/warden/src/types/index.ts
+++ b/packages/warden/src/types/index.ts
@@ -276,6 +276,12 @@ export const SkillErrorSchema = z.object({
 });
 export type SkillError = z.infer<typeof SkillErrorSchema>;
 
+export const VerifierRejectionsSchema = z.object({
+  count: z.number().int().nonnegative(),
+  reasons: z.array(z.string()),
+});
+export type VerifierRejections = z.infer<typeof VerifierRejectionsSchema>;
+
 // 'analysis' = SDK/auth/abort failure, 'extraction' = parse-tier failure.
 export const HunkFailureSchema = z.object({
   type: z.enum(['analysis', 'extraction']),
@@ -349,6 +355,7 @@ export const SkillReportSchema = z.object({
   traces: z.array(HunkTraceSchema).optional(),
   /** Set when the run cannot complete normally. */
   error: SkillErrorSchema.optional(),
+  verifierRejections: VerifierRejectionsSchema.optional(),
   /** Usage from auxiliary LLM calls (extraction repair, semantic dedup, etc.) */
   auxiliaryUsage: AuxiliaryUsageMapSchema.optional(),
   /** Model/runtime attribution for auxiliary LLM usage, keyed like auxiliaryUsage */

--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -689,6 +689,27 @@
         "error": {
           "$ref": "#/$defs/SkillError"
         },
+        "verifierRejections": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "reasons": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "count",
+            "reasons"
+          ],
+          "additionalProperties": false
+        },
         "auxiliaryUsage": {
           "$ref": "#/$defs/AuxiliaryUsage"
         },

--- a/specs/jsonl-schema.json
+++ b/specs/jsonl-schema.json
@@ -94,6 +94,9 @@
         },
         "trace": {
           "$ref": "#/$defs/HunkTrace"
+        },
+        "verifierRejections": {
+          "$ref": "#/$defs/__schema6"
         }
       },
       "required": [
@@ -629,6 +632,27 @@
       ],
       "additionalProperties": false
     },
+    "__schema6": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "count",
+        "reasons"
+      ],
+      "additionalProperties": false
+    },
     "SkillRecord": {
       "type": "object",
       "properties": {
@@ -690,25 +714,7 @@
           "$ref": "#/$defs/SkillError"
         },
         "verifierRejections": {
-          "type": "object",
-          "properties": {
-            "count": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 9007199254740991
-            },
-            "reasons": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "count",
-            "reasons"
-          ],
-          "additionalProperties": false
+          "$ref": "#/$defs/__schema6"
         },
         "auxiliaryUsage": {
           "$ref": "#/$defs/AuxiliaryUsage"
@@ -899,6 +905,11 @@
           "maximum": 9007199254740991
         },
         "totalFailedExtractions": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "totalVerifierRejections": {
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991


### PR DESCRIPTION
## Summary
- Today, a finding the verification pass rejects simply disappears — no count, no reason, visible nowhere in Warden's output. This PR adds a new `verifierRejections: {count, reasons[]}` field, computed in `verifyFindings()` and threaded through `postProcessFindings()` onto `SkillReport`.
- Surfaced everywhere `failedHunks`/`failedExtractions` already are: the terminal report, the `Reporter`'s aggregate summary (log + TTY modes), the JSONL run log (per-chunk and run-summary), and the GitHub Action's findings-file export.
- The run-level aggregate (JSONL summary, `Reporter`, terminal) intentionally surfaces only a `count`, not the reasons — matching the existing `failedHunks`/`failedExtractions` precedent. Reasons are still available at the per-skill chunk-record level.

## Real-world verification
This feature has been running in production for about a week, feeding an internal data pipeline into an observability platform we use to track skill health. Querying that platform now:
- ~3,900 skill runs recorded in that window.
- 555 of those runs (about 14%) logged at least one verifier rejection, totaling 874 rejected findings across three different review skills.
- Spot-checking a sample of the recorded reasons shows the verifier is doing real, substantive work, not rubber-stamping: the large majority cite a finding anchored outside the PR's actual changed files (out-of-scope), or reason through why a cited convention doesn't actually apply to the specific pattern flagged — exactly the "would have been noise for the author" cases this field exists to make visible.

## Test plan
- `pnpm test -- verify.test.ts` — rejection counting, default-reason fallback, multi-finding aggregation.
- `pnpm test -- output.test.ts` — findings-file export present/absent.
- `pnpm test -- terminal.test.ts`, `reporter.test.ts` — per-skill and aggregate warning lines.
- `pnpm test -- jsonl.test.ts`, `main.test.ts` — schema round-trip through the JSONL chunk stream and run summary.
- `pnpm test -- tasks.test.ts` — end-to-end through the CLI task runner.
- `pnpm lint && pnpm build && pnpm test` — full repo-wide run, clean, rebased onto `main` after #438 merged (1782 passed, 4 skipped).
