### PR TITLE
fix(service): Keep OAuth redirects on the current origin

### DIFF
--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -152,11 +152,11 @@ describe('Vercel service app', () => {
 
     const page = await app.request('https://warden.example/');
     expect(page.status).toBe(302);
-    expect(page.headers.get('location')).toBe('https://warden.example/api/auth/login');
+    expect(page.headers.get('location')).toBe('/api/auth/login');
 
     const asset = await app.request('https://warden.example/assets/app.js');
     expect(asset.status).toBe(302);
-    expect(asset.headers.get('location')).toBe('https://warden.example/api/auth/login');
+    expect(asset.headers.get('location')).toBe('/api/auth/login');
     expect((await app.request('https://warden.example/index.html')).status).toBe(302);
 
     const response = await app.request('https://warden.example/api/auth/login');

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -157,7 +157,7 @@ describe('createWardenService', () => {
     session = null;
     const protectedPage = await app.request('https://warden.example/');
     expect(protectedPage.status).toBe(302);
-    expect(protectedPage.headers.get('location')).toBe('https://warden.example/api/auth/login');
+    expect(protectedPage.headers.get('location')).toBe('/api/auth/login');
     expect((await app.request('https://warden.example/assets/app.js')).status).toBe(302);
     expect((await app.request('https://warden.example/api/auth/login')).headers.get('location'))
       .toBe('https://accounts.google.com/');

--- a/packages/warden-service/src/app.ts
+++ b/packages/warden-service/src/app.ts
@@ -78,9 +78,7 @@ function createDisabledAuthenticationAdapter(tenantId: string): DashboardAuthent
 function requireDashboardSession(authentication?: DashboardAuthenticationAdapter) {
   return createMiddleware<{ Variables: ServiceVariables }>(async (context, next) => {
     const serviceContext = await authentication?.authenticate(context.req.raw) ?? null;
-    if (!serviceContext) {
-      return context.redirect(new URL('/api/auth/login', context.req.url).toString());
-    }
+    if (!serviceContext) return context.redirect('/api/auth/login');
     if (!hasRole(serviceContext, 'read')) {
       return context.json({ error: { code: 'forbidden', message: 'Permission denied.' } }, 403);
     }


### PR DESCRIPTION
Use a relative dashboard login redirect.

Vercel's Node adapter reports its internal HTTP request URL, so constructing an absolute URL produced an `http://warden-prod.sentry.dev` redirect from the HTTPS site. A same-origin relative redirect lets the browser preserve the public scheme and host while retaining the OAuth gate added in #481.