### PR TITLE
fix(service): Address production dashboard feedback

### DIFF
--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -642,7 +642,8 @@ async function render() {
   } catch (error) {
     if (version !== renderVersion) return;
     if (error instanceof Error && error.status === 401) {
-      window.location.assign('/api/auth/login');
+      const returnTo = `${location.pathname}${location.search}`;
+      window.location.assign(`/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
       return;
     }
     content.replaceChildren(element('div', error instanceof Error

--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -8,6 +8,8 @@ const apiAccess = document.querySelector('#api-access');
 const apiDialog = document.querySelector('#api-dialog');
 const apiDialogContent = document.querySelector('#api-dialog-content');
 const apiDialogClose = document.querySelector('#api-dialog-close');
+const pageTitle = document.querySelector('#page-title');
+const pageDescription = document.querySelector('#page-description');
 let dimensions;
 let filterTimer;
 let renderVersion = 0;
@@ -43,6 +45,12 @@ function formatDate(value) {
   return value
     ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
     : 'Never';
+}
+
+function setPage(title, description) {
+  pageTitle.textContent = title;
+  pageDescription.textContent = description;
+  document.title = title === 'Explore' ? 'Warden Service' : `${title} · Warden`;
 }
 
 function setAccountMenuOpen(open) {
@@ -82,9 +90,14 @@ async function api(path, options) {
     headers: { accept: 'application/json', ...headers },
   });
   if (!response.ok) {
-    const error = new Error(response.status === 401
-      ? 'Authentication required.'
-      : 'Could not load service data. Try again.');
+    let message = response.status === 401 ? 'Authentication required.' : 'Request failed. Try again.';
+    try {
+      const body = await response.json();
+      if (body?.error?.message) message = body.error.message;
+    } catch {
+      // The status-based message covers non-JSON responses.
+    }
+    const error = new Error(message);
     error.status = response.status;
     throw error;
   }
@@ -158,8 +171,9 @@ async function renderApiAccess() {
         form.after(notice);
         const list = apiDialogContent.querySelector('.token-list');
         if (list) list.prepend(tokenRow(created));
-      } catch {
-        error.textContent = 'Could not create the token. Try again.';
+      } catch (cause) {
+        const detail = cause instanceof Error ? cause.message : 'Try again.';
+        error.textContent = `Could not create the token. ${detail}`;
       } finally {
         create.disabled = false;
       }
@@ -426,6 +440,7 @@ function findingRows(finding) {
   disclosure.setAttribute('aria-hidden', 'true');
   const summaryText = element('div', undefined, 'finding-summary-text');
   summaryText.append(
+    element('div', finding.displayId, 'finding-display-id'),
     element('div', finding.title, 'finding-title'),
     element('div', finding.description, 'finding-description'),
   );
@@ -461,9 +476,11 @@ function findingRows(finding) {
   description.append(
     element('div', 'Description', 'finding-detail-label'),
     element('p', finding.description, 'finding-detail-description'),
+    link('View finding', `/findings/${encodeURIComponent(finding.id)}`),
   );
   const metadata = element('dl', undefined, 'finding-detail-metadata');
   metadata.append(
+    findingDetail('ID', finding.displayId),
     findingDetail('Repository', finding.repository.fullName),
     findingDetail('Skill', finding.skill),
     findingDetail('Location', locationText),
@@ -525,6 +542,8 @@ function findingsSection(data, params) {
 }
 
 async function renderExplore(version) {
+  setPage('Explore', 'Filter findings and understand where Warden spends time and money.');
+  filterHost.hidden = false;
   if (!filterHost.querySelector('form')) await renderFilters();
   if (version !== renderVersion) return;
   const params = new URLSearchParams(location.search);
@@ -573,9 +592,40 @@ async function renderExplore(version) {
   content.replaceChildren(section);
 }
 
+async function renderFinding(version, findingId) {
+  setPage('Finding', 'Loading finding details.');
+  filterHost.replaceChildren();
+  filterHost.hidden = true;
+  const { finding } = await api(`/api/v1/findings/${encodeURIComponent(findingId)}`);
+  if (version !== renderVersion) return;
+  setPage(finding.displayId, finding.title);
+
+  const section = element('section', undefined, 'finding-page');
+  section.append(link('Back to findings', '/'));
+  const article = element('article', undefined, 'finding-page-card');
+  const heading = element('div', undefined, 'finding-page-heading');
+  heading.append(
+    element('span', finding.severity, `severity ${finding.severity}`),
+    element('span', finding.outcome ?? 'Not reported', `finding-status ${finding.outcome ?? ''}`),
+  );
+  const description = element('p', finding.description, 'finding-page-description');
+  const metadata = element('dl', undefined, 'finding-page-metadata');
+  metadata.append(
+    findingDetail('ID', finding.displayId),
+    findingDetail('Repository', finding.repository.fullName),
+    findingDetail('Skill', finding.skill),
+    findingDetail('Location', findingLocation(finding)),
+    findingDetail('Confidence', finding.confidence ?? 'Not reported'),
+    findingDetail('Observed', finding.observedAt ? formatDate(finding.observedAt) : 'Not reported'),
+    findingDetail('Completed', formatDate(finding.completedAt)),
+  );
+  article.append(heading, description, metadata);
+  section.append(article);
+  content.replaceChildren(section);
+}
+
 async function render() {
   const version = ++renderVersion;
-  if (location.pathname !== '/') history.replaceState({}, '', `/${location.search}`);
   if (!content.children.length || content.querySelector('.login-panel, .empty')) {
     content.replaceChildren(empty('Loading data'));
   }
@@ -585,7 +635,9 @@ async function render() {
     apiAccess.hidden = !authContext.canManagePersonalTokens;
     signOut.hidden = authContext.authDisabled;
     accountMenu.hidden = apiAccess.hidden && signOut.hidden;
-    await renderExplore(version);
+    const findingPath = location.pathname.match(/^\/findings\/([^/]+)\/?$/);
+    if (findingPath) await renderFinding(version, decodeURIComponent(findingPath[1]));
+    else await renderExplore(version);
     if (version !== renderVersion) return;
   } catch (error) {
     if (version !== renderVersion) return;

--- a/apps/warden-service/public/assets/styles.css
+++ b/apps/warden-service/public/assets/styles.css
@@ -203,6 +203,7 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-disclosure { width: 6px; height: 6px; margin-top: 5px; border-right: 1.5px solid var(--muted); border-bottom: 1.5px solid var(--muted); transform: rotate(-45deg); transition: transform 120ms ease; }
 .finding-row[aria-expanded="true"] .finding-disclosure { transform: rotate(45deg); }
 .finding-title { overflow: hidden; color: #f5f2f7; font-size: 13px; font-weight: 650; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.finding-display-id { margin-bottom: 2px; color: var(--accent); font: 650 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .04em; }
 .finding-description { overflow: hidden; margin-top: 3px; color: var(--muted); font-size: 11px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
 .finding-context, .finding-location { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .finding-skill { margin-top: 3px; color: var(--muted); }
@@ -218,6 +219,16 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-detail-metadata { display: grid; grid-template-columns: 1fr 1fr; gap: 13px 22px; margin: 0; }
 .finding-detail-item { min-width: 0; }
 .finding-detail-metadata dd { overflow-wrap: anywhere; margin: 4px 0 0; color: var(--muted-strong); font-size: 11px; line-height: 1.4; }
+.finding-detail-copy .text-link { display: inline-block; margin-top: 12px; font-size: 12px; }
+
+.finding-page { display: grid; gap: 16px; max-width: 920px; }
+.finding-page > .text-link { width: fit-content; font-size: 12px; }
+.finding-page-card { padding: 24px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+.finding-page-heading { display: flex; align-items: center; gap: 16px; }
+.finding-page-description { margin: 20px 0 26px; color: var(--muted-strong); font-size: 14px; line-height: 1.65; white-space: pre-wrap; }
+.finding-page-metadata { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px 28px; margin: 0; padding-top: 20px; border-top: 1px solid var(--border); }
+.finding-page-metadata dt { color: var(--muted); font-size: 10px; font-weight: 650; letter-spacing: .06em; text-transform: uppercase; }
+.finding-page-metadata dd { overflow-wrap: anywhere; margin: 5px 0 0; color: var(--muted-strong); font-size: 12px; line-height: 1.45; }
 
 .text-link { color: var(--accent-strong); text-decoration: underline; text-decoration-color: #8f73d980; text-underline-offset: 3px; }
 .pagination { display: flex; justify-content: center; margin-top: 16px; }
@@ -271,10 +282,13 @@ dialog::backdrop { background: #08060ab8; backdrop-filter: blur(3px); }
   .analytics-grid .panel:first-child { grid-column: auto; }
   .finding-table { min-width: 900px; }
   .finding-detail-content { grid-template-columns: 1fr; }
+  .finding-page-metadata { grid-template-columns: 1fr 1fr; }
 }
 
 @media (max-width: 440px) {
   .filter-bar { grid-template-columns: 1fr; }
   .search-field { grid-column: auto; }
   .metrics { grid-template-columns: 1fr; }
+  .finding-page-card { padding: 18px; }
+  .finding-page-metadata { grid-template-columns: 1fr; }
 }

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -75,7 +75,9 @@ describe('Vercel service app', () => {
     expect(`${html}\n${script}`).not.toContain('WARDEN_SERVICE_TOKEN');
     expect(`${html}\n${script}`).not.toContain('localStorage');
     expect(script).toContain("'/api/v1/personal-tokens'");
-    expect(script).toContain("window.location.assign('/api/auth/login')");
+    expect(script).toContain(
+      'window.location.assign(`/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`)',
+    );
     expect(script).toContain("fetch('/api/auth/sign-out'");
     expect(script).toContain("row.setAttribute('aria-expanded', 'false')");
     expect(script).toContain("event.key !== 'Enter' && event.key !== ' '");

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -28,6 +28,7 @@ describe('Vercel service app', () => {
       { source: '/ready', destination: '/api' },
       { source: '/assets/(.*)', destination: '/api' },
       { source: '/index.html', destination: '/api' },
+      { source: '/findings/(.*)', destination: '/api' },
       { source: '/', destination: '/api' },
     ]));
     expect(config.rewrites).toContainEqual({ source: '/api/(.*)', destination: '/api' });
@@ -59,6 +60,9 @@ describe('Vercel service app', () => {
     expect(script).not.toContain('renderRuns');
     expect(script).not.toContain('renderMemory');
     expect(script).toContain("'/api/v1/findings'");
+    expect(script).toContain("`/api/v1/findings/${encodeURIComponent(findingId)}`");
+    expect(script).toContain("`/findings/${encodeURIComponent(finding.id)}`");
+    expect(script).toContain('finding.displayId');
     expect(script).toContain("'groupBy', 'repository'");
     expect(script).toContain("'groupBy', 'skill'");
     expect(script).toContain("const byDay = await api(apiPath('/api/v1/costs', dayCosts))");
@@ -158,6 +162,7 @@ describe('Vercel service app', () => {
     expect(asset.status).toBe(302);
     expect(asset.headers.get('location')).toBe('/api/auth/login');
     expect((await app.request('https://warden.example/index.html')).status).toBe(302);
+    expect((await app.request('https://warden.example/findings/00000000-0000-4000-8000-000000000001')).status).toBe(302);
 
     const response = await app.request('https://warden.example/api/auth/login');
     expect(response.status).toBe(302);

--- a/apps/warden-service/src/create-app.ts
+++ b/apps/warden-service/src/create-app.ts
@@ -34,6 +34,9 @@ export function createVercelWardenService(environment: NodeJS.ProcessEnv) {
     jobHandlers: {
       ...createMemoryJobHandlers(database),
     },
+    ...(config.WARDEN_SERVICE_BASE_URL
+      ? { sessionOrigin: config.WARDEN_SERVICE_BASE_URL }
+      : {}),
     ...(config.DISABLE_AUTH
       ? { disableAuth: { tenantId: config.WARDEN_SERVICE_TENANT_ID } }
       : {

--- a/apps/warden-service/vercel.json
+++ b/apps/warden-service/vercel.json
@@ -37,6 +37,10 @@
       "destination": "/api"
     },
     {
+      "source": "/findings/(.*)",
+      "destination": "/api"
+    },
+    {
       "source": "/",
       "destination": "/api"
     }

--- a/packages/warden-service-api/src/api.ts
+++ b/packages/warden-service-api/src/api.ts
@@ -60,6 +60,7 @@ export const FindingOutcomeSchema = z.enum([
 
 export const FindingFeedItemSchema = z.object({
   id: IdSchema,
+  displayId: IdSchema,
   runId: IdSchema,
   clientRunId: IdSchema,
   repository: RepositoryIdentitySchema,
@@ -78,6 +79,11 @@ export const FindingFeedItemSchema = z.object({
   completedAt: TimestampSchema,
 }).strict();
 export type FindingFeedItem = z.infer<typeof FindingFeedItemSchema>;
+
+export const FindingDetailResponseSchema = z.object({
+  finding: FindingFeedItemSchema,
+}).strict();
+export type FindingDetailResponse = z.infer<typeof FindingDetailResponseSchema>;
 
 export const FindingListResponseSchema = z.object({
   items: z.array(FindingFeedItemSchema),

--- a/packages/warden-service-api/src/index.ts
+++ b/packages/warden-service-api/src/index.ts
@@ -40,6 +40,7 @@ export type {
 export {
   ApiErrorSchema,
   CostAggregateResponseSchema,
+  FindingDetailResponseSchema,
   FindingFeedItemSchema,
   FindingListResponseSchema,
   FindingOutcomeSchema,
@@ -64,6 +65,7 @@ export {
 export type {
   ApiError,
   CostAggregateResponse,
+  FindingDetailResponse,
   FindingFeedItem,
   FindingListResponse,
   IngestRunResponse,

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -205,8 +205,24 @@ describe('createWardenService', () => {
     expect(protectedPage.status).toBe(302);
     expect(protectedPage.headers.get('location')).toBe('/api/auth/login');
     expect((await app.request('https://warden.example/assets/app.js')).status).toBe(302);
+    const protectedFinding = await app.request(
+      'https://warden.example/findings/00000000-0000-4000-8000-000000000001',
+    );
+    expect(protectedFinding.headers.get('location')).toBe(
+      '/api/auth/login?returnTo=%2Ffindings%2F00000000-0000-4000-8000-000000000001',
+    );
     expect((await app.request('https://warden.example/api/auth/login')).headers.get('location'))
       .toBe('https://accounts.google.com/');
+    expect(callbackURL).toBe('https://warden.example/');
+
+    await app.request(
+      'https://warden.example/api/auth/login?returnTo=%2Ffindings%2F00000000-0000-4000-8000-000000000001',
+    );
+    expect(callbackURL).toBe(
+      'https://warden.example/findings/00000000-0000-4000-8000-000000000001',
+    );
+
+    await app.request('https://warden.example/api/auth/login?returnTo=https%3A%2F%2Fexample.com');
     expect(callbackURL).toBe('https://warden.example/');
     expect(await (await app.request('/api/auth/sign-out', { method: 'POST' })).text()).toBe('handled');
   });

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -183,6 +183,7 @@ describe('createWardenService', () => {
     const page = await app.request('https://warden.example/');
     expect(page.status).toBe(200);
     expect(page.headers.get('content-type')).toContain('text/html');
+    expect((await app.request('https://warden.example/findings/00000000-0000-4000-8000-000000000001')).status).toBe(200);
 
     const authenticated = await app.request('https://warden.example/api/v1/auth/context');
     expect(authenticated.status).toBe(200);
@@ -245,6 +246,7 @@ describe('createWardenService', () => {
       async query<TRow extends Record<string, unknown>>(sql: string, values: readonly unknown[] = []) {
         if (sql.includes('FROM findings f')) return { rows: [{
           id: '00000000-0000-4000-8000-000000000010',
+          client_finding_id: '7MV-5V7', reported_id: null,
           run_id: '00000000-0000-4000-8000-000000000011',
           client_run_id: 'run-11',
           provider: 'github', owner: 'acme', name: 'widgets', full_name: 'acme/widgets',
@@ -272,8 +274,15 @@ describe('createWardenService', () => {
     const findings = await app.request('/api/v1/findings?skill=security&query=unsafe');
     expect(findings.status).toBe(200);
     await expect(findings.json()).resolves.toMatchObject({
-      items: [{ title: 'Unsafe query', skill: 'security', repository: { fullName: 'acme/widgets' } }],
+      items: [{ displayId: '7MV-5V7', title: 'Unsafe query', skill: 'security', repository: { fullName: 'acme/widgets' } }],
     });
+
+    const detail = await app.request('/api/v1/findings/00000000-0000-4000-8000-000000000010');
+    expect(detail.status).toBe(200);
+    await expect(detail.json()).resolves.toMatchObject({
+      finding: { id: '00000000-0000-4000-8000-000000000010', displayId: '7MV-5V7' },
+    });
+    expect((await app.request('/api/v1/findings/not-a-uuid')).status).toBe(404);
 
     const costs = await app.request('/api/v1/costs?groupBy=skill&skill=security');
     expect(costs.status).toBe(200);

--- a/packages/warden-service/src/app.ts
+++ b/packages/warden-service/src/app.ts
@@ -54,6 +54,7 @@ export interface CreateWardenServiceOptions {
   sessionSecret?: string;
   sessionTtlSeconds?: number;
   dashboardAuth?: DashboardAuthenticationAdapter;
+  sessionOrigin?: string;
   googleAuth?: GoogleBrowserAuthOptions;
   disableAuth?: { tenantId: string };
   memoryRecall?: RecallMemoryOptions;
@@ -236,6 +237,7 @@ export function createWardenService(options: CreateWardenServiceOptions = {}) {
       for (const path of ['/', '/index.html']) {
         app.get(path, requireSession, (context) => context.html(dashboard.html));
       }
+      app.get('/findings/:id', requireSession, (context) => context.html(dashboard.html));
       app.get('/assets/app.js', requireSession, (context) => context.body(
         dashboard.script,
         200,
@@ -247,7 +249,7 @@ export function createWardenService(options: CreateWardenServiceOptions = {}) {
         { 'Content-Type': 'text/css; charset=utf-8' },
       ));
     }
-    app.use('/api/v1/*', authenticate(options.database, dashboardAuth));
+    app.use('/api/v1/*', authenticate(options.database, dashboardAuth, options.sessionOrigin));
     app.get('/api/v1/auth/context', requireRole('read'), (context) => {
       const serviceContext = context.get('serviceContext');
       return context.json({

--- a/packages/warden-service/src/app.ts
+++ b/packages/warden-service/src/app.ts
@@ -18,6 +18,7 @@ import { registerAdministrationRoutes } from './administration/routes.js';
 import { registerPersonalTokenRoutes } from './personal-tokens/routes.js';
 import {
   createGoogleAuthenticationAdapter,
+  dashboardLoginPath,
   registerGoogleAuthRoutes,
 } from './google-auth.js';
 import type { GoogleBrowserAuthOptions } from './google-auth.js';
@@ -78,7 +79,7 @@ function createDisabledAuthenticationAdapter(tenantId: string): DashboardAuthent
 function requireDashboardSession(authentication?: DashboardAuthenticationAdapter) {
   return createMiddleware<{ Variables: ServiceVariables }>(async (context, next) => {
     const serviceContext = await authentication?.authenticate(context.req.raw) ?? null;
-    if (!serviceContext) return context.redirect('/api/auth/login');
+    if (!serviceContext) return context.redirect(dashboardLoginPath(context.req.raw));
     if (!hasRole(serviceContext, 'read')) {
       return context.json({ error: { code: 'forbidden', message: 'Permission denied.' } }, 403);
     }

--- a/packages/warden-service/src/auth.ts
+++ b/packages/warden-service/src/auth.ts
@@ -20,7 +20,12 @@ function bearerToken(header: string | undefined): string | null {
 }
 
 /** Authenticate bearer credentials and attach runtime-derived authority to Hono context. */
-export function authenticate(database: WardenDatabase, dashboardAuth?: DashboardAuthenticationAdapter) {
+export function authenticate(
+  database: WardenDatabase,
+  dashboardAuth?: DashboardAuthenticationAdapter,
+  sessionOrigin?: string,
+) {
+  const expectedSessionOrigin = sessionOrigin ? new URL(sessionOrigin).origin : undefined;
   return createMiddleware<{ Variables: ServiceVariables }>(async (context, next) => {
     const token = bearerToken(context.req.header('authorization'));
     const serviceContext = token
@@ -43,7 +48,7 @@ export function authenticate(database: WardenDatabase, dashboardAuth?: Dashboard
     }
     if (context.get('authenticationMethod') === 'session' && !['GET', 'HEAD', 'OPTIONS'].includes(context.req.method)) {
       const origin = context.req.header('origin');
-      if (!origin || origin !== new URL(context.req.url).origin) {
+      if (!origin || origin !== (expectedSessionOrigin ?? new URL(context.req.url).origin)) {
         return context.json({ error: { code: 'forbidden', message: 'Permission denied.' } }, 403);
       }
     }

--- a/packages/warden-service/src/google-auth.ts
+++ b/packages/warden-service/src/google-auth.ts
@@ -33,6 +33,30 @@ export interface GoogleBrowserAuthOptions {
   allowedDomain: string;
 }
 
+function dashboardReturnPath(value: string | undefined): string {
+  if (!value) return '/';
+  try {
+    const base = new URL('https://warden.invalid');
+    const target = new URL(value, base);
+    const isDashboardPage = target.pathname === '/'
+      || /^\/findings\/[^/]+\/?$/.test(target.pathname);
+    return target.origin === base.origin && isDashboardPage
+      ? `${target.pathname}${target.search}`
+      : '/';
+  } catch {
+    return '/';
+  }
+}
+
+/** Build a login path that returns authenticated users to the requested dashboard page. */
+export function dashboardLoginPath(request: Request): string {
+  const url = new URL(request.url);
+  const returnTo = dashboardReturnPath(`${url.pathname}${url.search}`);
+  return returnTo === '/'
+    ? '/api/auth/login'
+    : `/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
 function normalizedAuthorizedEmail(session: GoogleAuthSession | null, allowedDomain: string): string | null {
   if (!session?.user.emailVerified) return null;
   const email = session.user.email.trim().toLowerCase();
@@ -133,11 +157,12 @@ export function registerGoogleAuthRoutes(
   options: GoogleBrowserAuthOptions,
 ): void {
   app.get('/api/auth/login', async (context) => {
+    const returnTo = dashboardReturnPath(context.req.query('returnTo'));
     const session = await options.auth.getSession(context.req.raw);
     if (normalizedAuthorizedEmail(session, options.allowedDomain)) {
-      return context.redirect('/');
+      return context.redirect(returnTo);
     }
-    return options.auth.signInWithGoogle(context.req.raw, new URL('/', context.req.url).toString());
+    return options.auth.signInWithGoogle(context.req.raw, new URL(returnTo, context.req.url).toString());
   });
   app.on(['GET', 'POST'], '/api/auth/*', (context) => options.auth.handler(context.req.raw));
 }

--- a/packages/warden-service/src/history/routes.ts
+++ b/packages/warden-service/src/history/routes.ts
@@ -1,5 +1,6 @@
 import {
   CostAggregateResponseSchema,
+  FindingDetailResponseSchema,
   FindingListResponseSchema,
   OutcomeSummaryResponseSchema,
   RepositoryListResponseSchema,
@@ -14,6 +15,7 @@ import type { ServiceVariables } from '../auth.js';
 import type { WardenDatabase } from '../db/database.js';
 import {
   aggregateCosts,
+  getFindingDetail,
   getRunDetail,
   listFindings,
   listRepositories,
@@ -86,6 +88,14 @@ export function registerHistoryRoutes(app: Hono<{ Variables: ServiceVariables }>
       context.get('serviceContext'),
       query,
     )));
+  });
+
+  app.get('/api/v1/findings/:id', requireRole('read'), async (context) => {
+    const id = z.string().uuid().safeParse(context.req.param('id'));
+    if (!id.success) return context.json({ error: { code: 'not_found', message: 'Finding not found.' } }, 404);
+    const detail = await getFindingDetail(database, context.get('serviceContext'), id.data);
+    if (!detail) return context.json({ error: { code: 'not_found', message: 'Finding not found.' } }, 404);
+    return context.json(FindingDetailResponseSchema.parse(detail));
   });
 
   app.get('/api/v1/repositories', requireRole('read'), async (context) => context.json(

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ServiceContext } from '../context.js';
 import type { QueryResult, WardenDatabase } from '../db/database.js';
-import { aggregateCosts, getRunDetail, listFindings, listRepositories, listRuns, listSkills, summarizeOutcomes } from './store.js';
+import { aggregateCosts, getFindingDetail, getRunDetail, listFindings, listRepositories, listRuns, listSkills, summarizeOutcomes } from './store.js';
 
 const context: ServiceContext = {
   tenantId: '00000000-0000-0000-0000-000000000001',
@@ -116,6 +116,8 @@ describe('history store', () => {
       captured = { sql, values };
       return { rows: [{
         id: '00000000-0000-0000-0000-000000000020',
+        client_finding_id: '7MV-5V7',
+        reported_id: null,
         run_id: '00000000-0000-0000-0000-000000000021',
         client_run_id: 'run-21',
         provider: 'github',
@@ -145,6 +147,7 @@ describe('history store', () => {
     });
 
     expect(page.items[0]).toMatchObject({
+      displayId: '7MV-5V7',
       title: 'Missing authorization check',
       repository: { fullName: 'acme/widgets' },
       location: { path: 'src/api.ts', startLine: 42 },
@@ -171,13 +174,14 @@ describe('history store', () => {
 
     await listRuns(database, restricted, {});
     await listFindings(database, restricted, {});
+    await getFindingDetail(database, restricted, '00000000-0000-0000-0000-000000000098');
     await getRunDetail(database, restricted, '00000000-0000-0000-0000-000000000099');
     await listRepositories(database, restricted);
     await listSkills(database, restricted);
     await summarizeOutcomes(database, restricted, {});
     await aggregateCosts(database, restricted, {}, ['repository']);
 
-    expect(statements).toHaveLength(8);
+    expect(statements).toHaveLength(9);
     for (const statement of statements) {
       expect(statement.sql).toContain('full_name = ANY');
       expect(statement.values).toContainEqual(['acme/widgets']);

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -1,5 +1,6 @@
 import type {
   CostAggregateResponse,
+  FindingDetailResponse,
   FindingFeedItem,
   FindingListResponse,
   OutcomeSummaryResponse,
@@ -157,6 +158,8 @@ function encodeCursor(completedAt: Date | string, id: string): string {
 
 interface FindingFeedRow extends Record<string, unknown> {
   id: string;
+  client_finding_id: string;
+  reported_id: string | null;
   run_id: string;
   client_run_id: string;
   provider: FindingFeedItem['repository']['provider'];
@@ -179,6 +182,7 @@ interface FindingFeedRow extends Record<string, unknown> {
 function mapFinding(row: FindingFeedRow): FindingFeedItem {
   return {
     id: row.id,
+    displayId: row.reported_id ?? row.client_finding_id,
     runId: row.run_id,
     clientRunId: row.client_run_id,
     repository: {
@@ -236,7 +240,8 @@ export async function listFindings(
   }
   values.push(limit + 1);
   const result = await database.query<FindingFeedRow>(`
-    SELECT f.id, f.run_id, r.client_run_id, repo.provider, repo.owner, repo.name, repo.full_name,
+    SELECT f.id, f.client_finding_id, f.reported_id, f.run_id, r.client_run_id,
+      repo.provider, repo.owner, repo.name, repo.full_name,
       se.skill, f.severity, f.confidence, f.title, f.description,
       location.path, location.start_line, location.end_line,
       observation.outcome AS observation_outcome, observation.observed_at, r.completed_at
@@ -266,6 +271,48 @@ export async function listFindings(
     items: page.map(mapFinding),
     ...(result.rows.length > limit && last ? { nextCursor: encodeCursor(last.completed_at, last.id) } : {}),
   };
+}
+
+/** Return one authorized finding without revealing cross-tenant or restricted repository IDs. */
+export async function getFindingDetail(
+  database: WardenDatabase,
+  contextInput: ServiceContext | undefined,
+  findingId: string,
+): Promise<FindingDetailResponse | null> {
+  const context = requireServiceContext(contextInput);
+  const values: unknown[] = [context.tenantId, findingId];
+  const repositoryScope = context.repositoryAllowlist
+    ? (() => {
+        values.push(context.repositoryAllowlist);
+        return `AND repo.full_name = ANY($${values.length}::text[])`;
+      })()
+    : '';
+  const result = await database.query<FindingFeedRow>(`
+    SELECT f.id, f.client_finding_id, f.reported_id, f.run_id, r.client_run_id,
+      repo.provider, repo.owner, repo.name, repo.full_name,
+      se.skill, f.severity, f.confidence, f.title, f.description,
+      location.path, location.start_line, location.end_line,
+      observation.outcome AS observation_outcome, observation.observed_at, r.completed_at
+    FROM findings f
+    JOIN runs r ON r.id = f.run_id AND r.tenant_id = f.tenant_id
+    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
+    JOIN skill_executions se ON se.id = f.skill_execution_id AND se.tenant_id = f.tenant_id
+    LEFT JOIN LATERAL (
+      SELECT fl.path, fl.start_line, fl.end_line
+      FROM finding_locations fl
+      WHERE fl.tenant_id = f.tenant_id AND fl.finding_id = f.id
+      ORDER BY fl.ordinal LIMIT 1
+    ) location ON true
+    LEFT JOIN LATERAL (
+      SELECT fo.outcome, fo.observed_at
+      FROM finding_observations fo
+      WHERE fo.tenant_id = f.tenant_id AND fo.finding_id = f.id
+      ORDER BY fo.observed_at DESC, fo.id DESC LIMIT 1
+    ) observation ON true
+    WHERE f.tenant_id = $1 AND f.id = $2 ${repositoryScope}
+  `, values);
+  const finding = result.rows[0];
+  return finding ? { finding: mapFinding(finding) } : null;
 }
 
 /** List runs visible to an authenticated tenant with stable cursor pagination. */

--- a/packages/warden-service/src/index.ts
+++ b/packages/warden-service/src/index.ts
@@ -58,7 +58,9 @@ export { ingestRun, RunIngestionError } from './runs/ingest.js';
 export type { IngestRunResult } from './runs/ingest.js';
 export {
   aggregateCosts,
+  getFindingDetail,
   getRunDetail,
+  listFindings,
   listRepositories,
   listRuns,
   listSkills,
@@ -122,6 +124,7 @@ export type {
 } from './jobs/runner.js';
 export type {
   CostDimension,
+  FindingListFilters,
   HistoryFilters,
   RunListFilters,
 } from './history/store.js';

--- a/packages/warden-service/src/personal-tokens/routes.test.ts
+++ b/packages/warden-service/src/personal-tokens/routes.test.ts
@@ -71,6 +71,7 @@ describe('personal API token routes', () => {
     } as unknown as WardenDatabase;
     const app = createWardenService({
       database,
+      sessionOrigin: 'https://warden.example',
       dashboardAuth: {
         async authenticate() {
           return {
@@ -85,7 +86,7 @@ describe('personal API token routes', () => {
       },
     });
 
-    const response = await app.request('https://warden.example/api/v1/personal-tokens', {
+    const response = await app.request('http://internal.vercel/api/v1/personal-tokens', {
       method: 'POST',
       headers: { origin: 'https://warden.example', 'content-type': 'application/json' },
       body: JSON.stringify({ name: 'Codex' }),
@@ -96,5 +97,12 @@ describe('personal API token routes', () => {
     expect(body.token).toMatch(/^wds_pat_/);
     expect(values.flat()).not.toContain(body.token);
     expect(values.flat()).toContain('browser:owner-1234567890');
+
+    const crossOrigin = await app.request('http://internal.vercel/api/v1/personal-tokens', {
+      method: 'POST',
+      headers: { origin: 'https://attacker.example', 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Blocked' }),
+    });
+    expect(crossOrigin.status).toBe(403);
   });
 });


### PR DESCRIPTION
Fix the production API token failure and add a focused, shareable finding view.

Vercel terminates TLS before the Hono adapter constructs its request URL, so browser mutations compared the public HTTPS `Origin` with an internal HTTP origin and returned 403. Session mutations now validate against the configured public service origin while retaining same-origin protection.

The read API now exposes Warden's human-readable finding ID alongside the canonical UUID and provides a tenant-scoped `GET /api/v1/findings/:id` endpoint. The dashboard uses the readable ID and serves OAuth-protected `/findings/:id` pages for sharing findings without making UUIDs the user-facing label.

The missing repositories are not an API or UI cutoff. The historical replay is paused at 16,100 of 131,562 GCS objects, whose lexicographic boundary is `getsentry/junior-prod`. Resume that backfill after the hosted memory runtime is deployed so historical ingestion also produces memory.