### PR TITLE
fix(service): Clarify finding detail context

### DIFF
--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -47,6 +47,14 @@ function formatDate(value) {
     : 'Never';
 }
 
+function dateTime(value, fallback = 'Not reported') {
+  if (!value) return element('span', fallback);
+  const time = element('time', formatDate(value));
+  time.dateTime = value;
+  time.title = new Date(value).toISOString();
+  return time;
+}
+
 function setPage(title, description) {
   pageTitle.textContent = title;
   pageDescription.textContent = description;
@@ -421,7 +429,10 @@ function findingLocation(finding) {
 
 function findingDetail(label, value) {
   const item = element('div', undefined, 'finding-detail-item');
-  item.append(element('dt', label), element('dd', value));
+  const description = element('dd');
+  if (value instanceof Node) description.append(value);
+  else description.textContent = String(value);
+  item.append(element('dt', label), description);
   return item;
 }
 
@@ -449,6 +460,27 @@ function sourceContext(evidence) {
   });
   pre.append(code);
   context.append(header, pre);
+  return context;
+}
+
+function findingPageSection(title) {
+  const section = element('section', undefined, 'finding-page-section');
+  section.append(element('h2', title));
+  return section;
+}
+
+function githubLink(sourceUrl) {
+  const sourceLink = link('Open on GitHub', sourceUrl, 'source-link text-link');
+  sourceLink.target = '_blank';
+  sourceLink.rel = 'noreferrer';
+  return sourceLink;
+}
+
+function unavailableSourceContext(finding) {
+  const context = element('div', undefined, 'source-context-empty');
+  const location = findingLocation(finding);
+  if (location !== '—') context.append(element('code', location));
+  context.append(element('p', 'No source snippet was retained for this finding.'));
   return context;
 }
 
