### PR TITLE
feat(reporting): add configuredSkills roster to findings output

### DIFF
--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -1882,6 +1882,16 @@ describe('runPRWorkflow', () => {
         })
       );
       expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockWriteFindingsOutput).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          repository: expect.objectContaining({ fullName: 'test-owner/test-repo' }),
+        }),
+        [],
+        expect.objectContaining({
+          configuredSkills: [{ name: 'test-skill', triggered: true }],
+        })
+      );
     });
 
     it('fails when findings exceed fail-on threshold and failCheck is true', async () => {

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -26,6 +26,7 @@ const RUNTIME_CLAUDE_FIXTURES_DIR = join(FIXTURES_DIR, 'runtime-claude');
 const EMPTY_AUXILIARY_MODEL_FIXTURES_DIR = join(FIXTURES_DIR, 'empty-auxiliary-model');
 const LAYERED_AUXILIARY_MODEL_FIXTURES_DIR = join(FIXTURES_DIR, 'layered-auxiliary-model');
 const NO_MATCH_EMPTY_AUXILIARY_MODEL_FIXTURES_DIR = join(FIXTURES_DIR, 'no-match-empty-auxiliary-model');
+const SCHEDULE_ONLY_FIXTURES_DIR = join(FIXTURES_DIR, 'schedule');
 const EVENT_PAYLOAD_PATH = join(FIXTURES_DIR, 'event-payloads/pull_request_opened.json');
 const PR_HEAD_SHA = 'abc123def456';
 const PREVIOUS_HEAD_SHA = 'previous123sha456';
@@ -392,6 +393,30 @@ describe('runPRWorkflow', () => {
             }),
           ],
           skillExecutions: [expect.objectContaining({ report, skillExecutionId: expect.any(String) })],
+          configuredSkills: [{ name: 'test-skill', triggered: true }],
+        })
+      );
+    });
+
+    it('analyze mode lists a schedule-only skill as configured but not triggered on a PR run', async () => {
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs({ mode: 'analyze' }),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        SCHEDULE_ONLY_FIXTURES_DIR
+      );
+
+      expect(mockRunSkillTask).not.toHaveBeenCalled();
+      expect(mockWriteFindingsOutput).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          repository: expect.objectContaining({ fullName: 'test-owner/test-repo' }),
+        }),
+        [],
+        expect.objectContaining({
+          triggerResults: [],
+          configuredSkills: [{ name: 'test-skill', triggered: false }],
         })
       );
     });
@@ -2730,7 +2755,9 @@ describe('runPRWorkflow', () => {
             resolvedReason: 'fix_evaluation',
           }),
         ],
-        expect.any(Object)
+        expect.objectContaining({
+          configuredSkills: [{ name: 'test-skill', triggered: false }],
+        })
       );
     });
 

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -447,6 +447,22 @@ describe('runPRWorkflow', () => {
       );
     });
 
+    it('analyze mode includes configuredSkills in the live findings snapshot', async () => {
+      mockRunSkillTask.mockResolvedValue({ name: 'test-trigger', report: createSkillReport({ skill: 'test-skill' }) });
+
+      await runPRWorkflow(
+        mockOctokit,
+        createDefaultInputs({ mode: 'analyze' }),
+        'pull_request',
+        EVENT_PAYLOAD_PATH,
+        FIXTURES_DIR
+      );
+
+      expect(mockWriteFindingsOutputLive).toHaveBeenCalledTimes(1);
+      const [, , , liveOptions] = mockWriteFindingsOutputLive.mock.calls[0]!;
+      expect(liveOptions?.configuredSkills).toEqual([{ name: 'test-skill', triggered: true }]);
+    });
+
     it('report mode carries skillExecutionId and resolvedDefaults into the final findings output', async () => {
       const finding = createFinding();
       const report = createSkillReport({ findings: [finding] });
@@ -1668,6 +1684,7 @@ describe('runPRWorkflow', () => {
         expect.objectContaining({ skillExecutionId: expect.any(String), triggerName: 'test-skill' }),
       ]);
       expect(liveOptions?.skippedTriggers).toEqual([]);
+      expect(liveOptions?.configuredSkills).toEqual([{ name: 'test-skill', triggered: true }]);
 
       // The final write happens after the live write and includes the same enrichment.
       const [, , , finalOptions] = mockWriteFindingsOutput.mock.calls[0]!;

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -2396,6 +2396,7 @@ export async function runPRWorkflow(
               reason: 'error' as const,
             })),
           ]),
