### PR TITLE
fix(service): Make ingest credentials write-only

### DIFF
--- a/apps/warden-service/README.md
+++ b/apps/warden-service/README.md
@@ -19,13 +19,15 @@ This is the reference deployment for the optional Warden backing service. It use
    pnpm --filter @sentry/warden-service cli db status
    ```
 
-6. Create the first tenant and ingest token. Save the token when it is printed. The service stores only its hash.
+6. Create the first tenant and write-only ingest token. Save the token when it is printed. The service stores only its hash.
 
    ```bash
    TENANT_ID=$(pnpm --silent --filter @sentry/warden-service cli tenant create --slug acme --name "Acme" | tail -1)
    pnpm --filter @sentry/warden-service cli token create \
      --tenant "$TENANT_ID" --name ingest --role ingest
    ```
+
+   The `ingest` role can submit runs and request server-side memory extraction, but cannot read findings, history, or memory. Memory recall requires `read`; only combine `ingest` and `read` on a repository-scoped token.
 
 7. In Google Auth Platform, create a Web application OAuth client. Add the stable production origin as an authorized JavaScript origin and `<origin>/api/auth/callback/google` as an authorized redirect URI.
 8. Set `WARDEN_SERVICE_TENANT_ID=$TENANT_ID` and add the OAuth client as `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Warden uses Vercel's stable production URL automatically; set `WARDEN_SERVICE_BASE_URL` only to override it with a custom origin. `WARDEN_SERVICE_GOOGLE_DOMAIN` defaults to `sentry.io`.

--- a/packages/docs/src/content/docs/service.mdx
+++ b/packages/docs/src/content/docs/service.mdx
@@ -25,7 +25,7 @@ pnpm --filter @sentry/warden-service cli db migrate
 pnpm --filter @sentry/warden-service cli db status
 ```
 
-Create a tenant and an ingest credential. Each token is displayed once and stored as a SHA-256 hash.
+Create a tenant and a write-only ingest credential. Each token is displayed once and stored as a SHA-256 hash.
 
 ```bash
 TENANT_ID=$(pnpm --silent --filter @sentry/warden-service cli tenant create \
@@ -34,6 +34,8 @@ TENANT_ID=$(pnpm --silent --filter @sentry/warden-service cli tenant create \
 pnpm --filter @sentry/warden-service cli token create \
   --tenant "$TENANT_ID" --name ingest --role ingest --repository acme/widgets
 ```
+
+The `ingest` role can submit runs and request server-side memory extraction. It cannot read findings, history, costs, or memory. Memory recall requires `read`; only combine `--role ingest --role read` on a repository-scoped token. Do not distribute a tenant-wide read token through organization-level Actions secrets.
 
 The dashboard uses the same stateless Better Auth Google OAuth design as Junior:
 
@@ -73,7 +75,7 @@ export WARDEN_SERVICE_URL=https://warden-service.example.com
 export WARDEN_SERVICE_TOKEN=wds_example_secret
 ```
 
-Once a URL and token are configured, Warden sends the `findings` profile and enables repository memory by default. This includes the data used by current history, cost, and memory features, but not source snippets. Use `warden.toml` to change the data and memory settings. Set `data = "metrics"` to retain counts and usage only; metrics automatically disables memory. Set only `memory = false` to keep finding history without recall and learning.
+Once a URL and token are configured, Warden sends the `findings` profile and requests server-side repository memory extraction by default. This includes the data used by current history, cost, and memory features, but not source snippets. A token with `read` can also recall memory; an ingest-only token receives no stored data and continues without recalled memory. Use `warden.toml` to change the data and memory settings. Set `data = "metrics"` to retain counts and usage only; metrics automatically disables memory. Set only `memory = false` to keep finding history without recall and learning.
 
 ```toml
 [service]

--- a/packages/warden-service/src/memory/routes.test.ts
+++ b/packages/warden-service/src/memory/routes.test.ts
@@ -9,7 +9,7 @@ function result<TRow extends Record<string, unknown>>(rows: TRow[]): QueryResult
   return { rows, rowCount: rows.length };
 }
 
-function conflictDatabase(): WardenDatabase {
+function conflictDatabase(roles: readonly string[] = ['admin']): WardenDatabase {
   const client: DatabaseClient = {
     async query<TRow extends Record<string, unknown>>(sql: string) {
       if (sql.includes('FROM service_tokens')) {
@@ -17,7 +17,7 @@ function conflictDatabase(): WardenDatabase {
           id: 'token-id',
           tenant_id: 'tenant-id',
           token_hash: hashServiceToken(token),
-          roles: ['admin'],
+          roles,
           repository_allowlist: ['acme/widgets'],
         }] as unknown as TRow[]);
       }
@@ -85,6 +85,34 @@ describe('POST /api/v1/memories', () => {
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
       error: { code: 'conflict' },
+    });
+  });
+});
+
+describe('POST /api/v1/memory/recall', () => {
+  it('denies write-only ingest credentials', async () => {
+    const response = await createWardenService({ database: conflictDatabase(['ingest']) }).request(
+      'http://localhost/api/v1/memory/recall',
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          protocolVersion: 1,
+          clientRecallId: '00000000-0000-4000-8000-000000000003',
+          repository: memory.repository,
+          skills: ['security'],
+          languages: ['typescript'],
+          paths: ['src/auth.ts'],
+        }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: 'forbidden', message: 'Permission denied.' },
     });
   });
 });

--- a/packages/warden-service/src/memory/routes.ts
+++ b/packages/warden-service/src/memory/routes.ts
@@ -50,7 +50,7 @@ export function registerMemoryRoutes(
   database: WardenDatabase,
   recallOptions: RecallMemoryOptions = {},
 ): void {
-  app.post('/api/v1/memory/recall', requireRole('ingest'), async (context) => {
+  app.post('/api/v1/memory/recall', requireRole('read'), async (context) => {
     const body = MemoryRecallRequestSchema.safeParse(await context.req.json().catch(() => null));
     if (!body.success) return context.json({ error: { code: 'invalid_request', message: 'Recall request is not valid.' } }, 400);
     return context.json(MemoryRecallResponseSchema.parse(await recallMemories(


### PR DESCRIPTION
Require `read` authority for memory recall so an organization-wide ingestion credential cannot retrieve findings, history, costs, or repository memory.

Run ingestion still requests server-side memory extraction. Clients using an ingest-only token fail open without recalled memory. Deployments that need recall can use a combined `ingest` and `read` token restricted to one repository.