### PR TITLE
fix(service): Buffer API bodies before authentication

### DIFF
--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -93,6 +93,51 @@ describe('createWardenService', () => {
     expect(response.status).toBe(413);
   });
 
+  it('buffers request bodies before asynchronous authentication', async () => {
+    const encoded = new TextEncoder().encode('{}');
+    let bodyRead = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        bodyRead = true;
+        controller.enqueue(encoded);
+        controller.close();
+      },
+    }, { highWaterMark: 0 });
+    const app = createWardenService({
+      database: readyDatabase(),
+      dashboardAuth: {
+        async authenticate() {
+          if (!bodyRead) throw new Error('request body was not buffered');
+          return {
+            tenantId: '00000000-0000-4000-8000-000000000001',
+            tokenId: null,
+            roles: ['ingest'],
+            repositoryAllowlist: null,
+            credentialKind: 'browser',
+          };
+        },
+      },
+    });
+    const request = new Request('http://localhost/api/v1/runs', {
+      method: 'POST',
+      headers: {
+        'content-length': String(encoded.byteLength),
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+      },
+      body,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+
+    const response = await app.request(request);
+
+    expect(bodyRead).toBe(true);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: 'invalid_envelope', message: 'Run envelope is not valid.' },
+    });
+  });
+
   it('never passes bearer credentials to rate-limit hooks or reflects thrown content', async () => {
     const inputs: unknown[] = [];
     const app = createWardenService({

--- a/packages/warden-service/src/app.ts
+++ b/packages/warden-service/src/app.ts
@@ -1,6 +1,5 @@
 import { ApiErrorSchema } from '@sentry/warden-service-api';
 import { Hono } from 'hono';
-import { bodyLimit } from 'hono/body-limit';
 import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
 import { authenticate, requireRole } from './auth.js';
@@ -97,6 +96,41 @@ function validatedJson<TSchema extends z.ZodType>(
   return context.json(schema.parse(value), status);
 }
 
+function bufferRequestBody(maxSize: number) {
+  return createMiddleware(async (context, next) => {
+    const request = context.req.raw;
+    if (!request.body) return next();
+
+    const declaredSize = Number(request.headers.get('content-length'));
+    if (Number.isFinite(declaredSize) && declaredSize > maxSize) {
+      return context.json({ error: { code: 'payload_too_large', message: 'Request is too large.' } }, 413);
+    }
+
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxSize) {
+        await reader.cancel();
+        return context.json({ error: { code: 'payload_too_large', message: 'Request is too large.' } }, 413);
+      }
+      chunks.push(value);
+    }
+
+    const body = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    context.req.raw = new Request(request, { body });
+    await next();
+  });
+}
+
 /** Create the portable Hono application used by Vercel and Node hosts. */
 export function createWardenService(options: CreateWardenServiceOptions = {}) {
   const jobHandlers = options.jobHandlers;
@@ -115,12 +149,7 @@ export function createWardenService(options: CreateWardenServiceOptions = {}) {
     context.header('X-Content-Type-Options', 'nosniff');
   });
 
-  app.use('/api/*', bodyLimit({
-    maxSize: maxRequestBytes,
-    onError: (context) => context.json({
-      error: { code: 'payload_too_large', message: 'Request is too large.' },
-    }, 413),
-  }));
+  app.use('/api/*', bufferRequestBody(maxRequestBytes));
 
   app.use('/api/*', async (context, next) => {
     if (options.rateLimit && !await options.rateLimit({


### PR DESCRIPTION
Buffer bounded API request bodies before entering asynchronous authentication middleware.

On Vercel, the incoming request can finish while bearer authentication is awaiting Postgres. Reading the lazy request stream afterward then waits until the 30-second function timeout, which prevented run ingestion and other body-reading routes from completing. Eager buffering preserves the existing 1 MB limit and gives downstream handlers a stable body.

A regression test models a lazy Vercel-style stream and verifies buffering happens before authentication.