### PR TITLE
fix(service): Apportion memory extraction usage

### DIFF
--- a/packages/warden-service/src/memory/handlers.test.ts
+++ b/packages/warden-service/src/memory/handlers.test.ts
@@ -51,6 +51,50 @@ describe('memory job handlers', () => {
     expect(statements.some((sql) => sql.includes('INSERT INTO memories'))).toBe(false);
   });
 
+  it('attributes one extraction call across its proposals without duplicating usage', async () => {
+    const { database, statements, statementValues } = databaseFixture();
+    let memories = 0;
+    const original = database.transaction.bind(database);
+    database.transaction = async (operation) => original(async (client) => {
+      const query = client.query.bind(client);
+      client.query = async <TRow extends Record<string, unknown>>(sql: string, values?: readonly unknown[]) => {
+        const result = await query<TRow>(sql, values);
+        return sql.includes('INSERT INTO memories')
+          ? { rows: [{ id: `memory-${++memories}` } as unknown as TRow], rowCount: 1 }
+          : result;
+      };
+      return operation(client);
+    });
+    const handler = createMemoryJobHandlers(database, {
+      extractor: {
+        async extract(input) {
+          return {
+            proposals: ['Use parameterized queries.', 'Validate query identifiers.'].map((content) => ({
+              kind: 'confirmed_pattern' as const,
+              content,
+              evidenceIds: input.evidence.map((item) => item.observationId),
+              skill: 'security',
+              confidence: 0.9,
+            })),
+            modelVersion: 'test-model',
+            usage: {
+              provider: 'test', model: 'test-model', runtime: 'test',
+              inputTokens: 101, outputTokens: 21, costUsd: 0.011, costBasis: 'estimated' as const,
+            },
+          };
+        },
+      },
+    }).memory_extract;
+
+    await expect(handler?.(job, { deadline: Date.now() + 5_000 })).resolves.toEqual({ complete: true });
+    const usage = statements.flatMap((sql, index) => (
+      sql.includes('INSERT INTO memories') ? [statementValues[index]!] : []
+    ));
+    expect(usage.map((values) => values[18])).toEqual([51, 50]);
+    expect(usage.map((values) => values[19])).toEqual([11, 10]);
+    expect(usage.reduce((total, values) => total + Number(values[20]), 0)).toBeCloseTo(0.011);
+  });
+
   it('expires inactive memory indexes through the retention handler', async () => {
     const { database, statements } = databaseFixture();
     const original = database.transaction.bind(database);

--- a/packages/warden-service/src/memory/handlers.ts
+++ b/packages/warden-service/src/memory/handlers.ts
@@ -96,6 +96,25 @@ function deterministicProposals(evidence: readonly PassiveEvidence[]): PassiveMe
   });
 }
 
+function apportionCount(value: number | undefined, index: number, total: number): number | undefined {
+  if (value === undefined) return undefined;
+  return Math.floor(value / total) + (index < value % total ? 1 : 0);
+}
+
+function apportionUsage(
+  usage: MemoryOperationUsage | undefined,
+  index: number,
+  total: number,
+): MemoryOperationUsage | undefined {
+  if (!usage) return undefined;
+  return {
+    ...usage,
+    inputTokens: apportionCount(usage.inputTokens, index, total),
+    outputTokens: apportionCount(usage.outputTokens, index, total),
+    costUsd: usage.costUsd === null ? null : usage.costUsd === undefined ? undefined : usage.costUsd / total,
+  };
+}
+
 /** Build passive extraction, embedding, and expiration handlers on the shared durable runner. */
 export function createMemoryJobHandlers(database: WardenDatabase, options: MemoryJobHandlerOptions = {}): JobHandlers {
   return {
@@ -108,14 +127,14 @@ export function createMemoryJobHandlers(database: WardenDatabase, options: Memor
         ? await options.extractor.extract(input)
         : { proposals: deterministicProposals(evidence), modelVersion: PASSIVE_MEMORY_MODEL_VERSION };
       const proposals = extracted.proposals.map((proposal) => PassiveMemoryProposalSchema.parse(proposal));
-      for (const proposal of proposals) {
+      for (const [index, proposal] of proposals.entries()) {
         const persisted = await persistPassiveMemoryCandidate(database, {
           tenantId: job.tenantId,
           repositoryId: job.repositoryId,
           proposal,
           evidence,
           modelVersion: extracted.modelVersion,
-          extractionUsage: extracted.usage,
+          extractionUsage: apportionUsage(extracted.usage, index, proposals.length),
           policy: options.promotionPolicy ?? defaultPassivePromotionPolicy,
         });
         if (persisted?.lifecycle === 'active' && options.embedding) {


### PR DESCRIPTION
Keep hosted-memory usage totals equal to the model calls that produced them.

One extraction call can yield several memory proposals. The service previously attached the entire call usage to every proposal, multiplying reported tokens and cost by the proposal count. This apportions integer tokens and cost across proposals while preserving the exact aggregate.