### PR TITLE
fix(reporting): resolve SkillReport.model from the actual API response

### DIFF
--- a/packages/warden/src/cli/output/tasks.test.ts
+++ b/packages/warden/src/cli/output/tasks.test.ts
@@ -1375,6 +1375,88 @@ describe('runSkillTask model lanes', () => {
     );
     expect(result.report?.runtime).toBe('pi');
   });
+
+  it('reports the model that actually answered when no model override is configured', async () => {
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+    const finding = makeFinding();
+
+    vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+      responseModels: ['claude-sonnet-4-5-20260929'],
+    } satisfies FileAnalysisResult);
+    vi.spyOn(sdkRunner, 'postProcessFindings').mockResolvedValue({
+      findings: [finding],
+      auxiliaryUsage: [],
+    });
+
+    const result = await runSkillTask({
+      name: 'lane-skill',
+      resolveSkill: async () =>
+        ({ name: 'lane-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+      runnerOptions: {
+        runtime: 'pi',
+      },
+    }, 1, noopCallbacks());
+
+    expect(result.report?.model).toBe('claude-sonnet-4-5-20260929');
+  });
+
+  it('reports the observed model on the error path when post-processing throws after hunks succeed', async () => {
+    const fakeHunk = {
+      hunk: { newStart: 1, newCount: 10 },
+    } as unknown as HunkWithContext;
+    const finding = makeFinding();
+
+    vi.spyOn(sdkRunner, 'prepareFiles').mockReturnValue({
+      files: [{ filename: 'a.ts', hunks: [fakeHunk] }],
+      skippedFiles: [],
+    });
+    vi.spyOn(sdkRunner, 'analyzeFile').mockResolvedValue({
+      filename: 'a.ts',
+      findings: [finding],
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0.001 },
+      failedHunks: 0,
+      failedExtractions: 0,
+      hunkFailures: [],
+      responseModels: ['claude-sonnet-4-5-20260929'],
+    } satisfies FileAnalysisResult);
+    vi.spyOn(sdkRunner, 'postProcessFindings').mockRejectedValue(new Error('verification blew up'));
+
+    const result = await runSkillTask({
+      name: 'lane-skill',
+      resolveSkill: async () =>
+        ({ name: 'lane-skill', definition: '', files: [] } as unknown as SkillDefinition),
+      context: {
+        eventType: 'pull_request',
+        repository: { owner: 'o', name: 'n', fullName: 'o/n', defaultBranch: 'main' },
+        repoPath: '/tmp',
+        pullRequest: { number: 1, title: 't', body: '', headSha: 'abc', baseSha: 'def', files: [] },
+      } as unknown as SkillTaskOptions['context'],
+      runnerOptions: {
+        runtime: 'pi',
+      },
+    }, 1, noopCallbacks());
+
+    expect(result.report?.error).toBeDefined();
+    expect(result.report?.model).toBe('claude-sonnet-4-5-20260929');
+  });
 });
 
 describe('runSkillTask error capture', () => {

--- a/packages/warden/src/cli/output/tasks.ts
+++ b/packages/warden/src/cli/output/tasks.ts
@@ -15,6 +15,7 @@ import {
   analyzeFile,
   aggregateUsage,
   aggregateAuxiliaryUsage,
+  resolveResponseModel,
   postProcessFindings,
   generateSummary,
   type AuxiliaryUsageEntry,
@@ -48,6 +49,7 @@ interface FileProcessResult {
   hunkFailures: HunkFailure[];
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   traces?: HunkTrace[];
+  responseModels?: string[];
 }
 
 function allAnalysisFailuresHaveCode(
@@ -307,6 +309,7 @@ export async function runSkillTask(
       // report.skill when resolveSkill succeeded but a later step threw.
       // Stays undefined only if resolveSkill itself failed.
       let resolvedSkillName: string | undefined;
+      let resolvedModel: string | undefined;
 
       try {
         let skill: SkillDefinition;
@@ -502,6 +505,7 @@ export async function runSkillTask(
             hunkFailures: result.hunkFailures,
             auxiliaryUsage: result.auxiliaryUsage,
             traces: result.traces,
+            responseModels: result.responseModels,
           };
         };
 
@@ -552,6 +556,8 @@ export async function runSkillTask(
         const allUsage = allResults.map((r) => r.usage).filter((u): u is UsageStats => u !== undefined);
         const allAuxEntries = allResults.flatMap((r) => r.auxiliaryUsage ?? []);
         const allTraces = allResults.flatMap((r) => r.traces ?? []);
+        const allResponseModels = allResults.flatMap((r) => r.responseModels ?? []);
+        resolvedModel = resolveResponseModel(allResponseModels, runnerOptions?.model);
         const totalFailedHunks = allResults.reduce((sum, r) => sum + r.failedHunks, 0);
         const totalFailedExtractions = allResults.reduce((sum, r) => sum + r.failedExtractions, 0);
         const allHunkFailures: HunkFailure[] = allResults.flatMap((r) => r.hunkFailures);
@@ -590,7 +596,7 @@ export async function runSkillTask(
             findings: [],
             usage: aggregateUsage(allUsage),
             durationMs: duration,
-            model: runnerOptions?.model,
+            model: resolvedModel,
             runtime,
             // Preserve per-file metadata (timing, partial usage, attempted
             // filenames) on failure runs too — `warden runs` and JSONL
@@ -668,7 +674,7 @@ export async function runSkillTask(
           findings: finalFindings,
           usage: aggregateUsage(allUsage),
           durationMs: duration,
-          model: runnerOptions?.model,
+          model: resolvedModel,
           runtime,
           files: buildFileReports(
             preparedFiles.map((file, i) => {
@@ -733,7 +739,7 @@ export async function runSkillTask(
           summary: `${skillName}: failed (${code})`,
           findings: [],
           durationMs: Date.now() - startTime,
-          model: runnerOptions?.model,
+          model: resolvedModel ?? runnerOptions?.model,
           runtime,
           error: { code, message, timestamp: new Date().toISOString() },
         };

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -405,6 +405,53 @@ describe('analyzeFile', () => {
     consoleSpy.mockRestore();
   });
 
+  it('preserves the response model when the circuit opens on an SDK-reported provider error', async () => {
+    const controller = new AbortController();
+    const circuitBreaker = new ProviderFailureCircuitBreaker({
+      maxConsecutiveProviderFailures: 1,
+      abortController: controller,
+    });
+    const runSkillMock = vi.fn().mockResolvedValue({
+      result: {
+        status: 'provider_error',
+        text: '',
+        errors: ['upstream provider error'],
+        usage: makeUsage(),
+        responseModel: 'claude-sonnet-4-5-20260929',
+      },
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const result = await analyzeFile(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makePreparedFile(1),
+      '/tmp/repo',
+      {
+        abortController: controller,
+        circuitBreaker,
+        retry: {
+          maxRetries: 0,
+          initialDelayMs: 1,
+          backoffMultiplier: 1,
+          maxDelayMs: 1,
+        },
+      },
+    );
+
+    expect(circuitBreaker.reason?.code).toBe('provider_unavailable');
+    expect(result.failedHunks).toBe(1);
+    expect(result.responseModels).toEqual(['claude-sonnet-4-5-20260929']);
+  });
+
   it('opens the shared circuit after consecutive provider failures', async () => {
     const controller = new AbortController();
     const circuitBreaker = new ProviderFailureCircuitBreaker({
@@ -787,6 +834,116 @@ describe('runSkill', () => {
 
     expect(report.summary).toBe('No code changes to analyze');
     expect(report.runtime).toBe('pi');
+  });
+
+  it('reports the model that actually answered when no model override is configured', async () => {
+    const runSkillMock = vi.fn().mockResolvedValue({
+      result: {
+        status: 'success',
+        text: JSON.stringify({ findings: [] }),
+        errors: [],
+        usage: makeUsage(),
+        responseModel: 'claude-sonnet-4-5-20260929',
+      },
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const report = await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makeContextWithOneHunk(),
+      {},
+    );
+
+    expect(report.model).toBe('claude-sonnet-4-5-20260929');
+  });
+
+  it('falls back to the configured model when hunks report different response models', async () => {
+    const runSkillMock = vi.fn()
+      .mockResolvedValueOnce({
+        result: {
+          status: 'success',
+          text: JSON.stringify({ findings: [] }),
+          errors: [],
+          usage: makeUsage(),
+          responseModel: 'claude-sonnet-4-5-20260929',
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          status: 'success',
+          text: JSON.stringify({ findings: [] }),
+          errors: [],
+          usage: makeUsage(),
+          responseModel: 'claude-opus-4-8-20260601',
+        },
+      });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const report = await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      makeContextWithTwoHunks(),
+      { model: 'configured-alias' },
+    );
+
+    expect(report.model).toBe('configured-alias');
+  });
+
+  it('attributes each skill its own response model when multiple skills run concurrently', async () => {
+    const modelBySkill: Record<string, string> = {
+      'skill-a': 'model-a',
+      'skill-b': 'model-b',
+      'skill-c': 'model-c',
+    };
+    const runSkillMock = vi.fn(async ({ skillName }: { skillName: string }) => ({
+      result: {
+        status: 'success',
+        text: JSON.stringify({ findings: [] }),
+        errors: [],
+        usage: makeUsage(),
+        responseModel: modelBySkill[skillName],
+      },
+    }));
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'claude',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+
+    const [reportA, reportB, reportC] = await Promise.all(
+      Object.keys(modelBySkill).map((skillName) =>
+        runSkill(
+          { name: skillName, description: `${skillName} description.`, prompt: 'Return findings as JSON.' },
+          makeContextWithOneHunk(),
+          {},
+        )
+      )
+    );
+
+    expect(reportA!.skill).toBe('skill-a');
+    expect(reportA!.model).toBe('model-a');
+    expect(reportB!.skill).toBe('skill-b');
+    expect(reportB!.model).toBe('model-b');
+    expect(reportC!.skill).toBe('skill-c');
+    expect(reportC!.model).toBe('model-c');
   });
 
   it('preserves candidate findings when verification is interrupted', async () => {

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -8,7 +8,7 @@ import { SkillRunnerError, WardenAuthenticationError, isRetryableError, isAuthen
 import { genAiProviderName } from './otel.js';
 import type { CircuitBreakerReason } from './circuit-breaker.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
-import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage, aggregateAuxiliaryUsageAttribution } from './usage.js';
+import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage, aggregateAuxiliaryUsageAttribution, resolveResponseModel } from './usage.js';
 import { buildHunkSystemPrompt, buildHunkUserPrompt, type PRPromptContext } from './prompt.js';
 import { extractFindingsJson, extractFindingsWithLLM, validateFindings } from './extract.js';
 import type { ExtractFindingsResult } from './extract.js';
@@ -74,6 +74,7 @@ function hunkFailureFromCircuit(
   usage: UsageStats[],
   attempts: number,
   trace?: HunkTrace,
+  responseModel?: string,
 ): HunkAnalysisResult {
   return {
     findings: [],
@@ -84,6 +85,7 @@ function hunkFailureFromCircuit(
     failureMessage: reason.message,
     attempts,
     trace,
+    responseModel,
   };
 }
 
@@ -517,6 +519,7 @@ async function analyzeHunk(
                   result: resultMessage,
                   traceRecorder,
                 }),
+                resultMessage.responseModel,
               );
             }
             return {
@@ -527,6 +530,7 @@ async function analyzeHunk(
               failureCode,
               failureMessage,
               attempts: attempt + 1,
+              responseModel: resultMessage.responseModel,
               trace: buildHunkTrace({
                 enabled: options.captureTraces,
                 span,
@@ -601,6 +605,7 @@ async function analyzeHunk(
                   runtime: runtimeName,
                 }]
               : undefined,
+            responseModel: resultMessage.responseModel,
             trace: buildHunkTrace({
               enabled: options.captureTraces,
               span,
@@ -842,6 +847,7 @@ export async function analyzeFile(
       const fileAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
       const hunkFailures: HunkFailure[] = [];
       const hunkTraces: HunkTrace[] = [];
+      const fileResponseModels: string[] = [];
       let failedHunks = 0;
       let failedExtractions = 0;
 
@@ -899,6 +905,9 @@ export async function analyzeFile(
         if (result.trace) {
           hunkTraces.push(result.trace);
         }
+        if (result.responseModel) {
+          fileResponseModels.push(result.responseModel);
+        }
         const chunkResult: ChunkAnalysisResult = {
           filename: file.filename,
           model: options.model,
@@ -939,6 +948,7 @@ export async function analyzeFile(
         hunkFailures,
         auxiliaryUsage: fileAuxiliaryUsage.length > 0 ? fileAuxiliaryUsage : undefined,
         traces: hunkTraces.length > 0 ? hunkTraces : undefined,
+        responseModels: fileResponseModels.length > 0 ? fileResponseModels : undefined,
       };
     },
   );
@@ -1044,6 +1054,7 @@ async function runSkillAnalysis(
   const allUsage: UsageStats[] = [];
   const allAuxiliaryUsage: AuxiliaryUsageEntry[] = [];
   const allTraces: HunkTrace[] = [];
+  const allResponseModels: string[] = [];
 
   // Track failed hunks across all files
   let totalFailedHunks = 0;
@@ -1173,6 +1184,9 @@ async function runSkillAnalysis(
     if (fr.result.traces) {
       allTraces.push(...fr.result.traces);
     }
+    if (fr.result.responseModels) {
+      allResponseModels.push(...fr.result.responseModels);
+    }
   }
 
   // All hunks failed — typically a systemic problem (auth, subprocess, etc).
@@ -1266,7 +1280,7 @@ async function runSkillAnalysis(
     findings: finalFindings,
     usage: totalUsage,
     durationMs: Date.now() - startTime,
-    model: options.model,
+    model: resolveResponseModel(allResponseModels, options.model),
     files: buildFileReports(
       fileResults.map((fr) => ({
         filename: fr.filename,

--- a/packages/warden/src/sdk/runner.ts
+++ b/packages/warden/src/sdk/runner.ts
@@ -22,7 +22,7 @@ export { verifyAuth } from './auth.js';
 export { calculateRetryDelay } from './retry.js';
 
 // Re-export usage utilities
-export { aggregateUsage, aggregateAuxiliaryUsage, mergeAuxiliaryUsage, estimateTokens } from './usage.js';
+export { aggregateUsage, aggregateAuxiliaryUsage, mergeAuxiliaryUsage, estimateTokens, resolveResponseModel } from './usage.js';
 
 // Re-export pricing utilities
 export { anthropicUsageToStats, apiUsageToStats } from './pricing.js';

--- a/packages/warden/src/sdk/types.ts
+++ b/packages/warden/src/sdk/types.ts
@@ -48,6 +48,8 @@ export interface HunkAnalysisResult {
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   /** Optional runtime trace captured for this hunk. */
   trace?: HunkTrace;
+  /** Model that actually answered this hunk, from the live API response. */
+  responseModel?: string;
 }
 
 /** Result from one completed chunk, suitable for durable run logging. */
@@ -225,6 +227,8 @@ export interface FileAnalysisResult {
   auxiliaryUsage?: AuxiliaryUsageEntry[];
   /** Optional runtime traces captured for analyzed hunks. */
   traces?: HunkTrace[];
+  /** Models that actually answered this file's hunks, from the live API responses. */
+  responseModels?: string[];
 }
 
 /**

--- a/packages/warden/src/sdk/usage.ts
+++ b/packages/warden/src/sdk/usage.ts
@@ -113,6 +113,12 @@ function uniqueSorted(values: (string | undefined)[]): string[] | undefined {
   return unique.length > 0 ? unique : undefined;
 }
 
+/** Collapses a run's observed response models to a single value when they agree, or falls back. */
+export function resolveResponseModel(models: string[], fallback?: string): string | undefined {
+  const unique = [...new Set(models)];
+  return unique.length === 1 ? unique[0] : fallback;
+}
+
 function attributionFromEntries(entries: AuxiliaryUsageEntry[]): UsageAttribution | undefined {
   const models = uniqueSorted(entries.map((entry) => entry.model));
   const runtimes = uniqueSorted(entries.map((entry) => entry.runtime));


### PR DESCRIPTION
## Summary

`SkillReport.model` only ever echoes the caller-configured model (`options.model` / `trigger.model`). When no model override is configured at any of the 4 levels a run can set one (per-skill, `defaults.agent`, `defaults`, per-trigger), this field is always `undefined` — even though the runtime already knows exactly which model answered each hunk.

The runtime normalizes this today as `SkillRunResult.responseModel` (sourced from the live API response, see `runtimes/claude.ts`'s `normalizeResult`), but it only ever fed an opt-in `HunkTrace` object (`captureTraces`) and OTel spans — never the exported `SkillReport.model` that findings-file consumers actually read.

This threads `responseModel` from every `analyzeHunk` return path that has a live API response — including the circuit-breaker-opens-on-an-SDK-error path via `hunkFailureFromCircuit`, which now accepts and forwards it — up through `analyzeFile` and both independent report-construction sites: `sdk/analyze.ts`'s `runSkillAnalysis` and the CLI's separate `tasks.ts` pipeline (`tasks.ts` drives `analyzeFile` directly with its own aggregation rather than calling `runSkillAnalysis`, so both need the same treatment).

Collapses to a single value via a new `resolveResponseModel(models, fallback)` helper in `usage.ts` when every hunk in the run agrees, falling back to the configured override when hunks disagree or none reported one — mirroring the existing model/models singular-vs-plural collapse pattern already used for `auxiliaryUsageAttribution`.

No schema change: `SkillReportSchema.model` already accepted a string, this only changes which value populates it.

## Test plan

- `pnpm lint && pnpm build && pnpm test` — all green (93 test files, 1832 passing, 4 pre-existing skips)
- Regression coverage for: the single-model case, the fallback-on-disagreement case, the circuit-breaker-with-a-live-response case, and — since this value is computed per independent skill execution — that concurrent skills each get their own model correctly attributed rather than any cross-skill bleed