### PR TITLE
feat(service): Add database tracing and typed reads

### DIFF
--- a/apps/warden-service/README.md
+++ b/apps/warden-service/README.md
@@ -36,7 +36,8 @@ This is the reference deployment for the optional Warden backing service. It use
 7. In Google Auth Platform, create a Web application OAuth client. Add the stable production origin as an authorized JavaScript origin and `<origin>/api/auth/callback/google` as an authorized redirect URI.
 8. Set `WARDEN_SERVICE_TENANT_ID=$TENANT_ID` and add the OAuth client as `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Warden uses Vercel's stable production URL automatically; set `WARDEN_SERVICE_BASE_URL` only to override it with a custom origin. `WARDEN_SERVICE_GOOGLE_DOMAIN` defaults to `sentry.io`.
 9. Vercel functions use the project OIDC token for AI Gateway. For local or non-Vercel deployments, set `AI_GATEWAY_API_KEY` instead. The hosted defaults use `openai/gpt-5.6-luna` for bounded extraction and relevance, `openai/text-embedding-3-small` for vectors, and promote only after three supporting independent runs with no contradictions. Set `WARDEN_SERVICE_MEMORY_AUTO_PROMOTE=false` to require manual approval.
-10. Deploy, open `/health` and `/ready`, then verify that Google sign-in and the Cron request to `/api/internal/jobs/tick` work.
+10. Set `WARDEN_SENTRY_DSN` to enable errors, request traces, and database query spans. The existing Warden project DSN can be reused; service events carry `service.name=warden-service`.
+11. Deploy, open `/health` and `/ready`, then verify that Google sign-in and the Cron request to `/api/internal/jobs/tick` work.
 
 At current AI Gateway rates, the defaults cost $0.20 per million extraction input tokens, $1.20 per million extraction output tokens, and $0.02 per million embedding tokens. The service records model, token, cost, and cost-basis metadata for extraction, embedding, and relevance operations. Provider work is bounded and retried through durable jobs; run ingestion remains independent from model availability.
 

--- a/apps/warden-service/api/index.ts
+++ b/apps/warden-service/api/index.ts
@@ -1,17 +1,19 @@
 import { handle } from '@hono/node-server/vercel';
 import { createVercelWardenService } from '../src/create-app.js';
+import { initServiceTelemetry, traceRequest } from '../src/sentry.js';
 import { prepareVercelRequest } from '../src/vercel-request.js';
 import type { VercelIncomingMessage } from '../src/vercel-request.js';
 
 export const runtime = 'nodejs';
 export const maxDuration = 300;
 
+initServiceTelemetry(process.env);
 const honoHandler = handle(createVercelWardenService(process.env));
 
-export default function handler(
+export default traceRequest(function handler(
   request: VercelIncomingMessage,
   response: Parameters<typeof honoHandler>[1],
 ) {
   prepareVercelRequest(request);
   return honoHandler(request, response);
-}
+});

--- a/apps/warden-service/package.json
+++ b/apps/warden-service/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.173",
     "@hono/node-server": "^1.19.17",
+    "@sentry/node": "^10.53.1",
     "@sentry/warden-service": "workspace:*",
     "@vercel/oidc": "^3.4.1",
     "ai": "^6.0.255",

--- a/apps/warden-service/src/create-app.ts
+++ b/apps/warden-service/src/create-app.ts
@@ -8,6 +8,7 @@ import {
 } from '@sentry/warden-service';
 import { readFileSync } from 'node:fs';
 import { createHostedMemoryRuntime } from './memory-ai.js';
+import { captureServiceError, traceDatabase } from './sentry.js';
 
 const dashboard = {
   html: readFileSync(new URL('../public/index.html', import.meta.url), 'utf8'),
@@ -23,12 +24,12 @@ function requiredAuthValue(value: string | undefined, name: string): string {
 /** Build the Vercel app from an explicitly validated environment. */
 export function createVercelWardenService(environment: NodeJS.ProcessEnv) {
   const config = parseServiceEnvironment(environment);
-  const database = getWarmDatabase({
+  const database = traceDatabase(getWarmDatabase({
     url: config.DATABASE_URL,
     driver: config.WARDEN_SERVICE_DATABASE_DRIVER,
     maxConnections: config.WARDEN_SERVICE_DATABASE_MAX_CONNECTIONS,
     statementTimeoutMs: config.WARDEN_SERVICE_DATABASE_STATEMENT_TIMEOUT_MS,
-  });
+  }));
   const memory = createHostedMemoryRuntime({
     memoryModel: config.WARDEN_SERVICE_MEMORY_MODEL,
     embeddingModel: config.WARDEN_SERVICE_EMBEDDING_MODEL,
@@ -36,6 +37,7 @@ export function createVercelWardenService(environment: NodeJS.ProcessEnv) {
   });
   return createWardenService({
     database,
+    onError: captureServiceError,
     dashboard,
     cronSecret: config.CRON_SECRET,
     jobHandlers: createMemoryJobHandlers(database, {

--- a/apps/warden-service/src/sentry.test.ts
+++ b/apps/warden-service/src/sentry.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { DatabaseClient, WardenDatabase } from '@sentry/warden-service';
+import {
+  initServiceTelemetry,
+  Sentry,
+  traceDatabase,
+  traceRequest,
+} from './sentry.js';
+
+type InitOptions = NonNullable<Parameters<typeof initServiceTelemetry>[1]>;
+type BeforeSendTransaction = NonNullable<InitOptions['beforeSendTransaction']>;
+type Transaction = Parameters<BeforeSendTransaction>[0];
+
+const transactions: Transaction[] = [];
+
+beforeAll(() => {
+  initServiceTelemetry({
+    WARDEN_SENTRY_DSN: 'https://public@example.com/1',
+    VERCEL_ENV: 'production',
+    VERCEL_GIT_COMMIT_SHA: 'abc123',
+  }, {
+    beforeSendTransaction(event) {
+      transactions.push(event);
+      return event;
+    },
+    transport: () => ({
+      send: async () => ({}),
+      flush: async () => true,
+    }),
+  });
+});
+
+afterEach(() => {
+  transactions.length = 0;
+});
+
+afterAll(async () => {
+  await Sentry.close(0);
+});
+
+describe('Warden Service telemetry', () => {
+  it('removes Drizzle parameters before spans leave the process', () => {
+    const beforeSendSpan = Sentry.getClient()?.getOptions().beforeSendSpan;
+    if (!beforeSendSpan) throw new Error('Sentry span sanitizer was not initialized');
+    const span = {
+      data: {
+        'drizzle.query.text': 'select * from repositories where tenant_id = $1',
+        'drizzle.query.params': '["private-tenant-id"]',
+      },
+    } as unknown as Parameters<typeof beforeSendSpan>[0];
+
+    const sanitized = beforeSendSpan(span);
+
+    expect(sanitized.data).toMatchObject({
+      'drizzle.query.text': 'select * from repositories where tenant_id = $1',
+    });
+    expect(sanitized.data).not.toHaveProperty('drizzle.query.params');
+  });
+
+  it('records bounded request transactions without trusting query strings, entity IDs, or Host', async () => {
+    const handler = traceRequest(async (_request, response) => {
+      response.statusCode = 200;
+    });
+
+    await handler({
+      method: 'GET',
+      url: '/api/v1/findings/not-a-valid-id?query=private',
+      headers: { host: 'not a valid host %' },
+    }, { statusCode: 500 });
+    await Sentry.flush(1_000);
+
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]).toMatchObject({
+      transaction: 'GET /api/v1/findings/:id',
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'ok',
+          data: {
+            'http.request.method': 'GET',
+            'http.route': '/api/v1/findings/:id',
+            'http.response.status_code': 200,
+            'service.name': 'warden-service',
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(transactions[0])).not.toContain('private');
+    expect(JSON.stringify(transactions[0])).not.toContain('not-a-valid-id');
+  });
+
+  it('records raw SQL as a child span without recording parameter values', async () => {
+    const receivedValues: (readonly unknown[])[] = [];
+    const rawDatabase: WardenDatabase = {
+      driver: 'neon',
+      maxConnections: 3,
+      statementTimeoutMs: 15_000,
+      async query<TRow extends Record<string, unknown>>(
+        _text: string,
+        values: readonly unknown[] = [],
+      ) {
+        receivedValues.push(values);
+        return { rows: [] as TRow[], rowCount: 0 };
+      },
+      async withClient<T>(operation: (client: DatabaseClient) => Promise<T>) {
+        return operation({ query: this.query });
+      },
+      async transaction<T>(operation: (client: DatabaseClient) => Promise<T>) {
+        return operation({ query: this.query });
+      },
+      async close() { return undefined; },
+    };
+    const database = traceDatabase(rawDatabase);
+
+    await Sentry.startSpan({
+      name: 'GET /api/v1/repositories',
+      op: 'http.server',
+      forceTransaction: true,
+    }, () => database.query(
+      'SELECT id, full_name FROM repositories WHERE tenant_id = $1',
+      ['private-tenant-id'],
+    ));
+    await Sentry.flush(1_000);
+
+    expect(receivedValues).toEqual([['private-tenant-id']]);
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]?.spans).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        op: 'db.query',
+        description: 'SELECT id, full_name FROM repositories WHERE tenant_id = $1',
+        data: expect.objectContaining({
+          'db.system.name': 'postgresql',
+          'db.operation.name': 'SELECT',
+          'db.query.text': 'SELECT id, full_name FROM repositories WHERE tenant_id = $1',
+        }),
+      }),
+    ]));
+    expect(JSON.stringify(transactions[0])).not.toContain('private-tenant-id');
+  });
+});

--- a/apps/warden-service/src/sentry.ts
+++ b/apps/warden-service/src/sentry.ts
@@ -1,0 +1,183 @@
+import * as Sentry from '@sentry/node';
+import type { NodeOptions } from '@sentry/node';
+import type {
+  DatabaseClient,
+  QueryResult,
+  WardenDatabase,
+} from '@sentry/warden-service';
+
+type SentryInitOptions = Pick<
+  NodeOptions,
+  'beforeSend' | 'beforeSendTransaction' | 'transport'
+>;
+
+interface RequestLike {
+  method?: string;
+  url?: string;
+  headers: { host?: string | undefined };
+}
+
+interface ResponseLike {
+  statusCode: number;
+}
+
+const UUID_PATH_SEGMENT = /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi;
+const ENTITY_PATH_SEGMENT = /^(\/(?:findings|api\/v1\/(?:findings|runs|memories|personal-tokens)|api\/v1\/admin\/(?:repositories|runs))\/)[^/]+(?=\/|$)/;
+
+let initialized = false;
+
+function compactSql(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function databaseOperation(statement: string): string {
+  return statement.match(/^[A-Za-z]+/)?.[0]?.toUpperCase() ?? 'QUERY';
+}
+
+function traceQuery<TRow extends Record<string, unknown>>(
+  text: string,
+  operation: () => Promise<QueryResult<TRow>>,
+): Promise<QueryResult<TRow>> {
+  const statement = compactSql(text);
+  const command = databaseOperation(statement);
+  return Sentry.startSpan({
+    name: statement.slice(0, 200),
+    op: 'db.query',
+    attributes: {
+      'db.system': 'postgresql',
+      'db.system.name': 'postgresql',
+      'db.operation.name': command,
+      'db.query.text': statement,
+      'sentry.origin': 'manual.db.warden-service',
+    },
+  }, operation);
+}
+
+function traceClient(client: DatabaseClient): DatabaseClient {
+  return {
+    query<TRow extends Record<string, unknown>>(
+      text: string,
+      values?: readonly unknown[],
+    ): Promise<QueryResult<TRow>> {
+      return traceQuery(text, () => client.query<TRow>(text, values));
+    },
+  };
+}
+
+function routePath(request: RequestLike): string {
+  const pathname = new URL(request.url ?? '/', 'https://warden-service').pathname;
+  return pathname
+    .replace(ENTITY_PATH_SEGMENT, '$1:id')
+    .replace(UUID_PATH_SEGMENT, '/:id');
+}
+
+/** Initialize Warden Service telemetry when its optional DSN is configured. */
+export function initServiceTelemetry(
+  environment: NodeJS.ProcessEnv,
+  options: SentryInitOptions = {},
+): void {
+  const dsn = environment['WARDEN_SENTRY_DSN'];
+  if (!dsn || initialized) return;
+  initialized = true;
+
+  const commitSha = environment['VERCEL_GIT_COMMIT_SHA'];
+  Sentry.init({
+    dsn,
+    environment: environment['VERCEL_ENV'] ?? 'development',
+    ...(commitSha ? { release: `warden-service@${commitSha}` } : {}),
+    tracesSampleRate: 1.0,
+    enableLogs: true,
+    sendDefaultPii: false,
+    beforeSendSpan(span) {
+      if (span.data?.['drizzle.query.params'] === undefined) return span;
+      const { ['drizzle.query.params']: _parameters, ...data } = span.data;
+      return { ...span, data };
+    },
+    integrations(defaultIntegrations) {
+      return [
+        ...defaultIntegrations.filter(({ name }) => !['Hono', 'Http', 'Postgres'].includes(name)),
+        Sentry.httpIntegration({ disableIncomingRequestSpans: true }),
+        Sentry.consoleLoggingIntegration({ levels: ['warn', 'error'] }),
+      ];
+    },
+    ...options,
+  });
+  Sentry.getGlobalScope().setAttributes({
+    'service.name': 'warden-service',
+    'warden.source': 'service',
+  });
+}
+
+/** Add query spans to a service database without recording parameter values. */
+export function traceDatabase(database: WardenDatabase): WardenDatabase {
+  return {
+    driver: database.driver,
+    maxConnections: database.maxConnections,
+    statementTimeoutMs: database.statementTimeoutMs,
+    query<TRow extends Record<string, unknown>>(
+      text: string,
+      values?: readonly unknown[],
+    ): Promise<QueryResult<TRow>> {
+      return traceQuery(text, () => database.query<TRow>(text, values));
+    },
+    withClient<T>(operation: (client: DatabaseClient) => Promise<T>): Promise<T> {
+      return Sentry.startSpan({
+        name: 'database connection',
+        op: 'db.connection',
+      }, () => database.withClient((client) => operation(traceClient(client))));
+    },
+    transaction<T>(operation: (client: DatabaseClient) => Promise<T>): Promise<T> {
+      return Sentry.startSpan({
+        name: 'database transaction',
+        op: 'db.transaction',
+      }, () => database.transaction((client) => operation(traceClient(client))));
+    },
+    close(): Promise<void> {
+      return database.close();
+    },
+  };
+}
+
+/** Trace one Vercel request as a route transaction with bounded cardinality. */
+export function traceRequest<
+  TRequest extends RequestLike,
+  TResponse extends ResponseLike,
+>(
+  handler: (request: TRequest, response: TResponse) => void | Promise<void>,
+): (request: TRequest, response: TResponse) => Promise<void> {
+  return async (request, response) => {
+    const method = request.method?.toUpperCase() ?? 'GET';
+    const route = routePath(request);
+    await Sentry.withIsolationScope(() => Sentry.startSpan({
+      name: `${method} ${route}`,
+      op: 'http.server',
+      forceTransaction: true,
+      attributes: {
+        'http.request.method': method,
+        'http.route': route,
+        'service.name': 'warden-service',
+        'sentry.source': 'route',
+      },
+    }, async (span) => {
+      try {
+        await handler(request, response);
+      } catch (error) {
+        Sentry.captureException(error);
+        throw error;
+      } finally {
+        Sentry.setHttpStatus(span, response.statusCode);
+      }
+    }));
+  };
+}
+
+/** Capture a handled service exception without allowing telemetry to affect the response. */
+export function captureServiceError(error: Error): void {
+  try {
+    Sentry.captureException(error);
+  } catch {
+    // Telemetry must never break the service error handler.
+  }
+}
+
+export { Sentry };

--- a/packages/warden-service/AGENTS.md
+++ b/packages/warden-service/AGENTS.md
@@ -1,5 +1,11 @@
 # Warden Service Instructions
 
+## Database Queries
+
+- Use the Drizzle schema and typed query builder for new or changed runtime queries.
+- Use raw SQL only when PostgreSQL behavior cannot be expressed clearly in Drizzle; keep it parameterized and tenant-scoped.
+- Keep tracing at the database boundary. Never record query parameter values.
+
 ## Database Migrations
 
 - Assume migrations run while the previous production version is still serving traffic.

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createWardenService } from './app.js';
 import type { DatabaseClient, WardenDatabase } from './db/database.js';
 import type { GoogleAuthBridge, GoogleAuthSession } from './google-auth.js';
@@ -109,8 +109,10 @@ describe('createWardenService', () => {
   });
 
   it('returns safe not-found and error responses', async () => {
+    const onError = vi.fn();
     const app = createWardenService({
       rateLimit() { throw new Error('sql contains private finding'); },
+      onError,
     });
 
     const missing = await app.request('/missing');
@@ -120,6 +122,9 @@ describe('createWardenService', () => {
     const failed = await app.request('/api/explode');
     expect(failed.status).toBe(500);
     expect(await failed.text()).not.toContain('private finding');
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'sql contains private finding',
+    }));
   });
 
   it('applies payload and rate-limit hooks before API handlers', async () => {
@@ -304,22 +309,28 @@ describe('createWardenService', () => {
     const database = {
       ...readyDatabase(),
       async query<TRow extends Record<string, unknown>>(sql: string, values: readonly unknown[] = []) {
-        if (sql.includes('JOIN findings f') || sql.includes('FROM findings f')) return { rows: [{
+        if (sql.includes('inner join "findings"') || sql.includes('from "findings"')) {
+          const finding = {
           id: '00000000-0000-4000-8000-000000000010',
           client_finding_id: '7MV-5V7', reported_id: null,
           run_id: '00000000-0000-4000-8000-000000000011',
           client_run_id: 'run-11',
-          head_sha: 'abc123def456', source_evidence: null,
-          verification: 'The query interpolates untrusted input.',
+          ...(sql.includes('"runs"."head_sha"') ? {
+            head_sha: 'abc123def456',
+            source_evidence: null,
+            verification: 'The query interpolates untrusted input.',
+          } : {}),
           provider: 'github', owner: 'acme', name: 'widgets', full_name: 'acme/widgets',
           skill: 'security', severity: 'high', confidence: 'high',
           title: 'Unsafe query', description: 'Use parameters.',
           path: 'src/query.ts', start_line: 12, end_line: 12,
           observation_outcome: 'posted', observed_at: '2026-08-12T10:01:00.000Z',
           completed_at: '2026-08-12T10:01:00.000Z',
-        }] as unknown as TRow[], rowCount: 1 };
-        if (sql.includes('FROM runs r') && sql.includes('SUM(u.input_tokens)')) {
-          const grouped = sql.includes('GROUP BY');
+          };
+          return { rows: [finding] as unknown as TRow[], rowCount: 1 };
+        }
+        if (sql.includes('from "runs"') && sql.includes('SUM("usage_line_items"."input_tokens")')) {
+          const grouped = sql.includes('group by');
           return { rows: [{
             ...(grouped ? { dimension_0: 'security' } : {}),
             runs: 1, input_tokens: '100', output_tokens: '20', cost_usd: '0.012',

--- a/packages/warden-service/src/app.ts
+++ b/packages/warden-service/src/app.ts
@@ -48,6 +48,7 @@ export interface DashboardAssets {
 
 export interface CreateWardenServiceOptions {
   database?: WardenDatabase;
+  onError?: (error: Error) => void;
   rateLimit?: RateLimitHook;
   maxRequestBytes?: number;
   cronSecret?: string;
@@ -277,10 +278,17 @@ export function createWardenService(options: CreateWardenServiceOptions = {}) {
     404,
   ));
 
-  app.onError((_error, context) => context.json(
-    ApiErrorSchema.parse({ error: { code: 'internal_error', message: 'The service could not complete the request.' } }),
-    500,
-  ));
+  app.onError((error, context) => {
+    try {
+      options.onError?.(error);
+    } catch {
+      // Observability hooks must not change the safe service response.
+    }
+    return context.json(
+      ApiErrorSchema.parse({ error: { code: 'internal_error', message: 'The service could not complete the request.' } }),
+      500,
+    );
+  });
 
   return app;
 }

--- a/packages/warden-service/src/db/query.ts
+++ b/packages/warden-service/src/db/query.ts
@@ -1,0 +1,27 @@
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import type { PgRemoteDatabase } from 'drizzle-orm/pg-proxy';
+import type { WardenDatabase } from './database.js';
+import * as schema from './schema.js';
+
+export type WardenReadDatabase = PgRemoteDatabase<typeof schema>;
+
+const readDatabases = new WeakMap<WardenDatabase, WardenReadDatabase>();
+
+/** Build one typed Drizzle read client over the service database boundary. */
+export function getReadDatabase(database: WardenDatabase): WardenReadDatabase {
+  const existing = readDatabases.get(database);
+  if (existing) return existing;
+
+  const readDatabase = drizzle(async (text, params, method) => {
+    const result = await database.query(text, params);
+    return {
+      // Postgres constructs row objects in result-column order. The proxy
+      // driver needs arrays so Drizzle can map them back to typed selections.
+      rows: method === 'all'
+        ? result.rows.map((row) => Object.values(row))
+        : result.rows,
+    };
+  }, { schema });
+  readDatabases.set(database, readDatabase);
+  return readDatabase;
+}

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -26,10 +26,6 @@ describe('history store', () => {
       client_run_id: `client-${id}`,
       source: 'action',
       data_profile: 'metrics',
-      provider: 'github',
-      owner: 'acme',
-      name: 'widgets',
-      full_name: 'acme/widgets',
       started_at: '2026-08-12T10:00:00.000Z',
       completed_at: completedAt,
       outcome: 'success',
@@ -37,8 +33,12 @@ describe('history store', () => {
       high_count: 0,
       medium_count: 0,
       low_count: 0,
-      cost_usd: null,
       trace_id: null,
+      provider: 'github',
+      owner: 'acme',
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      cost_usd: null,
     });
     const database = databaseFor((sql, values) => {
       seen.push({ sql, values });
@@ -53,8 +53,8 @@ describe('history store', () => {
     expect(page.items).toHaveLength(1);
     expect(page.items[0]?.costUsd).toBeNull();
     expect(page.nextCursor).toBeTypeOf('string');
-    expect(seen[0]?.sql).toContain('r.tenant_id = $1');
-    expect(seen[0]?.values[0]).toBe(context.tenantId);
+    expect(seen[0]?.sql).toContain('"runs"."tenant_id" = $1');
+    expect(seen[0]?.values).toContain(context.tenantId);
   });
 
   it('combines history dimensions without weakening tenant scope', async () => {
@@ -78,9 +78,9 @@ describe('history store', () => {
       errorCode: 'provider_unavailable',
     });
 
-    expect(captured?.sql).toContain('r.tenant_id = $1');
-    expect(captured?.sql).toContain('EXISTS (SELECT 1 FROM skill_executions filtered_se');
-    expect(captured?.sql).toContain('filtered_se.id = u.skill_execution_id');
+    expect(captured?.sql).toContain('"runs"."tenant_id" = $1');
+    expect(captured?.sql).toContain('exists (select 1 from "skill_executions" "filtered_se"');
+    expect(captured?.sql).toContain('"filtered_se"."id" = "usage_line_items"."skill_execution_id"');
     expect(captured?.values).toEqual(expect.arrayContaining([
       context.tenantId,
       'security',
@@ -102,11 +102,10 @@ describe('history store', () => {
 
     expect(statements).toHaveLength(2);
     for (const sql of statements) {
-      expect(sql).toContain('EXISTS (SELECT 1 FROM skill_executions filtered_se');
-      expect(sql).toContain('filtered_se.skill =');
-      expect(sql).toContain('filtered_se.error_code =');
-      expect(sql).not.toContain('filtered_se.id = u.skill_execution_id');
-      expect(sql).not.toContain('se.id = u.skill_execution_id');
+      expect(sql).toContain('exists (select 1 from "skill_executions" "filtered_se"');
+      expect(sql).toContain('"filtered_se"."skill" =');
+      expect(sql).toContain('"filtered_se"."error_code" =');
+      expect(sql).not.toContain('"filtered_se"."id" = "usage_line_items"."skill_execution_id"');
     }
   });
 
@@ -153,11 +152,11 @@ describe('history store', () => {
       location: { path: 'src/api.ts', startLine: 42 },
       outcome: 'posted',
     });
-    expect(captured?.sql).toContain('FROM runs r');
-    expect(captured?.sql).toContain('JOIN findings f ON f.run_id = r.id');
-    expect(captured?.sql).toContain('r.tenant_id = $1');
+    expect(captured?.sql).toContain('from "runs" inner join "findings"');
+    expect(captured?.sql).toContain('"findings"."run_id" = "runs"."id"');
+    expect(captured?.sql).toContain('"runs"."tenant_id" =');
     expect(captured?.sql).toContain('POSITION(');
-    expect(captured?.sql).toContain('LEFT JOIN LATERAL');
+    expect(captured?.sql).toContain('left join lateral');
     expect(captured?.values).toEqual(expect.arrayContaining([
       context.tenantId,
       'security-review',
@@ -206,7 +205,9 @@ describe('history store', () => {
       verification: 'The route reads an account before checking the caller.',
       finding: { observedAt: '2026-08-12T10:02:00.000Z' },
     });
-    expect(detailSql).toContain('ORDER BY fo.observed_at DESC, fo.id DESC LIMIT 1');
+    expect(detailSql).toContain(
+      'order by "finding_observations"."observed_at" desc, "finding_observations"."id" desc limit',
+    );
   });
 
   it('applies repository allowlists to every history read boundary', async () => {
@@ -228,8 +229,8 @@ describe('history store', () => {
 
     expect(statements).toHaveLength(9);
     for (const statement of statements) {
-      expect(statement.sql).toContain('full_name = ANY');
-      expect(statement.values).toContainEqual(['acme/widgets']);
+      expect(statement.sql).toContain('"repositories"."full_name" in');
+      expect(statement.values).toContain('acme/widgets');
     }
   });
 
@@ -244,18 +245,18 @@ describe('history store', () => {
     await listSkills(database, context);
     await summarizeOutcomes(database, context, {});
 
-    expect(statements[0]).toContain('WITH run_costs AS');
-    expect(statements[0]).toContain('LEFT JOIN run_costs costs ON costs.run_id = r.id');
-    expect(statements[1]).toContain('WITH skill_costs AS');
-    expect(statements[1]).toContain('LEFT JOIN skill_costs costs ON costs.skill_execution_id = se.id');
-    expect(statements[2]).toContain('run_costs AS');
-    expect(statements[2]).toContain('LEFT JOIN run_costs costs ON costs.run_id = filtered_runs.id');
-    expect(statements).not.toEqual(expect.arrayContaining([expect.stringContaining('LEFT JOIN LATERAL')]));
+    expect(statements[0]).toContain('with "run_costs" as');
+    expect(statements[0]).toContain('left join "run_costs" on "run_costs"."run_id" = "runs"."id"');
+    expect(statements[1]).toContain('with "skill_costs" as');
+    expect(statements[1]).toContain('left join "skill_costs" on "skill_costs"."skill_execution_id" = "skill_executions"."id"');
+    expect(statements[2]).toContain('"run_costs" as');
+    expect(statements[2]).toContain('left join "run_costs" on "run_costs"."run_id" = "filtered_runs"."id"');
+    expect(statements).not.toEqual(expect.arrayContaining([expect.stringContaining('left join lateral')]));
   });
 
   it('aggregates allowlisted dimensions while keeping unknown cost null', async () => {
     const database = databaseFor((sql) => ({
-      rows: sql.includes('GROUP BY') ? [{
+      rows: sql.includes('group by') ? [{
         dimension_0: 'acme/widgets',
         dimension_1: 'security',
         runs: 2,

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -12,10 +12,34 @@ import type {
   UsageLineItem,
 } from '@sentry/warden-service-api';
 import { SourceEvidenceSchema } from '@sentry/warden-service-api';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  lte,
+  sql,
+} from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 import { requireServiceContext } from '../context.js';
 import type { ServiceContext } from '../context.js';
 import type { WardenDatabase } from '../db/database.js';
+import { getReadDatabase } from '../db/query.js';
+import type { WardenReadDatabase } from '../db/query.js';
+import {
+  findingLocations,
+  findingObservations,
+  findings,
+  repositories,
+  runs,
+  skillExecutions,
+  usageLineItems,
+} from '../db/schema.js';
 
 export interface HistoryFilters {
   from?: string;
@@ -118,39 +142,51 @@ function mapRun(row: RunRow): RunSummary {
   };
 }
 
-function addFilter(conditions: string[], values: unknown[], expression: string, value: unknown): void {
-  values.push(value);
-  conditions.push(`${expression} $${values.length}`);
+const filteredSkillExecutions = alias(skillExecutions, 'filtered_se');
+
+function repositoryScope(context: ServiceContext): SQL | undefined {
+  return context.repositoryAllowlist
+    ? inArray(repositories.fullName, context.repositoryAllowlist)
+    : undefined;
 }
 
-function historyWhere(context: ServiceContext, filters: HistoryFilters, executionScope: 'run' | 'usage' = 'run') {
-  const values: unknown[] = [context.tenantId];
-  const conditions = ['r.tenant_id = $1'];
+function historyWhere(
+  database: WardenReadDatabase,
+  context: ServiceContext,
+  filters: HistoryFilters,
+  executionScope: 'run' | 'usage' = 'run',
+): SQL[] {
+  const conditions: SQL[] = [eq(runs.tenantId, context.tenantId)];
   const filtersUsage = Boolean(filters.model || filters.runtime || filters.provider || filters.lane);
-  if (context.repositoryAllowlist) {
-    values.push(context.repositoryAllowlist);
-    conditions.push(`repo.full_name = ANY($${values.length}::text[])`);
-  }
-  if (filters.from) addFilter(conditions, values, 'r.completed_at >=', filters.from);
-  if (filters.to) addFilter(conditions, values, 'r.completed_at <=', filters.to);
-  if (filters.repositoryId) addFilter(conditions, values, 'r.repository_id =', filters.repositoryId);
-  if (filters.source) addFilter(conditions, values, 'r.source =', filters.source);
-  if (filters.outcome) addFilter(conditions, values, 'r.outcome =', filters.outcome);
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  if (filters.from) conditions.push(gte(runs.completedAt, new Date(filters.from)));
+  if (filters.to) conditions.push(lte(runs.completedAt, new Date(filters.to)));
+  if (filters.repositoryId) conditions.push(eq(runs.repositoryId, filters.repositoryId));
+  if (filters.source) conditions.push(eq(runs.source, filters.source));
+  if (filters.outcome) conditions.push(eq(runs.outcome, filters.outcome));
   if (executionScope === 'usage') {
-    if (filters.skill) addFilter(conditions, values, 'se.skill =', filters.skill);
-    if (filters.errorCode) addFilter(conditions, values, 'se.error_code =', filters.errorCode);
+    if (filters.skill) conditions.push(eq(skillExecutions.skill, filters.skill));
+    if (filters.errorCode) conditions.push(eq(skillExecutions.errorCode, filters.errorCode));
   } else if (filters.skill || filters.errorCode) {
-    const executionConditions = ['filtered_se.tenant_id = r.tenant_id', 'filtered_se.run_id = r.id'];
-    if (filtersUsage) executionConditions.push('filtered_se.id = u.skill_execution_id');
-    if (filters.skill) addFilter(executionConditions, values, 'filtered_se.skill =', filters.skill);
-    if (filters.errorCode) addFilter(executionConditions, values, 'filtered_se.error_code =', filters.errorCode);
-    conditions.push(`EXISTS (SELECT 1 FROM skill_executions filtered_se WHERE ${executionConditions.join(' AND ')})`);
+    const executionConditions: SQL[] = [
+      eq(filteredSkillExecutions.tenantId, runs.tenantId),
+      eq(filteredSkillExecutions.runId, runs.id),
+    ];
+    if (filtersUsage) executionConditions.push(eq(filteredSkillExecutions.id, usageLineItems.skillExecutionId));
+    if (filters.skill) executionConditions.push(eq(filteredSkillExecutions.skill, filters.skill));
+    if (filters.errorCode) executionConditions.push(eq(filteredSkillExecutions.errorCode, filters.errorCode));
+    conditions.push(exists(
+      database.select({ value: sql`1` })
+        .from(filteredSkillExecutions)
+        .where(and(...executionConditions)),
+    ));
   }
-  if (filters.model) addFilter(conditions, values, 'u.model =', filters.model);
-  if (filters.runtime) addFilter(conditions, values, 'u.runtime =', filters.runtime);
-  if (filters.provider) addFilter(conditions, values, 'u.provider =', filters.provider);
-  if (filters.lane) addFilter(conditions, values, 'u.lane =', filters.lane);
-  return { conditions, values };
+  if (filters.model) conditions.push(eq(usageLineItems.model, filters.model));
+  if (filters.runtime) conditions.push(eq(usageLineItems.runtime, filters.runtime));
+  if (filters.provider) conditions.push(eq(usageLineItems.provider, filters.provider));
+  if (filters.lane) conditions.push(eq(usageLineItems.lane, filters.lane));
+  return conditions;
 }
 
 function encodeCursor(completedAt: Date | string, id: string): string {
@@ -224,6 +260,35 @@ function githubSourceUrl(row: FindingDetailRow): string | undefined {
   return `https://github.com/${repository}/blob/${encodeURIComponent(row.head_sha)}/${path}#L${row.start_line}${endLine}`;
 }
 
