### PR TITLE
fix(service): Release migration locks on timeout

### DIFF
--- a/packages/warden-service/src/db/migrations.test.ts
+++ b/packages/warden-service/src/db/migrations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { DatabaseClient, QueryResult, WardenDatabase } from './database.js';
+import { migrateDatabase } from './migrations.js';
+
+function result<TRow extends Record<string, unknown>>(rows: TRow[] = []): QueryResult<TRow> {
+  return { rows, rowCount: rows.length };
+}
+
+describe('migrateDatabase', () => {
+  it('uses a transaction-scoped lock that cannot survive a disconnected migrator', async () => {
+    const queries: string[] = [];
+    const client: DatabaseClient = {
+      async query<TRow extends Record<string, unknown>>(text: string): Promise<QueryResult<TRow>> {
+        queries.push(text.trim());
+        if (text.includes('SELECT version FROM _warden_service_migrations')) {
+          return result([
+            { version: '0000_nifty_frog_thor' },
+            { version: '0001_magical_puppet_master' },
+            { version: '0002_hosted_memory_costs' },
+            { version: '0003_hosted_memory_vectors' },
+          ]) as unknown as QueryResult<TRow>;
+        }
+        return result();
+      },
+    };
+    const database: WardenDatabase = {
+      driver: 'postgres',
+      maxConnections: 1,
+      statementTimeoutMs: 15_000,
+      withClient: (operation) => operation(client),
+      query: async <TRow extends Record<string, unknown>>() => (
+        result([{ version: '0003_hosted_memory_vectors' }]) as unknown as QueryResult<TRow>
+      ),
+      transaction: (operation) => operation(client),
+      close: () => Promise.resolve(),
+    };
+
+    await expect(migrateDatabase(database)).resolves.toMatchObject({ ready: true });
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries).toContain('SELECT pg_advisory_xact_lock($1)');
+    expect(queries).not.toContain('SELECT pg_advisory_lock($1)');
+    expect(queries.at(-1)).toBe('COMMIT');
+  });
+});

--- a/packages/warden-service/src/db/migrations.ts
+++ b/packages/warden-service/src/db/migrations.ts
@@ -3,7 +3,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { DatabaseClient, WardenDatabase } from './database.js';
 
-const MIGRATION_LOCK_ID = 8_217_436_291;
+// This differs from the legacy session-lock key so a lock stranded by an old
+// pooled deployment cannot block the transactional migrator.
+const MIGRATION_LOCK_ID = 8_217_436_292;
 const MIGRATIONS_DIRECTORY = join(dirname(fileURLToPath(import.meta.url)), '../../drizzle');
 
 function isUndefinedTable(error: unknown): boolean {
@@ -51,8 +53,9 @@ export async function getSchemaStatus(database: WardenDatabase): Promise<SchemaS
 export async function migrateDatabase(database: WardenDatabase): Promise<SchemaStatus> {
   const files = await migrationFiles();
   await database.withClient(async (client) => {
-    await client.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_ID]);
+    await client.query('BEGIN');
     try {
+      await client.query('SELECT pg_advisory_xact_lock($1)', [MIGRATION_LOCK_ID]);
       await ensureMigrationTable(client);
       const applied = await client.query<{ version: string }>('SELECT version FROM _warden_service_migrations');
       const appliedVersions = new Set(applied.rows.map((row) => row.version));
@@ -61,18 +64,13 @@ export async function migrateDatabase(database: WardenDatabase): Promise<SchemaS
         const version = file.replace(/\.sql$/, '');
         if (appliedVersions.has(version)) continue;
         const sql = await readFile(join(MIGRATIONS_DIRECTORY, file), 'utf8');
-        await client.query('BEGIN');
-        try {
-          await client.query(sql);
-          await client.query('INSERT INTO _warden_service_migrations (version) VALUES ($1)', [version]);
-          await client.query('COMMIT');
-        } catch (error) {
-          await client.query('ROLLBACK');
-          throw error;
-        }
+        await client.query(sql);
+        await client.query('INSERT INTO _warden_service_migrations (version) VALUES ($1)', [version]);
       }
-    } finally {
-      await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_ID]);
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
     }
   });
   return getSchemaStatus(database);


### PR DESCRIPTION
Use a transaction-scoped advisory lock for schema migrations so pooled Neon connections cannot retain it when Vercel terminates a function.

The production migrator is currently blocked by a session lock stranded by an earlier 30-second timeout. A fresh lock key bypasses that legacy lock, while one atomic migration transaction ensures future disconnects release both the lock and any partial schema work. The regression test verifies the migrator never acquires a session-scoped lock.