### PR TITLE
ci(release): Build service API before Action bundle

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build service API
+        run: pnpm --filter @sentry/warden-service-api build
+
       - name: Build action bundle
         run: pnpm build:action
 


### PR DESCRIPTION
Build the service API workspace package before bundling the GitHub Action.\n\nThe v0.46.0 npm publish succeeded, but its tag-update workflow could not resolve the unbuilt workspace dependency. This restores the release path so a patch release can publish the bundled Action and advance the v0 tag.