### PR TITLE
fix(service): Preserve Vercel request bodies

### DIFF
--- a/apps/warden-service/api/index.ts
+++ b/apps/warden-service/api/index.ts
@@ -1,7 +1,17 @@
 import { handle } from '@hono/node-server/vercel';
 import { createVercelWardenService } from '../src/create-app.js';
+import { prepareVercelRequest } from '../src/vercel-request.js';
+import type { VercelIncomingMessage } from '../src/vercel-request.js';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
-export default handle(createVercelWardenService(process.env));
+const honoHandler = handle(createVercelWardenService(process.env));
+
+export default function handler(
+  request: VercelIncomingMessage,
+  response: Parameters<typeof honoHandler>[1],
+) {
+  prepareVercelRequest(request);
+  return honoHandler(request, response);
+}

--- a/apps/warden-service/src/vercel-request.test.ts
+++ b/apps/warden-service/src/vercel-request.test.ts
@@ -1,0 +1,28 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { prepareVercelRequest } from './vercel-request.js';
+
+function request(body: unknown, contentType = 'application/json') {
+  return {
+    body,
+    headers: { 'content-type': contentType },
+  } as unknown as IncomingMessage & { body?: unknown; rawBody?: Buffer };
+}
+
+describe('prepareVercelRequest', () => {
+  it('makes Vercel-parsed JSON available to the Hono adapter', () => {
+    const parsed = request({ protocolVersion: 1, skills: [] });
+
+    prepareVercelRequest(parsed);
+
+    expect(parsed.rawBody?.toString('utf8')).toBe('{"protocolVersion":1,"skills":[]}');
+  });
+
+  it('preserves parsed form fields and repeated values', () => {
+    const parsed = request({ code: 'oauth-code', scope: ['openid', 'email'] }, 'application/x-www-form-urlencoded');
+
+    prepareVercelRequest(parsed);
+
+    expect(parsed.rawBody?.toString('utf8')).toBe('code=oauth-code&scope=openid&scope=email');
+  });
+});

--- a/apps/warden-service/src/vercel-request.ts
+++ b/apps/warden-service/src/vercel-request.ts
@@ -1,0 +1,43 @@
+import type { IncomingMessage } from 'node:http';
+
+export type VercelIncomingMessage = IncomingMessage & {
+  body?: unknown;
+  rawBody?: Buffer;
+};
+
+function formBody(body: Record<string, unknown>): string {
+  const form = new URLSearchParams();
+  for (const [key, value] of Object.entries(body)) {
+    if (Array.isArray(value)) {
+      for (const item of value) form.append(key, String(item));
+    } else if (value !== undefined && value !== null) {
+      form.append(key, String(value));
+    }
+  }
+  return form.toString();
+}
+
+/** Preserve Vercel's parsed request body for Hono's Node adapter. */
+export function prepareVercelRequest(request: VercelIncomingMessage): void {
+  if (request.rawBody || request.body === undefined || request.body === null) return;
+  if (Buffer.isBuffer(request.body)) {
+    request.rawBody = request.body;
+    return;
+  }
+  if (request.body instanceof Uint8Array) {
+    request.rawBody = Buffer.from(request.body);
+    return;
+  }
+  if (typeof request.body === 'string') {
+    request.rawBody = Buffer.from(request.body);
+    return;
+  }
+
+  const contentType = request.headers['content-type'] ?? '';
+  const serialized = contentType.startsWith('application/x-www-form-urlencoded')
+    && typeof request.body === 'object'
+    && !Array.isArray(request.body)
+    ? formBody(request.body as Record<string, unknown>)
+    : JSON.stringify(request.body);
+  request.rawBody = Buffer.from(serialized);
+}


### PR DESCRIPTION
Preserve Vercel parsed Node request bodies in the raw body field consumed by the Hono adapter.

Production run ingestion reached the Vercel function but timed out before Hono could parse JSON. Vercel had already parsed and consumed the incoming stream into request.body; the adapter only checks request.rawBody. Normalizing the boundary restores JSON and URL-encoded POST handlers without changing the service protocol.

Regression coverage verifies both JSON envelopes and repeated OAuth form fields.