### PR TITLE
perf(service): Default findings to last 30 days

### DIFF
--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -1,3 +1,4 @@
+const DEFAULT_RANGE_DAYS = '30';
 const content = document.querySelector('#content');
 const filterHost = document.querySelector('#filters');
 const accountMenu = document.querySelector('#account-menu');
@@ -253,6 +254,13 @@ function filterOptions(items, allLabel) {
   return [{ value: '', label: allLabel }, ...items];
 }
 
+function ensureDefaultRange() {
+  const params = new URLSearchParams(location.search);
+  if (params.get('range')) return;
+  params.set('range', DEFAULT_RANGE_DAYS);
+  history.replaceState({}, '', `/?${params}`);
+}
+
 function applyFilters(form) {
   const next = new URLSearchParams();
   for (const [name, value] of new FormData(form)) {
@@ -289,7 +297,8 @@ async function renderFilters() {
       name: 'range',
       label: 'Time',
       options: [
-        { value: '', label: 'All time' },
+        // Keep "all" explicit so a missing range can retain its faster default.
+        { value: 'all', label: 'All time' },
         { value: '7', label: 'Last 7 days' },
         { value: '30', label: 'Last 30 days' },
         { value: '90', label: 'Last 90 days' },
@@ -719,7 +728,10 @@ async function render() {
     accountMenu.hidden = apiAccess.hidden && signOut.hidden;
     const findingPath = location.pathname.match(/^\/findings\/([^/]+)\/?$/);
     if (findingPath) await renderFinding(version, decodeURIComponent(findingPath[1]));
-    else await renderExplore(version);
+    else {
+      ensureDefaultRange();
+      await renderExplore(version);
+    }
     if (version !== renderVersion) return;
   } catch (error) {
     if (version !== renderVersion) return;

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -110,6 +110,15 @@ describe('Vercel service app', () => {
     expect(script).toContain("findings.set('limit', '30')");
   });
 
+  it('defaults Explore to findings from the last 30 days', async () => {
+    const script = await readFile(new URL('../public/assets/app.js', import.meta.url), 'utf8');
+
+    expect(script).toContain("const DEFAULT_RANGE_DAYS = '30';");
+    expect(script).toContain("{ value: 'all', label: 'All time' }");
+    expect(script).toContain("params.set('range', DEFAULT_RANGE_DAYS)");
+    expect(script).toMatch(/ensureDefaultRange\(\);\s+await renderExplore\(version\);/);
+  });
+
   it('renders service content through text nodes without HTML injection sinks', async () => {
     const script = await readFile(new URL('../public/assets/app.js', import.meta.url), 'utf8');
 


### PR DESCRIPTION
Default Explore to a 30-day range before loading findings and cost analytics. This reduces the initial query volume while preserving the existing 7, 30, and 90-day filters.

All time now uses an explicit range=all URL value, so it remains selectable and shareable instead of colliding with the missing-range default.