### PR TITLE
fix(service): Allow bounded AI jobs to finish

### DIFF
--- a/apps/warden-service/api/index.ts
+++ b/apps/warden-service/api/index.ts
@@ -4,7 +4,7 @@ import { prepareVercelRequest } from '../src/vercel-request.js';
 import type { VercelIncomingMessage } from '../src/vercel-request.js';
 
 export const runtime = 'nodejs';
-export const maxDuration = 30;
+export const maxDuration = 300;
 
 const honoHandler = handle(createVercelWardenService(process.env));
 

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -20,7 +20,7 @@ describe('Vercel service app', () => {
       outputDirectory: string;
     };
 
-    expect(config.functions['api/index.ts']).toEqual({ maxDuration: 30, memory: 1024 });
+    expect(config.functions['api/index.ts']).toEqual({ maxDuration: 300, memory: 1024 });
     expect(config.crons).toContainEqual(expect.objectContaining({ path: '/api/internal/jobs/tick' }));
     expect(config.outputDirectory).toBe('static');
     expect(config.rewrites).toEqual(expect.arrayContaining([
@@ -121,7 +121,7 @@ describe('Vercel service app', () => {
     const route = await import('../api/index.js');
 
     expect(route.runtime).toBe('nodejs');
-    expect(route.maxDuration).toBe(30);
+    expect(route.maxDuration).toBe(300);
     const server = createServer(route.default);
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     try {

--- a/apps/warden-service/vercel.json
+++ b/apps/warden-service/vercel.json
@@ -5,7 +5,7 @@
   "outputDirectory": "static",
   "functions": {
     "api/index.ts": {
-      "maxDuration": 30,
+      "maxDuration": 300,
       "memory": 1024
     }
   },


### PR DESCRIPTION
Raise the Vercel function ceiling from 30 to 300 seconds so one hosted model call or explicit schema migration can finish.

The durable worker still uses a 25-second soft deadline and a bounded batch. The larger platform ceiling prevents Vercel from killing an in-flight provider request, which production cron and migration canaries both reproduced.