### PR TITLE
fix(service): Run migrations against Vercel database

### DIFF
--- a/apps/warden-service/README.md
+++ b/apps/warden-service/README.md
@@ -10,13 +10,17 @@ This is the reference deployment for the optional Warden backing service. It use
 2. Add Neon from the Vercel Storage or Marketplace screen and connect it to the project. Confirm that Vercel created `DATABASE_URL`.
 3. Add independent random values for `WARDEN_SERVICE_SESSION_SECRET` and `CRON_SECRET`. The session secret must contain at least 32 characters. The Cron secret must contain at least 16.
 4. Keep `WARDEN_SERVICE_DATABASE_DRIVER=neon` and the default connection limit of 3 unless the database operator gives you a different limit.
-5. Copy the pooled `DATABASE_URL` from the Vercel project environment into your shell, then run migrations from the repository root before directing clients to the deployment:
+5. Run migrations before directing clients to the deployment. Either use the pooled `DATABASE_URL` from the database provider locally, or call the signed migration endpoint so the command uses the database attached to the Vercel function:
 
    ```bash
    export DATABASE_URL='postgresql://...'
    pnpm --filter @sentry/warden-service... build
    pnpm --filter @sentry/warden-service cli db migrate
    pnpm --filter @sentry/warden-service cli db status
+
+   curl --fail --request POST \
+     --header "Authorization: Bearer $CRON_SECRET" \
+     https://warden.example.com/api/internal/db/migrate
    ```
 
 6. Create the first tenant and write-only ingest token. Save the token when it is printed. The service stores only its hash.

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -13,7 +13,9 @@ function readyDatabase(): WardenDatabase {
         ? { rows: [{ version: '0003_hosted_memory_vectors' }], rowCount: 1 } as never
         : { rows: [], rowCount: 0 } as never;
     },
-    async withClient() { throw new Error('not used'); },
+    async withClient<T>(operation: (client: DatabaseClient) => Promise<T>) {
+      return operation({ query: this.query });
+    },
     async transaction<T>(operation: (client: DatabaseClient) => Promise<T>) {
       return operation({
         async query() { return { rows: [], rowCount: 0 }; },
@@ -42,6 +44,27 @@ describe('createWardenService', () => {
 
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toEqual({ status: 'not_ready', database: 'unavailable' });
+  });
+
+  it('runs explicit migrations only with the cron secret', async () => {
+    const app = createWardenService({
+      database: readyDatabase(),
+      cronSecret: 'cron-secret',
+      jobHandlers: { retention: async () => ({ complete: true }) },
+    });
+
+    expect((await app.request('/api/internal/db/migrate', { method: 'POST' })).status).toBe(401);
+    const response = await app.request('/api/internal/db/migrate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer cron-secret' },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ready: true,
+      currentVersion: '0003_hosted_memory_vectors',
+      requiredVersion: '0003_hosted_memory_vectors',
+    });
   });
 
   it('distinguishes a missing migration table from other database failures', async () => {

--- a/packages/warden-service/src/jobs/routes.ts
+++ b/packages/warden-service/src/jobs/routes.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import type { Context, Hono } from 'hono';
 import type { ServiceVariables } from '../auth.js';
 import type { WardenDatabase } from '../db/database.js';
+import { migrateDatabase } from '../db/migrations.js';
 import { processJobSlice } from './runner.js';
 import type { JobHandlers } from './runner.js';
 
@@ -46,4 +47,10 @@ export function registerJobRoutes(
   };
   app.get('/api/internal/jobs/tick', tick);
   app.post('/api/internal/jobs/tick', tick);
+  app.post('/api/internal/db/migrate', async (context) => {
+    if (!authorized(context.req.header('authorization'), cronSecret)) {
+      return context.json({ error: { code: 'unauthorized', message: 'Authentication required.' } }, 401);
+    }
+    return context.json(await migrateDatabase(database));
+  });
 }


### PR DESCRIPTION
Add a CRON-secret-protected internal migration endpoint that runs against the database visible to the deployed Vercel function.

Vercel Marketplace credentials resolve only at function runtime and are intentionally empty when pulled through the CLI. That made the documented external migration path capable of targeting a different connection while production remained on an older schema.

The endpoint is POST-only, uses the existing constant-time cron authentication, and keeps migrations explicit. Cold starts and ordinary requests still never mutate the schema.