+          configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
         };
         try {
           writeFindingsOutput([], context, [], findingsOptions);

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -98,6 +98,7 @@ import {
   FindingsOutputSchema,
   buildFindingsOutput,
   buildBaseOutputOptions,
+  buildConfiguredSkillsList,
   type SkippedTriggerReasonSchema,
   type FindingsOutput,
   type ReplayTriggerResult,
@@ -114,6 +115,7 @@ interface InitResult {
   service?: ResolvedServiceOptions;
   runnerConcurrency?: number;
   auxiliaryOptions: AuxiliaryWorkflowOptions;
+  resolvedTriggers: ResolvedTrigger[];
   matchedTriggers: ResolvedTrigger[];
   skippedTriggers: ResolvedTrigger[];
   memoryRecall?: ActionMemoryRecall;
@@ -469,6 +471,7 @@ async function initializeWorkflow(
       service,
       runnerConcurrency,
       auxiliaryOptions,
+      resolvedTriggers,
       matchedTriggers,
       skippedTriggers,
       memoryRecall,
@@ -486,6 +489,7 @@ async function initializeWorkflow(
         service: resolveActionServiceOptions(inputs),
         runnerConcurrency,
         auxiliaryOptions,
+        resolvedTriggers: [],
         matchedTriggers: [],
         skippedTriggers: [],
         skipCoreCheck: {
@@ -1165,6 +1169,8 @@ async function finalizeWorkflow(
   inputs: ActionInputs,
   service: ResolvedServiceOptions | undefined,
   memoryRecall: ActionMemoryRecall | undefined,
+  matchedTriggers: ResolvedTrigger[],
+  resolvedTriggers: ResolvedTrigger[]
 ): Promise<void> {
   await dismissPreviousReviewIfResolved(
     octokit,
@@ -1189,6 +1195,7 @@ async function finalizeWorkflow(
     skillExecutions: toSkillExecutions(results),
     recalledMemories: memoryRecall?.memories.map(({ id, version }) => ({ id, version })),
     memoryRecallId: memoryRecall?.clientRecallId,
+    configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
   };
   try {
     const findingsPath = writeFindingsOutput(reports, context, findingObservations, findingsOptions);
@@ -1800,6 +1807,8 @@ async function finalizeReportWorkflow(
     service?: ResolvedServiceOptions;
     recalledMemories?: readonly { id: string; version: number }[];
     memoryRecallId?: string;
+    matchedTriggers?: ResolvedTrigger[];
+    resolvedTriggers?: ResolvedTrigger[];
   }
 ): Promise<void> {
   await dismissPreviousReviewIfResolved(
@@ -1824,6 +1833,10 @@ async function finalizeReportWorkflow(
     skillExecutions: toSkillExecutions(results),
     recalledMemories: options.recalledMemories,
     memoryRecallId: options.memoryRecallId,
+    configuredSkills: buildConfiguredSkillsList({
+      allTriggers: options.resolvedTriggers ?? [],
+      matchedTriggers: options.matchedTriggers ?? [],
+    }),
   };
   try {
     const findingsPath = writeFindingsOutput(reports, context, findingObservations, findingsOptions);
@@ -1953,6 +1966,7 @@ async function runAnalyzeMode(
   const {
     context,
     runnerConcurrency,
+    resolvedTriggers,
     matchedTriggers,
     skippedTriggers,
     skipCoreCheck,
@@ -1967,6 +1981,7 @@ async function runAnalyzeMode(
       const findingsPath = writeFindingsOutput([], context, [], {
         triggerResults: [],
         ...buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context)),
+        configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
       });
       logAction(`Findings written to ${findingsPath}`);
     } catch (error) {
@@ -2012,6 +2027,7 @@ async function runAnalyzeMode(
       skillExecutions: toSkillExecutions(results),
       recalledMemories: memoryRecall?.memories.map(({ id, version }) => ({ id, version })),
       memoryRecallId: memoryRecall?.clientRecallId,
+      configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
     });
     logAction(`Findings written to ${findingsPath}`);
   } catch (error) {
@@ -2037,6 +2053,7 @@ async function runReportMode(
     context,
     service,
     auxiliaryOptions,
+    resolvedTriggers,
     matchedTriggers,
     skippedTriggers,
     skipCoreCheck,
@@ -2065,6 +2082,7 @@ async function runReportMode(
         triggerResults: [],
         ...buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context)),
         ...replayMemoryOptions,
+        configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
       } satisfies BuildFindingsOutputOptions;
       try {
         const findingsPath = writeFindingsOutput([], context, [], findingsOptions);
@@ -2104,6 +2122,7 @@ async function runReportMode(
         triggerResults: [],
         ...buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context)),
         ...replayMemoryOptions,
+        configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
       } satisfies BuildFindingsOutputOptions;
       try {
         const findingsPath = writeFindingsOutput([], context, cleanupFindingObservations, findingsOptions);
@@ -2182,7 +2201,15 @@ async function runReportMode(
       canResolveStale,
       gate,
       triggerErrors,
-      { failOnWriteError: true, skippedTriggers, inputs, service, ...replayMemoryOptions },
+      {
+        failOnWriteError: true,
+        skippedTriggers,
+        inputs,
+        service,
+        ...replayMemoryOptions,
+        matchedTriggers,
+        resolvedTriggers,
+      },
     );
   } catch (error) {
     if (error instanceof ActionFailedError) {
@@ -2229,6 +2256,7 @@ export async function runPRWorkflow(
         service,
         runnerConcurrency,
         auxiliaryOptions,
+        resolvedTriggers,
         matchedTriggers,
         skippedTriggers,
         skipCoreCheck,
@@ -2279,7 +2307,10 @@ export async function runPRWorkflow(
         setOutput('findings-count', 0);
         setOutput('high-count', 0);
         setOutput('summary', skipCoreCheck.title);
-        const findingsOptions = buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context));
+        const findingsOptions = {
+          ...buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context)),
+          configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
+        };
         try {
           writeFindingsOutput([], context, [], findingsOptions);
         } catch (error) {
@@ -2301,7 +2332,10 @@ export async function runPRWorkflow(
           setOutput('findings-count', 0);
           setOutput('high-count', 0);
           setOutput('summary', 'No triggers matched');
-          const findingsOptions = buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context));
+          const findingsOptions = {
+            ...buildBaseOutputOptions(inputs, toSkippedTriggers(skippedTriggers, context)),
+            configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
+          };
           try {
             writeFindingsOutput([], context, cleanupFindingObservations, findingsOptions);
           } catch (error) {
@@ -2429,6 +2463,8 @@ export async function runPRWorkflow(
         inputs,
         service,
         memoryRecall,
+        matchedTriggers,
+        resolvedTriggers,
       );
 
       handleTriggerErrors(triggerErrors, matchedTriggers.length);

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -1807,8 +1807,8 @@ async function finalizeReportWorkflow(
     service?: ResolvedServiceOptions;
     recalledMemories?: readonly { id: string; version: number }[];
     memoryRecallId?: string;
-    matchedTriggers?: ResolvedTrigger[];
-    resolvedTriggers?: ResolvedTrigger[];
+    matchedTriggers: ResolvedTrigger[];
+    resolvedTriggers: ResolvedTrigger[];
   }
 ): Promise<void> {
   await dismissPreviousReviewIfResolved(
@@ -1834,8 +1834,8 @@ async function finalizeReportWorkflow(
     recalledMemories: options.recalledMemories,
     memoryRecallId: options.memoryRecallId,
     configuredSkills: buildConfiguredSkillsList({
-      allTriggers: options.resolvedTriggers ?? [],
-      matchedTriggers: options.matchedTriggers ?? [],
+      allTriggers: options.resolvedTriggers,
+      matchedTriggers: options.matchedTriggers,
     }),
   };
   try {

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -2007,6 +2007,7 @@ async function runAnalyzeMode(
             ...toErroredSkippedTriggers(completedSoFar),
           ]),
           skillExecutions: toSkillExecutions(completedSoFar),
+          configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
         });
       },
     }),
@@ -2372,6 +2373,7 @@ export async function runPRWorkflow(
                   ...toErroredSkippedTriggers(completedSoFar),
                 ]),
                 skillExecutions: toSkillExecutions(completedSoFar),
+                configuredSkills: buildConfiguredSkillsList({ allTriggers: resolvedTriggers, matchedTriggers }),
               });
             },
           }),

