### PR TITLE
perf(sdk): Omit ignored files from hunk prompts

### DIFF
--- a/packages/warden/src/cli/output/tasks.ts
+++ b/packages/warden/src/cli/output/tasks.ts
@@ -17,6 +17,7 @@ import {
   aggregateAuxiliaryUsage,
   postProcessFindings,
   generateSummary,
+  selectChangedFilesForPrompt,
   type AuxiliaryUsageEntry,
   type SkillRunnerOptions,
   type FileAnalysisCallbacks,
@@ -377,7 +378,12 @@ export async function runSkillTask(
         const isPullRequest = context.pullRequest ? context.pullRequest.number !== 0 : false;
         const prContext: PRPromptContext | undefined = context.pullRequest
           ? {
-              changedFiles: isPullRequest ? context.pullRequest.files.map((f) => f.filename) : [],
+              changedFiles: isPullRequest
+                ? selectChangedFilesForPrompt(
+                    context.pullRequest.files.map((file) => file.filename),
+                    skippedFiles,
+                  )
+                : [],
               title: context.pullRequest.title,
               body: context.pullRequest.body,
               maxContextFiles: runnerOptions.maxContextFiles,

--- a/packages/warden/src/sdk/analyze.test.ts
+++ b/packages/warden/src/sdk/analyze.test.ts
@@ -731,6 +731,56 @@ describe('runSkill', () => {
     vi.restoreAllMocks();
   });
 
+  it('omits ignored files from repeated hunk context but keeps budget-limited files', async () => {
+    const runSkillMock = vi.fn().mockResolvedValue({
+      result: {
+        status: 'success',
+        text: JSON.stringify({ findings: [] }),
+        errors: [],
+        usage: makeUsage(),
+      },
+    });
+    vi.mocked(getRuntime).mockReturnValue({
+      name: 'pi',
+      runSkill: runSkillMock,
+      runAuxiliary: vi.fn(),
+      runSynthesis: vi.fn(),
+    } as unknown as Runtime);
+    const context = makeContextWithOneHunk();
+    context.pullRequest!.files.push(
+      {
+        filename: 'pnpm-lock.yaml',
+        status: 'modified',
+        additions: 1,
+        deletions: 1,
+        patch: '@@ -1,1 +1,1 @@\n-old\n+new',
+        chunks: 1,
+      },
+      {
+        filename: 'src/unscanned.ts',
+        status: 'modified',
+        additions: 1,
+        deletions: 1,
+        patch: '@@ -1,1 +1,1 @@\n-old\n+new',
+        chunks: 1,
+      },
+    );
+
+    await runSkill(
+      {
+        name: 'security-review',
+        description: 'Security review.',
+        prompt: 'Return findings as JSON.',
+      },
+      context,
+      { runtime: 'pi', scan: { maxFiles: 1 }, verifyFindings: false },
+    );
+
+    const userPrompt = runSkillMock.mock.calls[0]?.[0].userPrompt;
+    expect(userPrompt).not.toContain('pnpm-lock.yaml');
+    expect(userPrompt).toContain('src/unscanned.ts');
+  });
+
   it('reports all-extraction failures without authentication guidance', async () => {
     vi.mocked(getRuntime).mockReturnValue({
       name: 'pi',

--- a/packages/warden/src/sdk/analyze.ts
+++ b/packages/warden/src/sdk/analyze.ts
@@ -9,7 +9,12 @@ import { genAiProviderName } from './otel.js';
 import type { CircuitBreakerReason } from './circuit-breaker.js';
 import { DEFAULT_RETRY_CONFIG, calculateRetryDelay, sleep } from './retry.js';
 import { aggregateUsage, emptyUsage, estimateTokens, aggregateAuxiliaryUsage, aggregateAuxiliaryUsageAttribution } from './usage.js';
-import { buildHunkSystemPrompt, buildHunkUserPrompt, type PRPromptContext } from './prompt.js';
+import {
+  buildHunkSystemPrompt,
+  buildHunkUserPrompt,
+  selectChangedFilesForPrompt,
+  type PRPromptContext,
+} from './prompt.js';
 import { extractFindingsJson, extractFindingsWithLLM, validateFindings } from './extract.js';
 import type { ExtractFindingsResult } from './extract.js';
 import { postProcessFindings } from './post-process.js';
@@ -1055,7 +1060,12 @@ async function runSkillAnalysis(
   const isPullRequest = context.pullRequest.number !== 0;
   const prContext: PRPromptContext = {
     repository: context.repository.fullName,
-    changedFiles: isPullRequest ? context.pullRequest.files.map((f) => f.filename) : [],
+    changedFiles: isPullRequest
+      ? selectChangedFilesForPrompt(
+          context.pullRequest.files.map((file) => file.filename),
+          skippedFiles,
+        )
+      : [],
     title: context.pullRequest.title,
     body: context.pullRequest.body,
     maxContextFiles: options.maxContextFiles,

--- a/packages/warden/src/sdk/prompt.ts
+++ b/packages/warden/src/sdk/prompt.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { SkillDefinition } from '../config/schema.js';
 import { formatHunkForAnalysis, type HunkWithContext } from '../diff/index.js';
+import type { SkippedFile } from '../types/index.js';
 import {
   buildChangedFilesSection,
   buildJsonOutputSection,
@@ -11,6 +12,27 @@ import {
 } from './prompt-sections.js';
 
 export type PRPromptContext = PromptPRContext;
+
+const PROMPT_IRRELEVANT_SKIP_REASONS = new Set<SkippedFile['reason']>([
+  'pattern',
+  'builtin',
+  'ignored:builtin',
+  'ignored:user',
+  'ignored:generated',
+]);
+
+/** Keep reviewable and budget-limited paths while omitting files classified as irrelevant. */
+export function selectChangedFilesForPrompt(
+  changedFiles: string[],
+  skippedFiles: SkippedFile[],
+): string[] {
+  const irrelevantFiles = new Set(
+    skippedFiles
+      .filter((file) => PROMPT_IRRELEVANT_SKIP_REASONS.has(file.reason))
+      .map((file) => file.filename),
+  );
+  return changedFiles.filter((filename) => !irrelevantFiles.has(filename));
+}
 
 /**
  * Builds the system prompt for hunk-based analysis.

--- a/packages/warden/src/sdk/runner.ts
+++ b/packages/warden/src/sdk/runner.ts
@@ -29,7 +29,11 @@ export { anthropicUsageToStats, apiUsageToStats } from './pricing.js';
 export type { AnthropicApiUsage } from './pricing.js';
 
 // Re-export prompt building (with legacy alias)
-export { buildHunkSystemPrompt, buildHunkUserPrompt } from './prompt.js';
+export {
+  buildHunkSystemPrompt,
+  buildHunkUserPrompt,
+  selectChangedFilesForPrompt,
+} from './prompt.js';
 export type { PRPromptContext } from './prompt.js';
 // Legacy export for backwards compatibility
 export { buildHunkSystemPrompt as buildSystemPrompt } from './prompt.js';


### PR DESCRIPTION
## Summary

- Remove files already classified as irrelevant from the changed-file list repeated in every hunk prompt.
- Preserve analyzed files and every `limit:*` skipped file so budget/read coverage remains visible to the reviewer.
- Share the selection policy across direct SDK runs and task-based CLI/Action runs.

## Motivation

`prepareFiles()` already excludes built-in, user-ignored, generated, empty, and pattern-skipped files from analysis. Both execution paths then rebuilt prompt context from the original pull-request file list, so up to 50 excluded paths could still be sent with every hunk for every skill.

This follows the pre-analysis filtering pattern used by [Qodo PR-Agent](https://github.com/qodo-ai/pr-agent/blob/20bc0fe8ae7c1494c0be580f7ceb35a1c45e5741/pr_agent/algo/file_filter.py#L8-L81), while retaining budget-limited filenames in the same spirit as its [remaining-files context](https://github.com/qodo-ai/pr-agent/blob/20bc0fe8ae7c1494c0be580f7ceb35a1c45e5741/pr_agent/algo/pr_processing.py#L281-L320).

In a deterministic synthetic fixture with 40 long generated paths and 10 budget-limited relevant paths, one hunk user prompt decreased from 3,695 to 985 characters. This is prompt-size evidence, not a wall-clock or billed-token claim.

## Design

`selectChangedFilesForPrompt()` omits only explicit irrelevant reasons:

- `pattern`
- `builtin`
- `ignored:builtin`
- `ignored:user`
- `ignored:generated`

All `limit:*` reasons, and any future reason not explicitly classified as irrelevant, fail open and remain in prompt context. Existing current-file exclusion and `maxContextFiles` behavior are unchanged.

## Testing

- `pnpm --filter @sentry/warden exec vitest run --config vitest.config.ts src/sdk/analyze.test.ts src/cli/output/tasks.test.ts src/sdk/prompt-sections.test.ts` — passed, 98 tests
- `pnpm lint && pnpm build && pnpm test` — passed, 1,915 tests passed and 4 repository-defined tests skipped
- `pnpm typecheck` — passed via the pre-commit hook
- Two-axis review against `upstream/main` — no Standards or Spec findings

## Compatibility and risks

There is no public configuration, schema, finding, or analysis-scope change. Ignored filenames can occasionally carry intent, so the selector deliberately keeps capacity/read/patch failures visible and removes only files Warden or the user already classified as irrelevant.

## Scope

Incremental review, cross-run caching, prompt character budgets, and workflow cancellation remain separate work. Workflow cancellation is intentionally deferred while #402 tracks orphaned in-progress checks after runner cancellation.

Related to #378.
