### PR TITLE
fix(service): Stop Vercel rewrite from polluting queries

### DIFF
--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -27,7 +27,8 @@ describe('Vercel service app', () => {
       { source: '/health', destination: '/api' },
       { source: '/ready', destination: '/api' },
     ]));
-    expect(config.rewrites).toContainEqual({ source: '/api/:path*', destination: '/api' });
+    expect(config.rewrites).toContainEqual({ source: '/api/(.*)', destination: '/api' });
+    expect(config.rewrites).not.toContainEqual({ source: '/api/:path*', destination: '/api' });
     expect(ServiceEnvironmentSchema.safeParse({}).success).toBe(false);
   });
 

--- a/apps/warden-service/vercel.json
+++ b/apps/warden-service/vercel.json
@@ -17,7 +17,7 @@
   ],
   "rewrites": [
     {
-      "source": "/api/:path*",
+      "source": "/api/(.*)",
       "destination": "/api"
     },
     {


### PR DESCRIPTION
Replace the named API rewrite capture with an unnamed wildcard.

Vercel forwards unused named captures as query parameters. The resulting `path` parameter made strict findings, outcomes, and cost endpoints reject otherwise valid dashboard requests with HTTP 400. The unnamed wildcard preserves routing without mutating API queries.

This also updates the Vercel configuration regression test to prevent the named capture from returning.