### PR TITLE
fix(service): Record extraction calls once

### DIFF
--- a/packages/warden-service/src/memory/handlers.test.ts
+++ b/packages/warden-service/src/memory/handlers.test.ts
@@ -51,7 +51,7 @@ describe('memory job handlers', () => {
     expect(statements.some((sql) => sql.includes('INSERT INTO memories'))).toBe(false);
   });
 
-  it('attributes one extraction call across its proposals without duplicating usage', async () => {
+  it('records one extraction usage line even when the call returns multiple proposals', async () => {
     const { database, statements, statementValues } = databaseFixture();
     let memories = 0;
     const original = database.transaction.bind(database);
@@ -88,11 +88,27 @@ describe('memory job handlers', () => {
 
     await expect(handler?.(job, { deadline: Date.now() + 5_000 })).resolves.toEqual({ complete: true });
     const usage = statements.flatMap((sql, index) => (
+      sql.includes('INSERT INTO usage_line_items') ? [statementValues[index]!] : []
+    ));
+    expect(usage).toEqual([[
+      job.tenantId,
+      job.entityId,
+      `memory_extract:${job.id}:attempt:${job.attempts}`,
+      'test',
+      'test-model',
+      'test',
+      101,
+      21,
+      0.011,
+      'estimated',
+    ]]);
+    const memoriesUsage = statements.flatMap((sql, index) => (
       sql.includes('INSERT INTO memories') ? [statementValues[index]!] : []
     ));
-    expect(usage.map((values) => values[18])).toEqual([51, 50]);
-    expect(usage.map((values) => values[19])).toEqual([11, 10]);
-    expect(usage.reduce((total, values) => total + Number(values[20]), 0)).toBeCloseTo(0.011);
+    expect(memoriesUsage.map((values) => values.slice(18, 22))).toEqual([
+      [null, null, null, null],
+      [null, null, null, null],
+    ]);
   });
 
   it('expires inactive memory indexes through the retention handler', async () => {

--- a/packages/warden-service/src/memory/handlers.ts
+++ b/packages/warden-service/src/memory/handlers.ts
@@ -96,22 +96,39 @@ function deterministicProposals(evidence: readonly PassiveEvidence[]): PassiveMe
   });
 }
 
-function apportionCount(value: number | undefined, index: number, total: number): number | undefined {
-  if (value === undefined) return undefined;
-  return Math.floor(value / total) + (index < value % total ? 1 : 0);
+async function recordExtractionUsage(
+  database: WardenDatabase,
+  job: { id: string; tenantId: string },
+  runId: string,
+  attempt: number,
+  usage: MemoryOperationUsage | undefined,
+): Promise<void> {
+  if (!usage) return;
+  await database.query(`
+    INSERT INTO usage_line_items (
+      tenant_id, run_id, skill_execution_id, lane, operation,
+      provider, model, runtime, input_tokens, output_tokens, cost_usd, cost_basis
+    ) VALUES ($1, $2, NULL, 'service', $3, $4, $5, $6, $7, $8, $9, $10::cost_basis)
+  `, [
+    job.tenantId,
+    runId,
+    `memory_extract:${job.id}:attempt:${attempt}`,
+    usage.provider ?? null,
+    usage.model ?? null,
+    usage.runtime ?? null,
+    usage.inputTokens ?? null,
+    usage.outputTokens ?? null,
+    usage.costUsd ?? null,
+    usage.costBasis ?? 'unknown',
+  ]);
 }
 
-function apportionUsage(
-  usage: MemoryOperationUsage | undefined,
-  index: number,
-  total: number,
-): MemoryOperationUsage | undefined {
+function extractionProvenance(usage: MemoryOperationUsage | undefined): MemoryOperationUsage | undefined {
   if (!usage) return undefined;
   return {
-    ...usage,
-    inputTokens: apportionCount(usage.inputTokens, index, total),
-    outputTokens: apportionCount(usage.outputTokens, index, total),
-    costUsd: usage.costUsd === null ? null : usage.costUsd === undefined ? undefined : usage.costUsd / total,
+    ...(usage.provider ? { provider: usage.provider } : {}),
+    ...(usage.model ? { model: usage.model } : {}),
+    ...(usage.runtime ? { runtime: usage.runtime } : {}),
   };
 }
 
@@ -126,15 +143,16 @@ export function createMemoryJobHandlers(database: WardenDatabase, options: Memor
       const extracted = options.extractor
         ? await options.extractor.extract(input)
         : { proposals: deterministicProposals(evidence), modelVersion: PASSIVE_MEMORY_MODEL_VERSION };
+      await recordExtractionUsage(database, job, job.entityId, job.attempts, extracted.usage);
       const proposals = extracted.proposals.map((proposal) => PassiveMemoryProposalSchema.parse(proposal));
-      for (const [index, proposal] of proposals.entries()) {
+      for (const proposal of proposals) {
         const persisted = await persistPassiveMemoryCandidate(database, {
           tenantId: job.tenantId,
           repositoryId: job.repositoryId,
           proposal,
           evidence,
           modelVersion: extracted.modelVersion,
-          extractionUsage: apportionUsage(extracted.usage, index, proposals.length),
+          extractionUsage: extractionProvenance(extracted.usage),
           policy: options.promotionPolicy ?? defaultPassivePromotionPolicy,
         });
         if (persisted?.lifecycle === 'active' && options.embedding) {


### PR DESCRIPTION
Record hosted-memory extraction usage at the model-call boundary.

A call can return proposals that are rejected, deduplicated, or fail later in persistence. Per-proposal accounting therefore cannot preserve the actual billed total. This writes one usage ledger item per job attempt on the originating run and keeps memory rows limited to provider provenance.

This follows up on Cursor Bugbot feedback in #492.