@@ -485,12 +517,10 @@ function findingRows(finding) {
   location.title = locationText;
 
   const status = element('td', finding.outcome ?? '—', `finding-status ${finding.outcome ?? ''}`);
-  const seen = document.createElement('td');
-  const time = element('time', formatDate(finding.completedAt));
-  time.dateTime = finding.completedAt;
-  seen.append(time);
+  const observed = document.createElement('td');
+  observed.append(dateTime(finding.observedAt, '—'));
 
-  row.append(severity, summary, context, location, status, seen);
+  row.append(severity, summary, context, location, status, observed);
 
   const detailRow = document.createElement('tr');
   detailRow.id = `finding-detail-${finding.id}`;
@@ -513,7 +543,7 @@ function findingRows(finding) {
     findingDetail('Location', locationText),
     findingDetail('Confidence', finding.confidence ?? 'Not reported'),
     findingDetail('Status', finding.outcome ?? 'Not reported'),
-    findingDetail('Observed', finding.observedAt ? formatDate(finding.observedAt) : 'Not reported'),
+    findingDetail('Last observed', dateTime(finding.observedAt)),
   );
   detailContent.append(description, metadata);
   detailCell.append(detailContent);
@@ -537,7 +567,7 @@ function findingRows(finding) {
 
 function findingsSection(data, params) {
   const section = element('section', undefined, 'section');
-  section.append(sectionHeader('Findings', `${data.items.length} shown, newest first`));
+  section.append(sectionHeader('Findings', `${data.items.length} shown, newest runs first`));
   if (!data.items.length) {
     section.append(empty('No findings match these filters.'));
     return section;
@@ -547,7 +577,7 @@ function findingsSection(data, params) {
   table.className = 'finding-table';
   const head = document.createElement('thead');
   const headings = document.createElement('tr');
-  for (const label of ['Severity', 'Finding', 'Repository / skill', 'Location', 'Status', 'Seen']) {
+  for (const label of ['Severity', 'Finding', 'Repository / skill', 'Location', 'Status', 'Last observed']) {
     const heading = element('th', label);
     heading.scope = 'col';
     headings.append(heading);
@@ -636,7 +666,27 @@ async function renderFinding(version, findingId) {
     element('span', finding.severity, `severity ${finding.severity}`),
     element('span', finding.outcome ?? 'Not reported', `finding-status ${finding.outcome ?? ''}`),
   );
-  const description = element('p', finding.description, 'finding-page-description');
+
+  const explanation = findingPageSection('Why Warden Flagged This');
+  explanation.append(element('p', finding.description, 'finding-page-description'));
+  if (detail.verification) {
+    const verification = element('div', undefined, 'finding-verification');
+    verification.append(
+      element('strong', 'Verification evidence'),
+      element('p', detail.verification),
+    );
+    explanation.append(verification);
+  }
+
+  const codeContext = element('section', undefined, 'finding-page-section');
+  const codeContextHeader = element('div', undefined, 'finding-page-section-header');
+  codeContextHeader.append(element('h2', 'Code Context'));
+  if (detail.sourceUrl) codeContextHeader.append(githubLink(detail.sourceUrl));
+  codeContext.append(codeContextHeader, detail.sourceEvidence
+    ? sourceContext(detail.sourceEvidence)
+    : unavailableSourceContext(finding));
+
+  const details = findingPageSection('Finding Details');
   const metadata = element('dl', undefined, 'finding-page-metadata');
   metadata.append(
     findingDetail('ID', finding.displayId),
@@ -644,18 +694,14 @@ async function renderFinding(version, findingId) {
     findingDetail('Skill', finding.skill),
     findingDetail('Location', findingLocation(finding)),
     findingDetail('Confidence', finding.confidence ?? 'Not reported'),
-    findingDetail('Observed', finding.observedAt ? formatDate(finding.observedAt) : 'Not reported'),
-    findingDetail('Completed', formatDate(finding.completedAt)),
+    findingDetail('Latest outcome', finding.outcome ?? 'Not reported'),
+    findingDetail('Last observed', dateTime(finding.observedAt)),
+    findingDetail('Run completed', dateTime(finding.completedAt)),
+    findingDetail('Run', finding.clientRunId),
+    findingDetail('Commit', detail.headSha ? detail.headSha.slice(0, 12) : 'Not reported'),
   );
-  article.append(heading, description);
-  if (detail.sourceEvidence) article.append(sourceContext(detail.sourceEvidence));
-  if (detail.sourceUrl) {
-    const sourceLink = link('View on GitHub', detail.sourceUrl, 'source-link text-link');
-    sourceLink.target = '_blank';
-    sourceLink.rel = 'noreferrer';
-    article.append(sourceLink);
-  }
-  article.append(metadata);
+  details.append(metadata);
+  article.append(heading, explanation, codeContext, details);
   section.append(article);
   content.replaceChildren(section);
 }

--- a/apps/warden-service/public/assets/styles.css
+++ b/apps/warden-service/public/assets/styles.css
@@ -221,21 +221,31 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-detail-metadata dd { overflow-wrap: anywhere; margin: 4px 0 0; color: var(--muted-strong); font-size: 11px; line-height: 1.4; }
 .finding-detail-copy .text-link { display: inline-block; margin-top: 12px; font-size: 12px; }
 
-.finding-page { display: grid; gap: 16px; max-width: 920px; }
+.finding-page { display: grid; min-width: 0; max-width: 920px; gap: 16px; }
 .finding-page > .text-link { width: fit-content; font-size: 12px; }
-.finding-page-card { padding: 24px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
-.finding-page-heading { display: flex; align-items: center; gap: 16px; }
-.finding-page-description { margin: 20px 0 26px; color: var(--muted-strong); font-size: 14px; line-height: 1.65; white-space: pre-wrap; }
-.source-context { overflow: hidden; margin: 0 0 20px; border: 1px solid var(--border); border-radius: 8px; background: #0c0a0f; }
+.finding-page-card { min-width: 0; padding: 24px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+.finding-page-heading { display: flex; align-items: center; gap: 16px; margin-bottom: 22px; }
+.finding-page-section { min-width: 0; padding-top: 22px; border-top: 1px solid var(--border); }
+.finding-page-heading + .finding-page-section { padding-top: 0; border-top: 0; }
+.finding-page-section + .finding-page-section { margin-top: 24px; }
+.finding-page-section-header { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }
+.finding-page-description { margin: 10px 0 0; color: var(--muted-strong); font-size: 14px; line-height: 1.65; white-space: pre-wrap; }
+.finding-verification { margin-top: 18px; padding: 14px 16px; border-left: 2px solid var(--accent); background: #1b1620; }
+.finding-verification strong { color: var(--muted-strong); font-size: 11px; }
+.finding-verification p { margin: 5px 0 0; color: var(--muted-strong); font-size: 13px; white-space: pre-wrap; }
+.source-context { overflow: hidden; margin-top: 12px; border: 1px solid var(--border); border-radius: 8px; background: #0c0a0f; }
 .source-context-header { display: flex; justify-content: space-between; gap: 16px; padding: 8px 12px; border-bottom: 1px solid var(--border); color: var(--muted); font-size: 11px; }
 .source-context-header strong { overflow: hidden; color: var(--muted-strong); font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
-.source-context pre { overflow: auto; margin: 0; padding: 8px 0; font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; tab-size: 2; }
+.source-context pre { overflow: auto; max-width: 100%; margin: 0; padding: 8px 0; font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; tab-size: 2; }
 .source-line { display: grid; grid-template-columns: 48px minmax(max-content, 1fr); min-height: 19px; }
 .source-line-target { background: #7d5cc726; box-shadow: inset 2px 0 var(--accent); }
 .source-line-number { padding-right: 12px; color: #736c77; text-align: right; user-select: none; }
 .source-line-content { padding-right: 16px; color: #ddd6e1; white-space: pre; }
-.source-link { display: inline-block; margin: -6px 0 22px; font-size: 12px; }
-.finding-page-metadata { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px 28px; margin: 0; padding-top: 20px; border-top: 1px solid var(--border); }
+.source-link { flex: none; font-size: 12px; }
+.source-context-empty { margin-top: 12px; padding: 18px; border: 1px dashed var(--border-strong); border-radius: 8px; background: #110e14; }
+.source-context-empty code { color: var(--muted-strong); font-size: 12px; }
+.source-context-empty p { margin: 7px 0 0; font-size: 13px; }
+.finding-page-metadata { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px 28px; margin: 14px 0 0; }
 .finding-page-metadata dt { color: var(--muted); font-size: 10px; font-weight: 650; letter-spacing: .06em; text-transform: uppercase; }
 .finding-page-metadata dd { overflow-wrap: anywhere; margin: 5px 0 0; color: var(--muted-strong); font-size: 12px; line-height: 1.45; }
 

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -69,7 +69,7 @@ describe('Vercel service app', () => {
     expect(script).toContain("const byRepository = await api(apiPath('/api/v1/costs', repositoryCosts))");
     expect(script).toContain("const bySkill = await api(apiPath('/api/v1/costs', skillCosts))");
     expect(script).toContain("document.createElement('table')");
-    expect(script).toContain("['Severity', 'Finding', 'Repository / skill', 'Location', 'Status', 'Seen']");
+    expect(script).toContain("['Severity', 'Finding', 'Repository / skill', 'Location', 'Status', 'Last observed']");
     expect(script).not.toContain('finding-card');
     expect(script).not.toContain('badge');
     expect(`${html}\n${script}`).not.toContain('WARDEN_SERVICE_TOKEN');
@@ -82,8 +82,13 @@ describe('Vercel service app', () => {
     expect(script).toContain("row.setAttribute('aria-expanded', 'false')");
     expect(script).toContain("event.key !== 'Enter' && event.key !== ' '");
     expect(script).toContain('detailRow.hidden = !expanded');
-    expect(script).toContain("link('View on GitHub'");
+    expect(script).toContain("link('Open on GitHub'");
     expect(script).toContain("element('span', lineNumber, 'source-line-number')");
+    expect(script).toContain("findingPageSection('Why Warden Flagged This')");
+    expect(script).toContain("element('h2', 'Code Context')");
+    expect(script).toContain("findingPageSection('Finding Details')");
+    expect(script).toContain("'No source snippet was retained for this finding.'");
+    expect(script).toContain("findingDetail('Last observed'");
     expect(script).not.toContain('protected-session');
     expect(script).not.toContain("'/api/auth/session'");
   });

--- a/packages/warden-service-api/src/api.ts
+++ b/packages/warden-service-api/src/api.ts
@@ -86,6 +86,7 @@ export const FindingDetailResponseSchema = z.object({
   headSha: z.string().trim().min(7).max(128).optional(),
   sourceUrl: z.url().max(4_096).optional(),
   sourceEvidence: SourceEvidenceSchema.optional(),
+  verification: z.string().trim().min(1).max(4_000).optional(),
 }).strict();
 export type FindingDetailResponse = z.infer<typeof FindingDetailResponseSchema>;
 

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -288,6 +288,8 @@ describe('createWardenService', () => {
           client_finding_id: '7MV-5V7', reported_id: null,
           run_id: '00000000-0000-4000-8000-000000000011',
           client_run_id: 'run-11',
+          head_sha: 'abc123def456', source_evidence: null,
+          verification: 'The query interpolates untrusted input.',
           provider: 'github', owner: 'acme', name: 'widgets', full_name: 'acme/widgets',
           skill: 'security', severity: 'high', confidence: 'high',
           title: 'Unsafe query', description: 'Use parameters.',
@@ -319,7 +321,12 @@ describe('createWardenService', () => {
     const detail = await app.request('/api/v1/findings/00000000-0000-4000-8000-000000000010');
     expect(detail.status).toBe(200);
     await expect(detail.json()).resolves.toMatchObject({
-      finding: { id: '00000000-0000-4000-8000-000000000010', displayId: '7MV-5V7' },
+      finding: {
+        id: '00000000-0000-4000-8000-000000000010',
+        displayId: '7MV-5V7',
+        observedAt: '2026-08-12T10:01:00.000Z',
+      },
+      verification: 'The query interpolates untrusted input.',
     });
     expect((await app.request('/api/v1/findings/not-a-uuid')).status).toBe(404);
 

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -164,28 +164,33 @@ describe('history store', () => {
     ]));
   });
 
-  it('returns bounded source evidence and a commit-pinned GitHub link for finding detail', async () => {
-    const database = databaseFor(() => ({
-      rows: [{
-        id: '00000000-0000-0000-0000-000000000020',
-        client_finding_id: 'finding-20',
-        reported_id: '7MV-5V7',
-        run_id: '00000000-0000-0000-0000-000000000021',
-        client_run_id: 'run-21',
-        head_sha: 'abc123def456',
-        source_evidence: {
-          path: 'src/api route.ts', language: 'typescript', startLine: 40, endLine: 49,
-          targetStartLine: 42, targetEndLine: 48, content: 'authorize(request);',
-        },
-        provider: 'github', owner: 'acme', name: 'widgets', full_name: 'acme/widgets',
-        skill: 'security-review', severity: 'high', confidence: 'high',
-        title: 'Missing authorization check', description: 'The endpoint does not verify ownership.',
-        path: 'src/api route.ts', start_line: 42, end_line: 48,
-        observation_outcome: 'posted', observed_at: '2026-08-12T10:02:00.000Z',
-        completed_at: '2026-08-12T10:01:00.000Z',
-      }],
-      rowCount: 1,
-    }));
+  it('returns source and verification context with the latest finding observation', async () => {
+    let detailSql = '';
+    const database = databaseFor((sql) => {
+      detailSql = sql;
+      return {
+        rows: [{
+          id: '00000000-0000-0000-0000-000000000020',
+          client_finding_id: 'finding-20',
+          reported_id: '7MV-5V7',
+          run_id: '00000000-0000-0000-0000-000000000021',
+          client_run_id: 'run-21',
+          head_sha: 'abc123def456',
+          source_evidence: {
+            path: 'src/api route.ts', language: 'typescript', startLine: 40, endLine: 49,
+            targetStartLine: 42, targetEndLine: 48, content: 'authorize(request);',
+          },
+          verification: 'The route reads an account before checking the caller.',
+          provider: 'github', owner: 'acme', name: 'widgets', full_name: 'acme/widgets',
+          skill: 'security-review', severity: 'high', confidence: 'high',
+          title: 'Missing authorization check', description: 'The endpoint does not verify ownership.',
+          path: 'src/api route.ts', start_line: 42, end_line: 48,
+          observation_outcome: 'posted', observed_at: '2026-08-12T10:02:00.000Z',
+          completed_at: '2026-08-12T10:01:00.000Z',
+        }],
+        rowCount: 1,
+      };
+    });
 
     await expect(getFindingDetail(
       database,
@@ -195,7 +200,10 @@ describe('history store', () => {
       headSha: 'abc123def456',
       sourceUrl: 'https://github.com/acme/widgets/blob/abc123def456/src/api%20route.ts#L42-L48',
       sourceEvidence: { targetStartLine: 42, content: 'authorize(request);' },
+      verification: 'The route reads an account before checking the caller.',
+      finding: { observedAt: '2026-08-12T10:02:00.000Z' },
     });
+    expect(detailSql).toContain('ORDER BY fo.observed_at DESC, fo.id DESC LIMIT 1');
   });
 
   it('applies repository allowlists to every history read boundary', async () => {

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -183,6 +183,7 @@ interface FindingFeedRow extends Record<string, unknown> {
 interface FindingDetailRow extends FindingFeedRow {
   head_sha: string | null;
   source_evidence: unknown;
+  verification: string | null;
 }
 
 function mapFinding(row: FindingFeedRow): FindingFeedItem {
@@ -303,7 +304,7 @@ export async function getFindingDetail(
     : '';
   const result = await database.query<FindingDetailRow>(`
     SELECT f.id, f.client_finding_id, f.reported_id, f.run_id, r.client_run_id,
-      r.head_sha, f.source_evidence,
+      r.head_sha, f.source_evidence, f.verification,
       repo.provider, repo.owner, repo.name, repo.full_name,
       se.skill, f.severity, f.confidence, f.title, f.description,
       location.path, location.start_line, location.end_line,
@@ -335,6 +336,7 @@ export async function getFindingDetail(
     ...(finding.head_sha ? { headSha: finding.head_sha } : {}),
     ...(sourceUrl ? { sourceUrl } : {}),
     ...(sourceEvidence.success ? { sourceEvidence: sourceEvidence.data } : {}),
+    ...(finding.verification ? { verification: finding.verification } : {}),
   };
 }
 


### PR DESCRIPTION
Clarify what finding timestamps mean and give individual findings more useful context.

The feed previously labeled run completion as Seen, while the detail endpoint selected the latest finding observation. The feed now shows and labels the last observation explicitly, with run completion kept separate in the finding metadata.

Finding pages now group the explanation, verifier evidence, source context, and metadata. Retained snippets highlight the target lines. Findings without retained code show their location and, when available, a commit-pinned GitHub link. The code scroller remains contained on narrow screens.

This preserves the existing data-retention boundary. The dashboard only renders stored source evidence and does not fetch repository contents.