+function findingContextQueries(database: WardenReadDatabase) {
+  const location = database.select({
+    path: findingLocations.path,
+    start_line: findingLocations.startLine,
+    end_line: findingLocations.endLine,
+  })
+    .from(findingLocations)
+    .where(and(
+      eq(findingLocations.tenantId, findings.tenantId),
+      eq(findingLocations.findingId, findings.id),
+    ))
+    .orderBy(asc(findingLocations.ordinal))
+    .limit(1)
+    .as('location');
+  const observation = database.select({
+    outcome: findingObservations.outcome,
+    observed_at: findingObservations.observedAt,
+  })
+    .from(findingObservations)
+    .where(and(
+      eq(findingObservations.tenantId, findings.tenantId),
+      eq(findingObservations.findingId, findings.id),
+    ))
+    .orderBy(desc(findingObservations.observedAt), desc(findingObservations.id))
+    .limit(1)
+    .as('observation');
+  return { location, observation };
+}
+
 /** List authorized findings newest first for dashboard and API investigations. */
 export async function listFindings(
   database: WardenDatabase,
@@ -232,62 +297,66 @@ export async function listFindings(
 ): Promise<FindingListResponse> {
   const context = requireServiceContext(contextInput);
   const limit = Math.min(100, Math.max(1, filters.limit ?? 50));
-  const values: unknown[] = [context.tenantId];
+  const read = getReadDatabase(database);
+  const { location, observation } = findingContextQueries(read);
   // Scope runs first so completed_at range/order can use runs_tenant_* indexes.
-  const conditions = ['r.tenant_id = $1'];
-  if (context.repositoryAllowlist) {
-    values.push(context.repositoryAllowlist);
-    conditions.push(`repo.full_name = ANY($${values.length}::text[])`);
-  }
-  if (filters.from) addFilter(conditions, values, 'r.completed_at >=', filters.from);
-  if (filters.to) addFilter(conditions, values, 'r.completed_at <=', filters.to);
-  if (filters.repositoryId) addFilter(conditions, values, 'r.repository_id =', filters.repositoryId);
-  if (filters.skill) addFilter(conditions, values, 'se.skill =', filters.skill);
-  if (filters.severity) addFilter(conditions, values, 'f.severity =', filters.severity);
-  if (filters.outcome) addFilter(conditions, values, 'observation.outcome =', filters.outcome);
+  const conditions: SQL[] = [eq(runs.tenantId, context.tenantId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  if (filters.from) conditions.push(gte(runs.completedAt, new Date(filters.from)));
+  if (filters.to) conditions.push(lte(runs.completedAt, new Date(filters.to)));
+  if (filters.repositoryId) conditions.push(eq(runs.repositoryId, filters.repositoryId));
+  if (filters.skill) conditions.push(eq(skillExecutions.skill, filters.skill));
+  if (filters.severity) conditions.push(eq(findings.severity, filters.severity));
+  if (filters.outcome) conditions.push(eq(observation.outcome, filters.outcome));
   if (filters.query) {
-    values.push(filters.query.toLowerCase());
-    conditions.push(`POSITION($${values.length} IN LOWER(f.title || ' ' || f.description || ' ' || COALESCE(location.path, ''))) > 0`);
+    conditions.push(sql`POSITION(${filters.query.toLowerCase()} IN LOWER(
+      ${findings.title} || ' ' || ${findings.description} || ' ' || COALESCE(${location.path}, '')
+    )) > 0`);
   }
   if (filters.cursor) {
     const [completedAt, id] = filters.cursor;
-    values.push(completedAt, id);
-    conditions.push(`(r.completed_at, f.id) < ($${values.length - 1}, $${values.length})`);
+    conditions.push(sql`(${runs.completedAt}, ${findings.id}) < (${new Date(completedAt)}, ${id})`);
   }
-  values.push(limit + 1);
   // Drive from runs so tenant + completed_at (+ repository) indexes own the sort,
   // then join findings by run instead of scanning findings and sorting after the fact.
-  const result = await database.query<FindingFeedRow>(`
-    SELECT f.id, f.client_finding_id, f.reported_id, f.run_id, r.client_run_id,
-      repo.provider, repo.owner, repo.name, repo.full_name,
-      se.skill, f.severity, f.confidence, f.title, f.description,
-      location.path, location.start_line, location.end_line,
-      observation.outcome AS observation_outcome, observation.observed_at, r.completed_at
-    FROM runs r
-    JOIN findings f ON f.run_id = r.id AND f.tenant_id = r.tenant_id
-    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    JOIN skill_executions se ON se.id = f.skill_execution_id AND se.tenant_id = f.tenant_id
-    LEFT JOIN LATERAL (
-      SELECT fl.path, fl.start_line, fl.end_line
-      FROM finding_locations fl
-      WHERE fl.tenant_id = f.tenant_id AND fl.finding_id = f.id
-      ORDER BY fl.ordinal LIMIT 1
-    ) location ON true
-    LEFT JOIN LATERAL (
-      SELECT fo.outcome, fo.observed_at
-      FROM finding_observations fo
-      WHERE fo.tenant_id = f.tenant_id AND fo.finding_id = f.id
-      ORDER BY fo.observed_at DESC, fo.id DESC LIMIT 1
-    ) observation ON true
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY r.completed_at DESC, f.id DESC
-    LIMIT $${values.length}
-  `, values);
-  const page = result.rows.slice(0, limit);
+  const result = await read.select({
+    id: findings.id,
+    client_finding_id: findings.clientFindingId,
+    reported_id: findings.reportedId,
+    run_id: findings.runId,
+    client_run_id: runs.clientRunId,
+    provider: repositories.provider,
+    owner: repositories.owner,
+    name: repositories.name,
+    full_name: repositories.fullName,
+    skill: skillExecutions.skill,
+    severity: findings.severity,
+    confidence: findings.confidence,
+    title: findings.title,
+    description: findings.description,
+    path: location.path,
+    start_line: location.start_line,
+    end_line: location.end_line,
+    observation_outcome: observation.outcome,
+    observed_at: observation.observed_at,
+    completed_at: runs.completedAt,
+  })
+    .from(runs)
+    .innerJoin(findings, and(eq(findings.runId, runs.id), eq(findings.tenantId, runs.tenantId)))
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .innerJoin(skillExecutions, and(eq(skillExecutions.id, findings.skillExecutionId), eq(skillExecutions.tenantId, findings.tenantId)))
+    .leftJoinLateral(location, sql`true`)
+    .leftJoinLateral(observation, sql`true`)
+    .where(and(...conditions))
+    .orderBy(desc(runs.completedAt), desc(findings.id))
+    .limit(limit + 1);
+  const rows = result as unknown as FindingFeedRow[];
+  const page = rows.slice(0, limit);
   const last = page.at(-1);
   return {
     items: page.map(mapFinding),
-    ...(result.rows.length > limit && last ? { nextCursor: encodeCursor(last.completed_at, last.id) } : {}),
+    ...(rows.length > limit && last ? { nextCursor: encodeCursor(last.completed_at, last.id) } : {}),
   };
 }
 
@@ -298,39 +367,44 @@ export async function getFindingDetail(
   findingId: string,
 ): Promise<FindingDetailResponse | null> {
   const context = requireServiceContext(contextInput);
-  const values: unknown[] = [context.tenantId, findingId];
-  const repositoryScope = context.repositoryAllowlist
-    ? (() => {
-        values.push(context.repositoryAllowlist);
-        return `AND repo.full_name = ANY($${values.length}::text[])`;
-      })()
-    : '';
-  const result = await database.query<FindingDetailRow>(`
-    SELECT f.id, f.client_finding_id, f.reported_id, f.run_id, r.client_run_id,
-      r.head_sha, f.source_evidence, f.verification,
-      repo.provider, repo.owner, repo.name, repo.full_name,
-      se.skill, f.severity, f.confidence, f.title, f.description,
-      location.path, location.start_line, location.end_line,
-      observation.outcome AS observation_outcome, observation.observed_at, r.completed_at
-    FROM findings f
-    JOIN runs r ON r.id = f.run_id AND r.tenant_id = f.tenant_id
-    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    JOIN skill_executions se ON se.id = f.skill_execution_id AND se.tenant_id = f.tenant_id
-    LEFT JOIN LATERAL (
-      SELECT fl.path, fl.start_line, fl.end_line
-      FROM finding_locations fl
-      WHERE fl.tenant_id = f.tenant_id AND fl.finding_id = f.id
-      ORDER BY fl.ordinal LIMIT 1
-    ) location ON true
-    LEFT JOIN LATERAL (
-      SELECT fo.outcome, fo.observed_at
-      FROM finding_observations fo
-      WHERE fo.tenant_id = f.tenant_id AND fo.finding_id = f.id
-      ORDER BY fo.observed_at DESC, fo.id DESC LIMIT 1
-    ) observation ON true
-    WHERE f.tenant_id = $1 AND f.id = $2 ${repositoryScope}
-  `, values);
-  const finding = result.rows[0];
+  const read = getReadDatabase(database);
+  const { location, observation } = findingContextQueries(read);
+  const conditions: SQL[] = [eq(findings.tenantId, context.tenantId), eq(findings.id, findingId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  const result = await read.select({
+    id: findings.id,
+    client_finding_id: findings.clientFindingId,
+    reported_id: findings.reportedId,
+    run_id: findings.runId,
+    client_run_id: runs.clientRunId,
+    head_sha: runs.headSha,
+    source_evidence: findings.sourceEvidence,
+    verification: findings.verification,
+    provider: repositories.provider,
+    owner: repositories.owner,
+    name: repositories.name,
+    full_name: repositories.fullName,
+    skill: skillExecutions.skill,
+    severity: findings.severity,
+    confidence: findings.confidence,
+    title: findings.title,
+    description: findings.description,
+    path: location.path,
+    start_line: location.start_line,
+    end_line: location.end_line,
+    observation_outcome: observation.outcome,
+    observed_at: observation.observed_at,
+    completed_at: runs.completedAt,
+  })
+    .from(findings)
+    .innerJoin(runs, and(eq(runs.id, findings.runId), eq(runs.tenantId, findings.tenantId)))
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .innerJoin(skillExecutions, and(eq(skillExecutions.id, findings.skillExecutionId), eq(skillExecutions.tenantId, findings.tenantId)))
+    .leftJoinLateral(location, sql`true`)
+    .leftJoinLateral(observation, sql`true`)
+    .where(and(...conditions));
+  const finding = result[0] as unknown as FindingDetailRow | undefined;
   if (!finding) return null;
   const sourceEvidence = SourceEvidenceSchema.safeParse(finding.source_evidence);
   const sourceUrl = githubSourceUrl(finding);
@@ -347,31 +421,47 @@ export async function getFindingDetail(
 export async function listRuns(database: WardenDatabase, contextInput: ServiceContext | undefined, filters: RunListFilters): Promise<RunListResponse> {
   const context = requireServiceContext(contextInput);
   const limit = Math.min(100, Math.max(1, filters.limit ?? 50));
-  const { conditions, values } = historyWhere(context, filters);
+  const read = getReadDatabase(database);
+  const conditions = historyWhere(read, context, filters);
   if (filters.cursor) {
     const [completedAt, id] = filters.cursor;
-    values.push(completedAt, id);
-    conditions.push(`(r.completed_at, r.id) < ($${values.length - 1}, $${values.length})`);
+    conditions.push(sql`(${runs.completedAt}, ${runs.id}) < (${new Date(completedAt)}, ${id})`);
   }
-  values.push(limit + 1);
-  const result = await database.query<RunRow>(`
-    SELECT DISTINCT
-      r.id, r.client_run_id, r.source, r.data_profile, r.started_at, r.completed_at,
-      r.outcome, r.finding_count, r.high_count, r.medium_count, r.low_count, r.trace_id,
-      repo.provider, repo.owner, repo.name, repo.full_name,
-      (SELECT SUM(cost_usd) FROM usage_line_items totals WHERE totals.run_id = r.id) AS cost_usd
-    FROM runs r
-    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    LEFT JOIN usage_line_items u ON u.run_id = r.id AND u.tenant_id = r.tenant_id
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY r.completed_at DESC, r.id DESC
-    LIMIT $${values.length}
-  `, values);
-  const page = result.rows.slice(0, limit);
+  const result = await read.selectDistinct({
+    id: runs.id,
+    client_run_id: runs.clientRunId,
+    source: runs.source,
+    data_profile: runs.dataProfile,
+    started_at: runs.startedAt,
+    completed_at: runs.completedAt,
+    outcome: runs.outcome,
+    finding_count: runs.findingCount,
+    high_count: runs.highCount,
+    medium_count: runs.mediumCount,
+    low_count: runs.lowCount,
+    trace_id: runs.traceId,
+    provider: repositories.provider,
+    owner: repositories.owner,
+    name: repositories.name,
+    full_name: repositories.fullName,
+    cost_usd: sql<string | null>`(
+      SELECT SUM(${usageLineItems.costUsd})
+      FROM ${usageLineItems}
+      WHERE ${usageLineItems.runId} = ${runs.id}
+    )`.as('cost_usd'),
+  })
+    .from(runs)
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
+    .where(and(...conditions))
+    .orderBy(desc(runs.completedAt), desc(runs.id))
+    .limit(limit + 1);
+  const rows = result as unknown as RunRow[];
+  const page = rows.slice(0, limit);
   const last = page.at(-1);
   return {
     items: page.map(mapRun),
-    ...(result.rows.length > limit && last ? { nextCursor: encodeCursor(last.completed_at, last.id) } : {}),
+    ...(rows.length > limit && last ? { nextCursor: encodeCursor(last.completed_at, last.id) } : {}),
   };
 }
 
@@ -429,37 +519,79 @@ function mapUsage(row: UsageRow): UsageLineItem {
 /** Return one run and its skill/usage breakdown without revealing cross-tenant ID existence. */
 export async function getRunDetail(database: WardenDatabase, contextInput: ServiceContext | undefined, runId: string): Promise<RunDetailResponse | null> {
   const context = requireServiceContext(contextInput);
-  const values: unknown[] = [context.tenantId, runId];
-  const repositoryScope = context.repositoryAllowlist
-    ? (() => {
-        values.push(context.repositoryAllowlist);
-        return `AND repo.full_name = ANY($${values.length}::text[])`;
-      })()
-    : '';
-  const runs = await database.query<RunRow>(`
-    SELECT r.id, r.client_run_id, r.source, r.data_profile, r.started_at, r.completed_at,
-      r.outcome, r.finding_count, r.high_count, r.medium_count, r.low_count, r.trace_id,
-      repo.provider, repo.owner, repo.name, repo.full_name,
-      (SELECT SUM(cost_usd) FROM usage_line_items totals WHERE totals.run_id = r.id) AS cost_usd
-    FROM runs r JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    WHERE r.tenant_id = $1 AND r.id = $2 ${repositoryScope}
-  `, values);
-  const run = runs.rows[0];
+  const read = getReadDatabase(database);
+  const conditions: SQL[] = [eq(runs.tenantId, context.tenantId), eq(runs.id, runId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  const loadedRuns = await read.select({
+    id: runs.id,
+    client_run_id: runs.clientRunId,
+    source: runs.source,
+    data_profile: runs.dataProfile,
+    started_at: runs.startedAt,
+    completed_at: runs.completedAt,
+    outcome: runs.outcome,
+    finding_count: runs.findingCount,
+    high_count: runs.highCount,
+    medium_count: runs.mediumCount,
+    low_count: runs.lowCount,
+    trace_id: runs.traceId,
+    provider: repositories.provider,
+    owner: repositories.owner,
+    name: repositories.name,
+    full_name: repositories.fullName,
+    cost_usd: sql<string | null>`(
+      SELECT SUM(${usageLineItems.costUsd})
+      FROM ${usageLineItems}
+      WHERE ${usageLineItems.runId} = ${runs.id}
+    )`.as('cost_usd'),
+  })
+    .from(runs)
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .where(and(...conditions));
+  const run = loadedRuns[0] as unknown as RunRow | undefined;
   if (!run) return null;
-  const skills = await database.query<SkillRow>(`
-    SELECT id, client_execution_id, skill, status, model, runtime, duration_ms,
-      finding_count, high_count, medium_count, low_count
-    FROM skill_executions WHERE tenant_id = $1 AND run_id = $2 ORDER BY created_at, id
-  `, [context.tenantId, runId]);
-  const usage = await database.query<UsageRow>(`
-    SELECT skill_execution_id, lane, operation, provider, model, runtime, input_tokens, output_tokens,
-      cache_read_input_tokens, cache_creation_input_tokens, cache_creation_5m_input_tokens,
-      cache_creation_1h_input_tokens, web_search_requests, cost_usd, cost_basis
-    FROM usage_line_items WHERE tenant_id = $1 AND run_id = $2 ORDER BY created_at, id
-  `, [context.tenantId, runId]);
+  const loadedSkills = await read.select({
+    id: skillExecutions.id,
+    client_execution_id: skillExecutions.clientExecutionId,
+    skill: skillExecutions.skill,
+    status: skillExecutions.status,
+    model: skillExecutions.model,
+    runtime: skillExecutions.runtime,
+    duration_ms: skillExecutions.durationMs,
+    finding_count: skillExecutions.findingCount,
+    high_count: skillExecutions.highCount,
+    medium_count: skillExecutions.mediumCount,
+    low_count: skillExecutions.lowCount,
+  })
+    .from(skillExecutions)
+    .where(and(eq(skillExecutions.tenantId, context.tenantId), eq(skillExecutions.runId, runId)))
+    .orderBy(asc(skillExecutions.createdAt), asc(skillExecutions.id));
+  const loadedUsage = await read.select({
+    skill_execution_id: usageLineItems.skillExecutionId,
+    lane: usageLineItems.lane,
+    operation: usageLineItems.operation,
+    provider: usageLineItems.provider,
+    model: usageLineItems.model,
+    runtime: usageLineItems.runtime,
+    input_tokens: usageLineItems.inputTokens,
+    output_tokens: usageLineItems.outputTokens,
+    cache_read_input_tokens: usageLineItems.cacheReadInputTokens,
+    cache_creation_input_tokens: usageLineItems.cacheCreationInputTokens,
+    cache_creation_5m_input_tokens: usageLineItems.cacheCreation5mInputTokens,
+    cache_creation_1h_input_tokens: usageLineItems.cacheCreation1hInputTokens,
+    web_search_requests: usageLineItems.webSearchRequests,
+    cost_usd: usageLineItems.costUsd,
+    cost_basis: usageLineItems.costBasis,
+  })
+    .from(usageLineItems)
+    .where(and(eq(usageLineItems.tenantId, context.tenantId), eq(usageLineItems.runId, runId)))
+    .orderBy(asc(usageLineItems.createdAt), asc(usageLineItems.id));
+  const skills = loadedSkills as unknown as SkillRow[];
+  const usage = loadedUsage as unknown as UsageRow[];
   return {
     run: mapRun(run),
-    skills: skills.rows.map((skill) => ({
+    skills: skills.map((skill) => ({
       id: skill.id,
       executionId: skill.client_execution_id,
       skill: skill.skill,
@@ -471,21 +603,21 @@ export async function getRunDetail(database: WardenDatabase, contextInput: Servi
         total: skill.finding_count,
         bySeverity: { high: skill.high_count, medium: skill.medium_count, low: skill.low_count },
       },
-      usage: usage.rows.filter((item) => item.skill_execution_id === skill.id).map(mapUsage),
+      usage: usage.filter((item) => item.skill_execution_id === skill.id).map(mapUsage),
     })),
   };
 }
 
-const dimensionSql: Record<CostDimension, string> = {
-  day: "to_char(date_trunc('day', r.completed_at), 'YYYY-MM-DD')",
-  repository: 'repo.full_name',
-  skill: "COALESCE(se.skill, 'unattributed')",
-  model: "COALESCE(u.model, 'unknown')",
-  runtime: "COALESCE(u.runtime, 'unknown')",
-  provider: "COALESCE(u.provider, 'unknown')",
-  lane: "COALESCE(u.lane, 'unattributed')",
-  source: 'r.source::text',
-  outcome: 'r.outcome::text',
+const dimensionSql: Record<CostDimension, SQL<string>> = {
+  day: sql<string>`to_char(date_trunc('day', ${runs.completedAt}), 'YYYY-MM-DD')`,
+  repository: sql<string>`${repositories.fullName}`,
+  skill: sql<string>`COALESCE(${skillExecutions.skill}, 'unattributed')`,
+  model: sql<string>`COALESCE(${usageLineItems.model}, 'unknown')`,
+  runtime: sql<string>`COALESCE(${usageLineItems.runtime}, 'unknown')`,
+  provider: sql<string>`COALESCE(${usageLineItems.provider}, 'unknown')`,
+  lane: sql<string>`COALESCE(${usageLineItems.lane}, 'unattributed')`,
+  source: sql<string>`${runs.source}::text`,
+  outcome: sql<string>`${runs.outcome}::text`,
 };
 
 interface AggregateRow extends Record<string, unknown> {
@@ -497,24 +629,29 @@ interface AggregateRow extends Record<string, unknown> {
 }
 
 async function aggregateRows(database: WardenDatabase, context: ServiceContext, filters: HistoryFilters, dimensions: readonly CostDimension[]) {
-  const { conditions, values } = historyWhere(context, filters, 'usage');
-  const selectDimensions = dimensions.map((dimension, index) => `${dimensionSql[dimension]} AS dimension_${index}`);
+  const read = getReadDatabase(database);
+  const conditions = historyWhere(read, context, filters, 'usage');
   const groupDimensions = dimensions.map((dimension) => dimensionSql[dimension]);
-  const result = await database.query<AggregateRow>(`
-    SELECT ${selectDimensions.length ? `${selectDimensions.join(', ')},` : ''}
-      COUNT(DISTINCT r.id)::integer AS runs,
-      COALESCE(SUM(u.input_tokens), 0) AS input_tokens,
-      COALESCE(SUM(u.output_tokens), 0) AS output_tokens,
-      SUM(u.cost_usd) AS cost_usd
-    FROM runs r
-    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    LEFT JOIN usage_line_items u ON u.run_id = r.id AND u.tenant_id = r.tenant_id
-    LEFT JOIN skill_executions se ON se.id = u.skill_execution_id AND se.tenant_id = r.tenant_id
-    WHERE ${conditions.join(' AND ')}
-    ${groupDimensions.length ? `GROUP BY ${groupDimensions.join(', ')}` : ''}
-    ${groupDimensions.length ? `ORDER BY ${groupDimensions.join(', ')}` : ''}
-  `, values);
-  return result.rows;
+  const selectDimensions = Object.fromEntries(dimensions.map((dimension, index) => [
+    `dimension_${index}`,
+    dimensionSql[dimension].as(`dimension_${index}`),
+  ]));
+  const query = read.select({
+    ...selectDimensions,
+    runs: sql<number>`COUNT(DISTINCT ${runs.id})::integer`.as('runs'),
+    input_tokens: sql<string | number>`COALESCE(SUM(${usageLineItems.inputTokens}), 0)`.as('input_tokens'),
+    output_tokens: sql<string | number>`COALESCE(SUM(${usageLineItems.outputTokens}), 0)`.as('output_tokens'),
+    cost_usd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
+  })
+    .from(runs)
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
+    .leftJoin(skillExecutions, and(eq(skillExecutions.id, usageLineItems.skillExecutionId), eq(skillExecutions.tenantId, runs.tenantId)))
+    .where(and(...conditions));
+  const result = groupDimensions.length > 0
+    ? await query.groupBy(...groupDimensions).orderBy(...groupDimensions)
+    : await query;
+  return result as unknown as AggregateRow[];
 }
 
 /** Aggregate additive usage and nullable cost over explicit, allowlisted dimensions. */
@@ -548,30 +685,37 @@ export async function aggregateCosts(
 /** Summarize authorized repositories with additive cost and finding counts. */
 export async function listRepositories(database: WardenDatabase, contextInput: ServiceContext | undefined): Promise<RepositoryListResponse> {
   const context = requireServiceContext(contextInput);
-  const values: unknown[] = [context.tenantId];
-  const repositoryScope = context.repositoryAllowlist
-    ? (() => {
-        values.push(context.repositoryAllowlist);
-        return `AND repo.full_name = ANY($${values.length}::text[])`;
-      })()
-    : '';
-  const result = await database.query<Record<string, unknown>>(`
-    WITH run_costs AS (
-      SELECT run_id, SUM(cost_usd) AS cost_usd
-      FROM usage_line_items
-      WHERE tenant_id = $1
-      GROUP BY run_id
-    )
-    SELECT repo.id, repo.provider, repo.owner, repo.name, repo.full_name,
-      COUNT(DISTINCT r.id)::integer AS runs, COALESCE(SUM(r.finding_count), 0)::integer AS findings,
-      SUM(costs.cost_usd) AS cost_usd, MAX(r.completed_at) AS last_run_at
-    FROM repositories repo
-    LEFT JOIN runs r ON r.repository_id = repo.id AND r.tenant_id = repo.tenant_id
-    LEFT JOIN run_costs costs ON costs.run_id = r.id
-    WHERE repo.tenant_id = $1 ${repositoryScope}
-    GROUP BY repo.id ORDER BY MAX(r.completed_at) DESC NULLS LAST, repo.full_name
-  `, values);
-  return { items: result.rows.map((row) => ({
+  const read = getReadDatabase(database);
+  const costs = read.$with('run_costs').as(
+    read.select({
+      runId: usageLineItems.runId,
+      costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
+    })
+      .from(usageLineItems)
+      .where(eq(usageLineItems.tenantId, context.tenantId))
+      .groupBy(usageLineItems.runId),
+  );
+  const conditions: SQL[] = [eq(repositories.tenantId, context.tenantId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  const result = await read.with(costs).select({
+    id: repositories.id,
+    provider: repositories.provider,
+    owner: repositories.owner,
+    name: repositories.name,
+    full_name: repositories.fullName,
+    runs: sql<number>`COUNT(DISTINCT ${runs.id})::integer`.as('runs'),
+    findings: sql<number>`COALESCE(SUM(${runs.findingCount}), 0)::integer`.as('findings'),
+    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
+    last_run_at: sql<Date | string | null>`MAX(${runs.completedAt})`.as('last_run_at'),
+  })
+    .from(repositories)
+    .leftJoin(runs, and(eq(runs.repositoryId, repositories.id), eq(runs.tenantId, repositories.tenantId)))
+    .leftJoin(costs, eq(costs.runId, runs.id))
+    .where(and(...conditions))
+    .groupBy(repositories.id)
+    .orderBy(sql`MAX(${runs.completedAt}) DESC NULLS LAST`, asc(repositories.fullName));
+  return { items: result.map((row) => ({
     id: String(row['id']),
     repository: {
       provider: row['provider'] as 'github' | 'gitlab' | 'local',
@@ -589,32 +733,38 @@ export async function listRepositories(database: WardenDatabase, contextInput: S
 /** Summarize skill execution quality with explicit success/failure denominators. */
 export async function listSkills(database: WardenDatabase, contextInput: ServiceContext | undefined): Promise<SkillListResponse> {
   const context = requireServiceContext(contextInput);
-  const values: unknown[] = [context.tenantId];
-  const repositoryScope = context.repositoryAllowlist
-    ? (() => {
-        values.push(context.repositoryAllowlist);
-        return `AND repo.full_name = ANY($${values.length}::text[])`;
-      })()
-    : '';
-  const result = await database.query<Record<string, unknown>>(`
-    WITH skill_costs AS (
-      SELECT skill_execution_id, SUM(cost_usd) AS cost_usd
-      FROM usage_line_items
-      WHERE tenant_id = $1 AND skill_execution_id IS NOT NULL
-      GROUP BY skill_execution_id
-    )
-    SELECT se.skill, COUNT(*)::integer AS executions,
-      COUNT(*) FILTER (WHERE se.status = 'success')::integer AS successful,
-      COUNT(*) FILTER (WHERE se.status = 'failure')::integer AS failed,
-      COALESCE(SUM(se.finding_count), 0)::integer AS findings,
-      SUM(costs.cost_usd) AS cost_usd
-    FROM skill_executions se
-    JOIN runs r ON r.id = se.run_id AND r.tenant_id = se.tenant_id
-    JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-    LEFT JOIN skill_costs costs ON costs.skill_execution_id = se.id
-    WHERE se.tenant_id = $1 ${repositoryScope} GROUP BY se.skill ORDER BY executions DESC, se.skill
-  `, values);
-  return { items: result.rows.map((row) => ({
+  const read = getReadDatabase(database);
+  const costs = read.$with('skill_costs').as(
+    read.select({
+      skillExecutionId: usageLineItems.skillExecutionId,
+      costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
+    })
+      .from(usageLineItems)
+      .where(and(
+        eq(usageLineItems.tenantId, context.tenantId),
+        sql`${usageLineItems.skillExecutionId} IS NOT NULL`,
+      ))
+      .groupBy(usageLineItems.skillExecutionId),
+  );
+  const conditions: SQL[] = [eq(skillExecutions.tenantId, context.tenantId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) conditions.push(authorizedRepositories);
+  const result = await read.with(costs).select({
+    skill: skillExecutions.skill,
+    executions: sql<number>`COUNT(*)::integer`.as('executions'),
+    successful: sql<number>`COUNT(*) FILTER (WHERE ${skillExecutions.status} = 'success')::integer`.as('successful'),
+    failed: sql<number>`COUNT(*) FILTER (WHERE ${skillExecutions.status} = 'failure')::integer`.as('failed'),
+    findings: sql<number>`COALESCE(SUM(${skillExecutions.findingCount}), 0)::integer`.as('findings'),
+    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
+  })
+    .from(skillExecutions)
+    .innerJoin(runs, and(eq(runs.id, skillExecutions.runId), eq(runs.tenantId, skillExecutions.tenantId)))
+    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+    .leftJoin(costs, eq(costs.skillExecutionId, skillExecutions.id))
+    .where(and(...conditions))
+    .groupBy(skillExecutions.skill)
+    .orderBy(desc(sql`COUNT(*)`), asc(skillExecutions.skill));
+  return { items: result.map((row) => ({
     skill: String(row['skill']),
     executions: Number(row['executions']),
     successful: Number(row['successful']),
@@ -627,38 +777,47 @@ export async function listSkills(database: WardenDatabase, contextInput: Service
 /** Return run outcome denominators and nullable total cost for the authorized tenant. */
 export async function summarizeOutcomes(database: WardenDatabase, contextInput: ServiceContext | undefined, filters: HistoryFilters): Promise<OutcomeSummaryResponse> {
   const context = requireServiceContext(contextInput);
-  const { conditions, values } = historyWhere(context, filters);
-  const result = await database.query<Record<string, unknown>>(`
-    WITH filtered_runs AS (
-      SELECT DISTINCT r.id, r.outcome, r.finding_count
-      FROM runs r
-      JOIN repositories repo ON repo.id = r.repository_id AND repo.tenant_id = r.tenant_id
-      LEFT JOIN usage_line_items u ON u.run_id = r.id AND u.tenant_id = r.tenant_id
-      WHERE ${conditions.join(' AND ')}
-    ), run_costs AS (
-      SELECT run_id, SUM(cost_usd) AS cost_usd
-      FROM usage_line_items
-      WHERE tenant_id = $1
-      GROUP BY run_id
-    )
-    SELECT COUNT(*)::integer AS runs,
-      COUNT(*) FILTER (WHERE filtered_runs.outcome = 'success')::integer AS successful,
-      COUNT(*) FILTER (WHERE filtered_runs.outcome = 'failure')::integer AS failed,
-      COUNT(*) FILTER (WHERE filtered_runs.outcome = 'cancelled')::integer AS cancelled,
-      COUNT(*) FILTER (WHERE filtered_runs.outcome = 'skipped')::integer AS skipped,
-      COALESCE(SUM(filtered_runs.finding_count), 0)::integer AS findings,
-      SUM(costs.cost_usd) AS cost_usd
-    FROM filtered_runs
-    LEFT JOIN run_costs costs ON costs.run_id = filtered_runs.id
-  `, values);
-  const row = result.rows[0] ?? {};
+  const read = getReadDatabase(database);
+  const conditions = historyWhere(read, context, filters);
+  const filteredRuns = read.$with('filtered_runs').as(
+    read.selectDistinct({
+      id: runs.id,
+      outcome: runs.outcome,
+      findingCount: runs.findingCount,
+    })
+      .from(runs)
+      .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
+      .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
+      .where(and(...conditions)),
+  );
+  const costs = read.$with('run_costs').as(
+    read.select({
+      runId: usageLineItems.runId,
+      costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
+    })
+      .from(usageLineItems)
+      .where(eq(usageLineItems.tenantId, context.tenantId))
+      .groupBy(usageLineItems.runId),
+  );
+  const result = await read.with(filteredRuns, costs).select({
+    runs: sql<number>`COUNT(*)::integer`.as('runs'),
+    successful: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'success')::integer`.as('successful'),
+    failed: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'failure')::integer`.as('failed'),
+    cancelled: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'cancelled')::integer`.as('cancelled'),
+    skipped: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'skipped')::integer`.as('skipped'),
+    findings: sql<number>`COALESCE(SUM(${filteredRuns.findingCount}), 0)::integer`.as('findings'),
+    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
+  })
+    .from(filteredRuns)
+    .leftJoin(costs, eq(costs.runId, filteredRuns.id));
+  const row = result[0];
   return { totals: {
-    runs: Number(row['runs'] ?? 0),
-    successful: Number(row['successful'] ?? 0),
-    failed: Number(row['failed'] ?? 0),
-    cancelled: Number(row['cancelled'] ?? 0),
-    skipped: Number(row['skipped'] ?? 0),
-    findings: Number(row['findings'] ?? 0),
-    costUsd: numberOrNull((row['cost_usd'] ?? null) as string | number | null),
+    runs: Number(row?.runs ?? 0),
+    successful: Number(row?.successful ?? 0),
+    failed: Number(row?.failed ?? 0),
+    cancelled: Number(row?.cancelled ?? 0),
+    skipped: Number(row?.skipped ?? 0),
+    findings: Number(row?.findings ?? 0),
+    costUsd: numberOrNull(row?.cost_usd ?? null),
   } };
 }

--- a/packages/warden-service/src/integration/postgres.integration.test.ts
+++ b/packages/warden-service/src/integration/postgres.integration.test.ts
@@ -6,7 +6,16 @@ import { createWardenService } from '../app.js';
 import type { ServiceContext } from '../context.js';
 import { createDatabase, type DatabaseDriver, type WardenDatabase } from '../db/database.js';
 import { migrateDatabase } from '../db/migrations.js';
-import { getRunDetail } from '../history/store.js';
+import {
+  aggregateCosts,
+  getFindingDetail,
+  getRunDetail,
+  listFindings,
+  listRepositories,
+  listRuns,
+  listSkills,
+  summarizeOutcomes,
+} from '../history/store.js';
 import { createMemory } from '../memory/store.js';
 import { persistPassiveMemoryCandidate } from '../memory/passive-store.js';
 import type { PassiveEvidence } from '../memory/passive.js';
@@ -223,6 +232,48 @@ function defineDriverIntegration(driver: DatabaseDriver, environmentName: string
       await expect(ingestRun(database, context, invalid)).rejects.toThrow();
       const rolledBack = await database.query('SELECT 1 FROM runs WHERE tenant_id = $1 AND client_run_id = $2', [tenantId, invalidId]);
       expect(rolledBack.rowCount).toBe(0);
+    }, 30_000);
+
+    it('executes typed Drizzle history reads against PostgreSQL', async () => {
+      const tenantId = await createTenant(database, {
+        slug: `history-${randomUUID()}`,
+        name: 'History Tenant',
+      });
+      tenantIds.push(tenantId);
+      const reader = await createServiceToken(database, {
+        tenantId,
+        name: 'History reader',
+        roles: ['ingest', 'read'],
+      });
+      const context = await authenticateServiceToken(database, reader.token);
+      if (!context) throw new Error('history token did not authenticate');
+      const stored = await ingestRun(database, context, findingsEnvelope(`history-${randomUUID()}`));
+
+      await expect(listRuns(database, context, {})).resolves.toMatchObject({
+        items: [{ id: stored.runId, repository: { fullName: 'acme/widgets' }, costUsd: 0.01 }],
+      });
+      const findingPage = await listFindings(database, context, { query: 'unsafe' });
+      expect(findingPage.items).toHaveLength(1);
+      await expect(getFindingDetail(database, context, findingPage.items[0]!.id)).resolves.toMatchObject({
+        finding: { title: 'Unsafe sink', outcome: 'resolved' },
+      });
+      await expect(listRepositories(database, context)).resolves.toMatchObject({
+        items: [{ repository: { fullName: 'acme/widgets' }, runs: 1, findings: 1, costUsd: 0.01 }],
+      });
+      await expect(listSkills(database, context)).resolves.toMatchObject({
+        items: expect.arrayContaining([
+          expect.objectContaining({ skill: 'security', executions: 1 }),
+        ]),
+      });
+      await expect(summarizeOutcomes(database, context, {})).resolves.toMatchObject({
+        totals: { runs: 1, successful: 1, findings: 1, costUsd: 0.01 },
+      });
+      await expect(aggregateCosts(database, context, {}, ['repository', 'skill'])).resolves.toMatchObject({
+        groups: expect.arrayContaining([
+          expect.objectContaining({ dimensions: { repository: 'acme/widgets', skill: 'security' } }),
+        ]),
+        totals: { runs: 1, inputTokens: 110, outputTokens: 22, costUsd: 0.01 },
+      });
     }, 30_000);
 
     it('persists multiple passive evidence rows in one transaction', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.17
         version: 1.19.17(hono@4.13.1)
+      '@sentry/node':
+        specifier: ^10.53.1
+        version: 10.53.1
       '@sentry/warden-service':
         specifier: workspace:*
         version: link:../../packages/warden-service


### PR DESCRIPTION
Instrument Warden Service requests and database operations with privacy-safe Sentry spans, then move the dashboard and history read path onto typed Drizzle queries.

This gives the slow dashboard request path bounded route transactions and SQL timing without sending query parameters. Drizzle owns query construction and schema typing, while an explicit database wrapper owns tracing because driver-level instrumentation is inconsistent across Neon and PostgreSQL and may serialize parameters. Transaction-heavy ingestion remains on the existing adapter to keep this change reviewable.

Telemetry stays disabled until `WARDEN_SENTRY_DSN` is configured in the Vercel project. The service tags its events with `service.name=warden-service` so the existing Warden Sentry project can be reused.