--- a/packages/warden/src/reporting/output.test.ts
+++ b/packages/warden/src/reporting/output.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { EventContext, Finding, SkillReport } from '../types/index.js';
-import { buildFindingsOutput, buildResolvedDefaults, FindingsOutputSchema } from './output.js';
+import {
+  buildConfiguredSkillsList,
+  buildFindingsOutput,
+  buildResolvedDefaults,
+  FindingsOutputSchema,
+} from './output.js';
 
 describe('findings output schema', () => {
   it('builds a schema-valid public findings payload', () => {
@@ -716,6 +721,68 @@ describe('findings output schema', () => {
       { skillExecutionId: 'exec-security', skillName: 'security-skill', role: 'primary' },
       { skillName: 'style-skill', role: 'corroborating', matchType: 'semantic' },
     ]);
+  });
+
+  it('includes the configured skills roster when provided', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+      configuredSkills: [
+        { name: 'test-skill', triggered: true },
+        { name: 'idle-skill', triggered: false },
+      ],
+    });
+
+    expect(FindingsOutputSchema.parse(output)).toEqual(output);
+    expect(output.configuredSkills).toEqual([
+      { name: 'test-skill', triggered: true },
+      { name: 'idle-skill', triggered: false },
+    ]);
+  });
+
+  it('omits the configured skills roster when not provided', () => {
+    const output = buildFindingsOutput([createReport()], createContext(), [], {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: '123',
+    });
+
+    expect(output.configuredSkills).toBeUndefined();
+  });
+});
+
+describe('buildConfiguredSkillsList', () => {
+  it('marks matched skills as triggered and unmatched skills as not', () => {
+    const result = buildConfiguredSkillsList({
+      allTriggers: [{ name: 'matched-skill' }, { name: 'skipped-skill' }],
+      matchedTriggers: [{ name: 'matched-skill' }],
+    });
+
+    expect(result).toEqual([
+      { name: 'matched-skill', triggered: true },
+      { name: 'skipped-skill', triggered: false },
+    ]);
+  });
+
+  it('deduplicates multiple trigger blocks for the same skill', () => {
+    const result = buildConfiguredSkillsList({
+      allTriggers: [{ name: 'multi-trigger-skill' }, { name: 'multi-trigger-skill' }],
+      matchedTriggers: [{ name: 'multi-trigger-skill' }],
+    });
+
+    expect(result).toEqual([{ name: 'multi-trigger-skill', triggered: true }]);
+  });
+
+  it('returns an empty list when nothing is configured', () => {
+    expect(buildConfiguredSkillsList({ allTriggers: [], matchedTriggers: [] })).toEqual([]);
+  });
+
+  it('includes a skill whose only trigger is neither matched nor a PR-check skip', () => {
+    const result = buildConfiguredSkillsList({
+      allTriggers: [{ name: 'nightly-sweep' }],
+      matchedTriggers: [],
+    });
+
+    expect(result).toEqual([{ name: 'nightly-sweep', triggered: false }]);
   });
 });
 

