### PR TITLE
fix(docs): Show max benchmark reasoning level

### DIFF
--- a/packages/docs/src/components/BenchmarkRuns.astro
+++ b/packages/docs/src/components/BenchmarkRuns.astro
@@ -69,6 +69,7 @@ const MODEL_LABELS: Record<string, string> = {
 const REASONING_LABELS: Record<string, string> = {
   high: "high",
   low: "low",
+  max: "max",
   "pi-default-medium": "medium",
   "provider-default": "default",
   xhigh: "xhigh",


### PR DESCRIPTION
Kimi K3's recorded `max` reasoning level now appears in the benchmark
comparison instead of being silently omitted. The benchmark result already
stored the level correctly; the display label map lacked that value.
