### PR TITLE
fix(service): Use Vercel Node request adapter

### DIFF
--- a/apps/warden-service/api/[[...route]].ts
+++ b/apps/warden-service/api/[[...route]].ts
@@ -1,4 +1,4 @@
-import { handle } from 'hono/vercel';
+import { handle } from '@hono/node-server/vercel';
 import { createVercelWardenService } from '../src/create-app.js';
 
 export const runtime = 'nodejs';

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -1,4 +1,6 @@
 import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ServiceEnvironmentSchema } from '@sentry/warden-service';
 
@@ -107,9 +109,19 @@ describe('Vercel service app', () => {
 
     expect(route.runtime).toBe('nodejs');
     expect(route.maxDuration).toBe(30);
-    const response = await route.default(new Request('https://warden.example/health'));
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: 'ok', service: 'warden-service' });
+    const server = createServer(route.default);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ status: 'ok', service: 'warden-service' });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      }));
+    }
   });
 
   it('starts Google OAuth when auth is enabled by default', async () => {

--- a/apps/warden-service/tsconfig.json
+++ b/apps/warden-service/tsconfig.json
@@ -9,6 +9,7 @@
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
     "noPropertyAccessFromIndexSignature": true,
+    "types": ["node"],
     "skipLibCheck": true
   },
   "include": ["api/**/*.ts", "examples/**/*.ts", "src/**/*.ts", "vitest.config.ts"],


### PR DESCRIPTION
Use the Hono Node adapter expected by Vercel functions and make Node types explicit during function compilation.

The production deployment returned a Web Response from a default Node handler. Vercel ignored that return value and timed out every API request. The regression test now exercises the entrypoint through a real Node HTTP server.