--- a/packages/warden/src/reporting/output.ts
+++ b/packages/warden/src/reporting/output.ts
@@ -312,6 +312,7 @@ export function buildBaseOutputOptions(
   };
 }
 
+/** Build the configured-skills roster, deduping by name since a skill's multiple trigger blocks (e.g. PR + schedule) share one name. */
 export function buildConfiguredSkillsList({
   allTriggers,
   matchedTriggers,

--- a/packages/warden/src/reporting/output.ts
+++ b/packages/warden/src/reporting/output.ts
@@ -227,6 +227,10 @@ export const FindingsOutputSchema = z.object({
   discardedFindings: z.array(DiscardedFindingSchema).optional(),
   triggerResults: z.array(TriggerRunResultSchema).optional(),
   findingObservations: z.array(FindingObservationSchema).default([]),
+  configuredSkills: z.array(z.object({
+    name: z.string(),
+    triggered: z.boolean(),
+  })).optional(),
 });
 
 export type FindingsOutput = z.infer<typeof FindingsOutputSchema>;
@@ -271,6 +275,7 @@ export interface BuildFindingsOutputOptions {
   skillExecutions?: SkillExecutionMeta[];
   recalledMemories?: readonly { id: string; version: number }[];
   memoryRecallId?: string;
+  configuredSkills?: { name: string; triggered: boolean }[];
 }
 
 /** Build the action-level `resolvedDefaults` block from parsed action inputs. */
@@ -305,6 +310,26 @@ export function buildBaseOutputOptions(
     resolvedDefaults: buildResolvedDefaults(inputs),
     skippedTriggers,
   };
+}
+
+export function buildConfiguredSkillsList({
+  allTriggers,
+  matchedTriggers,
+}: {
+  allTriggers: { name: string }[];
+  matchedTriggers: { name: string }[];
+}): { name: string; triggered: boolean }[] {
+  const matchedNames = new Set(matchedTriggers.map((t) => t.name));
+  const seen = new Set<string>();
+  const result: { name: string; triggered: boolean }[] = [];
+
+  for (const trigger of allTriggers) {
+    if (seen.has(trigger.name)) continue;
+    seen.add(trigger.name);
+    result.push({ name: trigger.name, triggered: matchedNames.has(trigger.name) });
+  }
+
+  return result;
 }
 
 function serializeTriggerError(error: unknown): z.infer<typeof TriggerErrorSchema> {
@@ -516,6 +541,7 @@ export function buildFindingsOutput(
       triggerResults: options.triggerResults.map(serializeTriggerResult),
     }),
     findingObservations,
+    ...(options.configuredSkills && { configuredSkills: options.configuredSkills }),
   };
 
   return FindingsOutputSchema.parse(output);


### PR DESCRIPTION
## Summary

The `warden-findings.json` export lists what ran, but not what was *configured* to run — there's no way for a downstream consumer to distinguish "this skill has no findings because nothing was wrong" from "this skill never ran on this event." A schedule-only or local-only skill is invisible on every PR run, not just absent.

This adds a top-level `configuredSkills: { name: string; triggered: boolean }[]` field: the full roster of skills configured for the repo, each flagged with whether it actually triggered for this run. `buildConfiguredSkillsList` computes it from the full resolved-trigger set against the matched subset, deduping by name since a skill can have multiple trigger blocks (e.g. a PR trigger and a schedule trigger) that share one name.

No schema change to existing fields: the field is new and optional, so existing consumers see no difference unless they read it.

## Test plan

- `pnpm lint && pnpm build && pnpm test` — all green (93 test files, 1833 passing, 4 pre-existing skips)
- Coverage for: the roster shape when provided, the field's absence when not provided, `buildConfiguredSkillsList`'s dedup/match/empty-input behavior, and a schedule-only skill correctly appearing as configured-but-not-triggered on a PR run