### PR TITLE
perf(service): Simplify dashboard database queries

### DIFF
--- a/packages/warden-service/drizzle/0006_tiny_garia.sql
+++ b/packages/warden-service/drizzle/0006_tiny_garia.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "usage_tenant_skill_execution_idx" ON "usage_line_items" USING btree ("tenant_id","skill_execution_id");

--- a/packages/warden-service/drizzle/meta/0006_snapshot.json
+++ b/packages/warden-service/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3445 @@
+{
+  "id": "c99b615e-5aa5-4ced-b428-2afe3191dd0c",
+  "prevId": "79016c95-15c7-49a7-b7e6-7539f4cc4493",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.finding_locations": {
+      "name": "finding_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "finding_locations_finding_ordinal_unique": {
+          "name": "finding_locations_finding_ordinal_unique",
+          "columns": [
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finding_locations_tenant_finding_idx": {
+          "name": "finding_locations_tenant_finding_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finding_locations_tenant_id_tenants_id_fk": {
+          "name": "finding_locations_tenant_id_tenants_id_fk",
+          "tableFrom": "finding_locations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finding_locations_finding_id_findings_id_fk": {
+          "name": "finding_locations_finding_id_findings_id_fk",
+          "tableFrom": "finding_locations",
+          "tableTo": "findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_observations": {
+      "name": "finding_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_execution_id": {
+          "name": "skill_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "finding_observations_tenant_finding_observed_idx": {
+          "name": "finding_observations_tenant_finding_observed_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finding_observations_tenant_id_tenants_id_fk": {
+          "name": "finding_observations_tenant_id_tenants_id_fk",
+          "tableFrom": "finding_observations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finding_observations_run_id_runs_id_fk": {
+          "name": "finding_observations_run_id_runs_id_fk",
+          "tableFrom": "finding_observations",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finding_observations_finding_id_findings_id_fk": {
+          "name": "finding_observations_finding_id_findings_id_fk",
+          "tableFrom": "finding_observations",
+          "tableTo": "findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "finding_observations_skill_execution_id_skill_executions_id_fk": {
+          "name": "finding_observations_skill_execution_id_skill_executions_id_fk",
+          "tableFrom": "finding_observations",
+          "tableTo": "skill_executions",
+          "columnsFrom": [
+            "skill_execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.findings": {
+      "name": "findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_execution_id": {
+          "name": "skill_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_finding_id": {
+          "name": "client_finding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification": {
+          "name": "verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "findings_run_client_unique": {
+          "name": "findings_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "findings_tenant_run_idx": {
+          "name": "findings_tenant_run_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "findings_tenant_severity_idx": {
+          "name": "findings_tenant_severity_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "findings_tenant_skill_idx": {
+          "name": "findings_tenant_skill_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "findings_tenant_id_tenants_id_fk": {
+          "name": "findings_tenant_id_tenants_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "findings_run_id_runs_id_fk": {
+          "name": "findings_run_id_runs_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "findings_skill_execution_id_skill_executions_id_fk": {
+          "name": "findings_skill_execution_id_skill_executions_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "skill_executions",
+          "columnsFrom": [
+            "skill_execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_attempts": {
+      "name": "job_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_error_code": {
+          "name": "safe_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_attempts_job_attempt_unique": {
+          "name": "job_attempts_job_attempt_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_attempts_tenant_id_tenants_id_fk": {
+          "name": "job_attempts_tenant_id_tenants_id_fk",
+          "tableFrom": "job_attempts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_attempts_job_id_jobs_id_fk": {
+          "name": "job_attempts_job_id_jobs_id_fk",
+          "tableFrom": "job_attempts",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_version": {
+          "name": "input_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_ref": {
+          "name": "payload_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "job_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_age_seconds": {
+          "name": "max_age_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continuation": {
+          "name": "continuation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_error_code": {
+          "name": "safe_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_tenant_idempotency_unique": {
+          "name": "jobs_tenant_idempotency_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_claim_idx": {
+          "name": "jobs_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_tenant_repository_idx": {
+          "name": "jobs_tenant_repository_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_tenant_id_tenants_id_fk": {
+          "name": "jobs_tenant_id_tenants_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_repository_id_repositories_id_fk": {
+          "name": "jobs_repository_id_repositories_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "jobs_limits_positive": {
+          "name": "jobs_limits_positive",
+          "value": "\"jobs\".\"max_attempts\" > 0 AND \"jobs\".\"max_age_seconds\" > 0 AND \"jobs\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "memory_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "memory_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_document": {
+          "name": "search_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_family": {
+          "name": "path_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(6, 5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_count": {
+          "name": "support_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contradiction_count": {
+          "name": "contradiction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_provider": {
+          "name": "extraction_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_runtime": {
+          "name": "extraction_runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_input_tokens": {
+          "name": "extraction_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_output_tokens": {
+          "name": "extraction_output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_cost_usd": {
+          "name": "extraction_cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_cost_basis": {
+          "name": "extraction_cost_basis",
+          "type": "cost_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memories_tenant_idempotency_unique": {
+          "name": "memories_tenant_idempotency_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_recall_idx": {
+          "name": "memories_recall_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_search_idx": {
+          "name": "memories_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"search_document\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_tenant_id_tenants_id_fk": {
+          "name": "memories_tenant_id_tenants_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memories_repository_id_repositories_id_fk": {
+          "name": "memories_repository_id_repositories_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memories_counts_nonnegative": {
+          "name": "memories_counts_nonnegative",
+          "value": "\"memories\".\"support_count\" >= 0 AND \"memories\".\"contradiction_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_embeddings": {
+      "name": "memory_embeddings",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_basis": {
+          "name": "cost_basis",
+          "type": "cost_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_embeddings_tenant_idx": {
+          "name": "memory_embeddings_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_embeddings_tenant_id_tenants_id_fk": {
+          "name": "memory_embeddings_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_embeddings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_embeddings_memory_id_memories_id_fk": {
+          "name": "memory_embeddings_memory_id_memories_id_fk",
+          "tableFrom": "memory_embeddings",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memory_embeddings_memory_id_provider_model_pk": {
+          "name": "memory_embeddings_memory_id_provider_model_pk",
+          "columns": [
+            "memory_id",
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_evidence": {
+      "name": "memory_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_evidence_memory_observation_unique": {
+          "name": "memory_evidence_memory_observation_unique",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"memory_evidence\".\"observation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_evidence_tenant_idx": {
+          "name": "memory_evidence_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_evidence_tenant_id_tenants_id_fk": {
+          "name": "memory_evidence_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_evidence",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_evidence_memory_id_memories_id_fk": {
+          "name": "memory_evidence_memory_id_memories_id_fk",
+          "tableFrom": "memory_evidence",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_evidence_finding_id_findings_id_fk": {
+          "name": "memory_evidence_finding_id_findings_id_fk",
+          "tableFrom": "memory_evidence",
+          "tableTo": "findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_evidence_observation_id_finding_observations_id_fk": {
+          "name": "memory_evidence_observation_id_finding_observations_id_fk",
+          "tableFrom": "memory_evidence",
+          "tableTo": "finding_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_feedback": {
+      "name": "memory_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_token_id": {
+          "name": "actor_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_feedback_tenant_memory_idx": {
+          "name": "memory_feedback_tenant_memory_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_feedback_tenant_id_tenants_id_fk": {
+          "name": "memory_feedback_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_feedback",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_feedback_memory_id_memories_id_fk": {
+          "name": "memory_feedback_memory_id_memories_id_fk",
+          "tableFrom": "memory_feedback",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_feedback_actor_token_id_service_tokens_id_fk": {
+          "name": "memory_feedback_actor_token_id_service_tokens_id_fk",
+          "tableFrom": "memory_feedback",
+          "tableTo": "service_tokens",
+          "columnsFrom": [
+            "actor_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_lifecycle_events": {
+      "name": "memory_lifecycle_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "memory_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "memory_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_token_id": {
+          "name": "actor_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_lifecycle_events_tenant_idx": {
+          "name": "memory_lifecycle_events_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_lifecycle_events_tenant_id_tenants_id_fk": {
+          "name": "memory_lifecycle_events_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_lifecycle_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_lifecycle_events_memory_id_memories_id_fk": {
+          "name": "memory_lifecycle_events_memory_id_memories_id_fk",
+          "tableFrom": "memory_lifecycle_events",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_lifecycle_events_actor_token_id_service_tokens_id_fk": {
+          "name": "memory_lifecycle_events_actor_token_id_service_tokens_id_fk",
+          "tableFrom": "memory_lifecycle_events",
+          "tableTo": "service_tokens",
+          "columnsFrom": [
+            "actor_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_recall_batches": {
+      "name": "memory_recall_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_recall_id": {
+          "name": "client_recall_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_count": {
+          "name": "memory_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "numeric(18, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_basis": {
+          "name": "cost_basis",
+          "type": "cost_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_recall_batches_tenant_client_unique": {
+          "name": "memory_recall_batches_tenant_client_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_recall_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_recall_batches_tenant_repository_idx": {
+          "name": "memory_recall_batches_tenant_repository_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_recall_batches_tenant_id_tenants_id_fk": {
+          "name": "memory_recall_batches_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_recall_batches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_recall_batches_repository_id_repositories_id_fk": {
+          "name": "memory_recall_batches_repository_id_repositories_id_fk",
+          "tableFrom": "memory_recall_batches",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_recall_batches_run_id_runs_id_fk": {
+          "name": "memory_recall_batches_run_id_runs_id_fk",
+          "tableFrom": "memory_recall_batches",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_recall_batches_count_nonnegative": {
+          "name": "memory_recall_batches_count_nonnegative",
+          "value": "\"memory_recall_batches\".\"memory_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_recalls": {
+      "name": "memory_recalls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_version": {
+          "name": "lifecycle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "numeric(18, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_recalls_tenant_repository_idx": {
+          "name": "memory_recalls_tenant_repository_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_recalls_batch_memory_unique": {
+          "name": "memory_recalls_batch_memory_unique",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_recalls_tenant_id_tenants_id_fk": {
+          "name": "memory_recalls_tenant_id_tenants_id_fk",
+          "tableFrom": "memory_recalls",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_recalls_repository_id_repositories_id_fk": {
+          "name": "memory_recalls_repository_id_repositories_id_fk",
+          "tableFrom": "memory_recalls",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_recalls_batch_id_memory_recall_batches_id_fk": {
+          "name": "memory_recalls_batch_id_memory_recall_batches_id_fk",
+          "tableFrom": "memory_recalls",
+          "tableTo": "memory_recall_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_recalls_run_id_runs_id_fk": {
+          "name": "memory_recalls_run_id_runs_id_fk",
+          "tableFrom": "memory_recalls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memory_recalls_memory_id_memories_id_fk": {
+          "name": "memory_recalls_memory_id_memories_id_fk",
+          "tableFrom": "memory_recalls",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_tenant_identity_unique": {
+          "name": "repositories_tenant_identity_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_tenant_full_name_idx": {
+          "name": "repositories_tenant_full_name_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_tenant_id_tenants_id_fk": {
+          "name": "repositories_tenant_id_tenants_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_run_id": {
+          "name": "client_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope_version": {
+          "name": "envelope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope_checksum": {
+          "name": "envelope_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_profile": {
+          "name": "data_profile",
+          "type": "data_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warden_version": {
+          "name": "warden_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "run_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request": {
+          "name": "pull_request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_tenant_client_run_unique": {
+          "name": "runs_tenant_client_run_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_tenant_completed_idx": {
+          "name": "runs_tenant_completed_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_tenant_repository_completed_idx": {
+          "name": "runs_tenant_repository_completed_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_tenant_outcome_completed_idx": {
+          "name": "runs_tenant_outcome_completed_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_tenant_id_tenants_id_fk": {
+          "name": "runs_tenant_id_tenants_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_repository_id_repositories_id_fk": {
+          "name": "runs_repository_id_repositories_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_finding_counts_nonnegative": {
+          "name": "runs_finding_counts_nonnegative",
+          "value": "\"runs\".\"finding_count\" >= 0 AND \"runs\".\"high_count\" >= 0 AND \"runs\".\"medium_count\" >= 0 AND \"runs\".\"low_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.service_tokens": {
+      "name": "service_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_kind": {
+          "name": "credential_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "owner_subject": {
+          "name": "owner_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles": {
+          "name": "roles",
+          "type": "service_role[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_allowlist": {
+          "name": "repository_allowlist",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_tokens_prefix_unique": {
+          "name": "service_tokens_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_tokens_hash_unique": {
+          "name": "service_tokens_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_tokens_tenant_idx": {
+          "name": "service_tokens_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_tokens_owner_idx": {
+          "name": "service_tokens_owner_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_tokens_tenant_id_tenants_id_fk": {
+          "name": "service_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "service_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "service_tokens_kind_valid": {
+          "name": "service_tokens_kind_valid",
+          "value": "\"service_tokens\".\"credential_kind\" IN ('service', 'personal')"
+        },
+        "service_tokens_personal_owner": {
+          "name": "service_tokens_personal_owner",
+          "value": "\"service_tokens\".\"credential_kind\" = 'service' OR (\"service_tokens\".\"owner_subject\" IS NOT NULL AND \"service_tokens\".\"token_suffix\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.skill_executions": {
+      "name": "skill_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_execution_id": {
+          "name": "client_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_digest": {
+          "name": "skill_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "numeric(18, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_executions_run_client_unique": {
+          "name": "skill_executions_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_executions_tenant_run_idx": {
+          "name": "skill_executions_tenant_run_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_executions_tenant_skill_idx": {
+          "name": "skill_executions_tenant_skill_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_executions_tenant_error_idx": {
+          "name": "skill_executions_tenant_error_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "error_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_executions_tenant_id_tenants_id_fk": {
+          "name": "skill_executions_tenant_id_tenants_id_fk",
+          "tableFrom": "skill_executions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_executions_run_id_runs_id_fk": {
+          "name": "skill_executions_run_id_runs_id_fk",
+          "tableFrom": "skill_executions",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metrics_retention_days": {
+          "name": "metrics_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 365
+        },
+        "findings_retention_days": {
+          "name": "findings_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "code_retention_days": {
+          "name": "code_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "lifecycle_retention_days": {
+          "name": "lifecycle_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 365
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenants_retention_positive": {
+          "name": "tenants_retention_positive",
+          "value": "\"tenants\".\"metrics_retention_days\" > 0 AND \"tenants\".\"findings_retention_days\" > 0 AND \"tenants\".\"code_retention_days\" > 0 AND \"tenants\".\"lifecycle_retention_days\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_line_items": {
+      "name": "usage_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_execution_id": {
+          "name": "skill_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lane": {
+          "name": "lane",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_basis": {
+          "name": "cost_basis",
+          "type": "cost_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_tenant_run_idx": {
+          "name": "usage_tenant_run_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_tenant_skill_execution_idx": {
+          "name": "usage_tenant_skill_execution_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_tenant_dimensions_idx": {
+          "name": "usage_tenant_dimensions_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lane",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_line_items_tenant_id_tenants_id_fk": {
+          "name": "usage_line_items_tenant_id_tenants_id_fk",
+          "tableFrom": "usage_line_items",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_line_items_run_id_runs_id_fk": {
+          "name": "usage_line_items_run_id_runs_id_fk",
+          "tableFrom": "usage_line_items",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_line_items_skill_execution_id_skill_executions_id_fk": {
+          "name": "usage_line_items_skill_execution_id_skill_executions_id_fk",
+          "tableFrom": "usage_line_items",
+          "tableTo": "skill_executions",
+          "columnsFrom": [
+            "skill_execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.cost_basis": {
+      "name": "cost_basis",
+      "schema": "public",
+      "values": [
+        "reported",
+        "estimated",
+        "unknown"
+      ]
+    },
+    "public.data_profile": {
+      "name": "data_profile",
+      "schema": "public",
+      "values": [
+        "metrics",
+        "findings",
+        "code"
+      ]
+    },
+    "public.execution_status": {
+      "name": "execution_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure",
+        "cancelled",
+        "skipped"
+      ]
+    },
+    "public.job_state": {
+      "name": "job_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "retry",
+        "complete",
+        "dead"
+      ]
+    },
+    "public.memory_kind": {
+      "name": "memory_kind",
+      "schema": "public",
+      "values": [
+        "convention",
+        "confirmed_pattern",
+        "false_positive",
+        "review_guidance"
+      ]
+    },
+    "public.memory_lifecycle": {
+      "name": "memory_lifecycle",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "active",
+        "superseded",
+        "archived",
+        "expired"
+      ]
+    },
+    "public.run_outcome": {
+      "name": "run_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure",
+        "cancelled",
+        "skipped"
+      ]
+    },
+    "public.run_source": {
+      "name": "run_source",
+      "schema": "public",
+      "values": [
+        "cli",
+        "action",
+        "sdk",
+        "replay"
+      ]
+    },
+    "public.service_role": {
+      "name": "service_role",
+      "schema": "public",
+      "values": [
+        "ingest",
+        "read",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/warden-service/drizzle/meta/_journal.json
+++ b/packages/warden-service/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786811253249,
       "tag": "0005_large_mattie_franklin",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786823438457,
+      "tag": "0006_tiny_garia",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -4,7 +4,7 @@ import type { DatabaseClient, WardenDatabase } from './db/database.js';
 import type { GoogleAuthBridge, GoogleAuthSession } from './google-auth.js';
 
 function readyDatabase(
-  versions: string[] = ['0005_large_mattie_franklin'],
+  versions: string[] = ['0006_tiny_garia'],
 ): WardenDatabase {
   return {
     driver: 'postgres',
@@ -44,7 +44,8 @@ describe('createWardenService', () => {
   it('stays ready when newer backward-compatible migrations are applied', async () => {
     const app = createWardenService({
       database: readyDatabase([
-        '0006_future_migration',
+        '0007_future_migration',
+        '0006_tiny_garia',
         '0005_large_mattie_franklin',
       ]),
     });
@@ -55,8 +56,8 @@ describe('createWardenService', () => {
     await expect(response.json()).resolves.toEqual({
       status: 'ready',
       database: 'ready',
-      currentVersion: '0006_future_migration',
-      requiredVersion: '0005_large_mattie_franklin',
+      currentVersion: '0007_future_migration',
+      requiredVersion: '0006_tiny_garia',
     });
   });
 
@@ -83,8 +84,8 @@ describe('createWardenService', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       ready: true,
-      currentVersion: '0005_large_mattie_franklin',
-      requiredVersion: '0005_large_mattie_franklin',
+      currentVersion: '0006_tiny_garia',
+      requiredVersion: '0006_tiny_garia',
     });
   });
 
@@ -338,29 +339,15 @@ describe('createWardenService', () => {
           };
           return { rows: [finding] as unknown as TRow[], rowCount: 1 };
         }
-        if (sql.includes('GROUPING SETS')) {
-          return { rows: [
-            {
-              dimension_0: '2026-08-15', dimension_1: null, dimension_2: null,
-              grouping_0: 0, grouping_1: 1, grouping_2: 1,
-              runs: 1, input_tokens: '100', output_tokens: '20', cost_usd: '0.012',
-            },
-            {
-              dimension_0: null, dimension_1: 'acme/widgets', dimension_2: null,
-              grouping_0: 1, grouping_1: 0, grouping_2: 1,
-              runs: 1, input_tokens: '100', output_tokens: '20', cost_usd: '0.012',
-            },
-            {
-              dimension_0: null, dimension_1: null, dimension_2: 'security',
-              grouping_0: 1, grouping_1: 1, grouping_2: 0,
-              runs: 1, input_tokens: '100', output_tokens: '20', cost_usd: '0.012',
-            },
-          ] as unknown as TRow[], rowCount: 3 };
-        }
         if (sql.includes('from "runs"') && sql.includes('SUM("usage_line_items"."input_tokens")')) {
           const grouped = sql.includes('group by');
+          const dimension = sql.includes("date_trunc('day'")
+            ? '2026-08-15'
+            : sql.includes('"repositories"."full_name" as "dimension_0"')
+              ? 'acme/widgets'
+              : 'security';
           return { rows: [{
-            ...(grouped ? { dimension_0: 'security' } : {}),
+            ...(grouped ? { dimension_0: dimension } : {}),
             runs: 1, input_tokens: '100', output_tokens: '20', cost_usd: '0.012',
           }] as unknown as TRow[], rowCount: 1 };
         }

--- a/packages/warden-service/src/cli.test.ts
+++ b/packages/warden-service/src/cli.test.ts
@@ -8,7 +8,7 @@ describe('warden-service CLI', () => {
     let output = '';
     const database = {
       async query() {
-        return { rows: [{ version: '0005_large_mattie_franklin' }], rowCount: 1 };
+        return { rows: [{ version: '0006_tiny_garia' }], rowCount: 1 };
       },
       async close() { closed = true; },
     } as unknown as WardenDatabase;
@@ -18,8 +18,8 @@ describe('warden-service CLI', () => {
     expect(exitCode).toBe(0);
     expect(JSON.parse(output)).toEqual({
       ready: true,
-      currentVersion: '0005_large_mattie_franklin',
-      requiredVersion: '0005_large_mattie_franklin',
+      currentVersion: '0006_tiny_garia',
+      requiredVersion: '0006_tiny_garia',
     });
     expect(closed).toBe(true);
   });

--- a/packages/warden-service/src/db/migrations.test.ts
+++ b/packages/warden-service/src/db/migrations.test.ts
@@ -20,6 +20,7 @@ describe('migrateDatabase', () => {
             { version: '0003_hosted_memory_vectors' },
             { version: '0004_dazzling_vermin' },
             { version: '0005_large_mattie_franklin' },
+            { version: '0006_tiny_garia' },
           ]) as unknown as QueryResult<TRow>;
         }
         return result();
@@ -31,7 +32,7 @@ describe('migrateDatabase', () => {
       statementTimeoutMs: 15_000,
       withClient: (operation) => operation(client),
       query: async <TRow extends Record<string, unknown>>() => (
-        result([{ version: '0005_large_mattie_franklin' }]) as unknown as QueryResult<TRow>
+        result([{ version: '0006_tiny_garia' }]) as unknown as QueryResult<TRow>
       ),
       transaction: (operation) => operation(client),
       close: () => Promise.resolve(),

--- a/packages/warden-service/src/db/schema.ts
+++ b/packages/warden-service/src/db/schema.ts
@@ -162,6 +162,7 @@ export const usageLineItems = pgTable('usage_line_items', {
   ...timestamps,
 }, (table) => [
   index('usage_tenant_run_idx').on(table.tenantId, table.runId),
+  index('usage_tenant_skill_execution_idx').on(table.tenantId, table.skillExecutionId),
   index('usage_tenant_dimensions_idx').on(table.tenantId, table.lane, table.model, table.runtime, table.provider),
 ]);
 

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -90,8 +90,10 @@ describe('history store', () => {
     });
 
     expect(captured?.sql).toContain('"runs"."tenant_id" = $1');
-    expect(captured?.sql).toContain('exists (select 1 from "skill_executions" "filtered_se"');
-    expect(captured?.sql).toContain('"filtered_se"."id" = "usage_line_items"."skill_execution_id"');
+    expect(captured?.sql).toContain('exists (select 1 from "usage_line_items" "filtered_usage"');
+    expect(captured?.sql).toContain('inner join "skill_executions" "filtered_se"');
+    expect(captured?.sql).toContain('"filtered_se"."id" = "filtered_usage"."skill_execution_id"');
+    expect(captured?.sql).not.toContain('left join "usage_line_items"');
     expect(captured?.values).toEqual(expect.arrayContaining([
       context.tenantId,
       'security',
@@ -111,7 +113,7 @@ describe('history store', () => {
     await listRuns(database, context, { skill: 'security', errorCode: 'provider_unavailable' });
     await summarizeOutcomes(database, context, { skill: 'security', errorCode: 'provider_unavailable' });
 
-    expect(statements).toHaveLength(2);
+    expect(statements).toHaveLength(3);
     for (const sql of statements) {
       expect(sql).toContain('exists (select 1 from "skill_executions" "filtered_se"');
       expect(sql).toContain('"filtered_se"."skill" =');
@@ -239,14 +241,14 @@ describe('history store', () => {
     await summarizeOutcomes(database, restricted, {});
     await aggregateCosts(database, restricted, {}, ['repository']);
 
-    expect(statements).toHaveLength(11);
+    expect(statements).toHaveLength(15);
     for (const statement of statements) {
-      expect(statement.sql).toContain('"repositories"."full_name" in');
+      expect(statement.sql).toContain('"full_name" in');
       expect(statement.values).toContain('acme/widgets');
     }
   });
 
-  it('pre-aggregates summary costs instead of probing usage for every row', async () => {
+  it('uses narrow indexable aggregates instead of tenant-wide cost CTEs', async () => {
     const statements: string[] = [];
     const database = databaseFor((sql) => {
       statements.push(sql);
@@ -257,13 +259,18 @@ describe('history store', () => {
     await listSkills(database, context);
     await summarizeOutcomes(database, context, {});
 
-    expect(statements[0]).toContain('with "run_costs" as');
-    expect(statements[0]).toContain('left join "run_costs" on "run_costs"."run_id" = "runs"."id"');
-    expect(statements[1]).toContain('with "skill_costs" as');
-    expect(statements[1]).toContain('left join "skill_costs" on "skill_costs"."skill_execution_id" = "skill_executions"."id"');
-    expect(statements[2]).toContain('"run_costs" as');
-    expect(statements[2]).toContain('left join "run_costs" on "run_costs"."run_id" = "filtered_runs"."id"');
-    expect(statements).not.toEqual(expect.arrayContaining([expect.stringContaining('left join lateral')]));
+    expect(statements).toHaveLength(7);
+    expect(statements).not.toEqual(expect.arrayContaining([
+      expect.stringContaining('with "run_costs" as'),
+      expect.stringContaining('with "skill_costs" as'),
+      expect.stringContaining('select distinct'),
+    ]));
+    expect(statements).toEqual(expect.arrayContaining([
+      expect.stringContaining('from "runs" where "runs"."tenant_id" = $1 group by "runs"."repository_id"'),
+      expect.stringContaining('from "usage_line_items" inner join "runs"'),
+      expect.stringContaining('from "skill_executions" where "skill_executions"."tenant_id" = $1 group by "skill_executions"."skill"'),
+      expect.stringContaining('from "usage_line_items" inner join "skill_executions"'),
+    ]));
   });
 
   it('aggregates allowlisted dimensions while keeping unknown cost null', async () => {
@@ -334,25 +341,17 @@ describe('history store', () => {
     const statements: string[] = [];
     const database = databaseFor((sql) => {
       statements.push(sql);
+      const dimension = sql.includes("date_trunc('day'")
+        ? '2026-08-15'
+        : sql.includes('"repositories"."full_name" as "dimension_0"')
+          ? 'acme/widgets'
+          : 'security';
       return {
-        rows: [
-          {
-            dimension_0: '2026-08-15', dimension_1: null, dimension_2: null,
-            grouping_0: 0, grouping_1: 1, grouping_2: 1,
-            runs: 2, input_tokens: '120', output_tokens: '30', cost_usd: '0.01',
-          },
-          {
-            dimension_0: null, dimension_1: 'acme/widgets', dimension_2: null,
-            grouping_0: 1, grouping_1: 0, grouping_2: 1,
-            runs: 2, input_tokens: '120', output_tokens: '30', cost_usd: '0.01',
-          },
-          {
-            dimension_0: null, dimension_1: null, dimension_2: 'security',
-            grouping_0: 1, grouping_1: 1, grouping_2: 0,
-            runs: 2, input_tokens: '120', output_tokens: '30', cost_usd: '0.01',
-          },
-        ],
-        rowCount: 3,
+        rows: [{
+          dimension_0: dimension,
+          runs: 2, input_tokens: '120', output_tokens: '30', cost_usd: '0.01',
+        }],
+        rowCount: 1,
       };
     });
 
@@ -364,8 +363,17 @@ describe('history store', () => {
       { repository: 'acme/widgets' },
       { skill: 'security' },
     ]);
-    expect(statements).toHaveLength(1);
-    expect(statements[0]).toContain('group by GROUPING SETS');
+    expect(statements).toHaveLength(3);
+    expect(statements).not.toEqual(expect.arrayContaining([expect.stringContaining('GROUPING SETS')]));
+    const day = statements.find((statement) => statement.includes("date_trunc('day'"));
+    const repository = statements.find((statement) => statement.includes('"repositories"."full_name" as "dimension_0"'));
+    const skill = statements.find((statement) => statement.includes('"skill_executions"."skill"'));
+    expect(day).not.toContain('join "repositories"');
+    expect(day).not.toContain('join "skill_executions"');
+    expect(repository).toContain('join "repositories"');
+    expect(repository).not.toContain('join "skill_executions"');
+    expect(skill).toContain('join "skill_executions"');
+    expect(skill).not.toContain('join "repositories"');
   });
 
   it('returns not found for a run ID absent from the authenticated tenant', async () => {

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -146,10 +146,26 @@ function mapRun(row: RunRow): RunSummary {
 }
 
 const filteredSkillExecutions = alias(skillExecutions, 'filtered_se');
+const filteredUsageLineItems = alias(usageLineItems, 'filtered_usage');
+const authorizedRepository = alias(repositories, 'authorized_repository');
 
 function repositoryScope(context: ServiceContext): SQL | undefined {
   return context.repositoryAllowlist
     ? inArray(repositories.fullName, context.repositoryAllowlist)
+    : undefined;
+}
+
+function runRepositoryScope(database: WardenReadDatabase, context: ServiceContext): SQL | undefined {
+  return context.repositoryAllowlist
+    ? exists(
+        database.select({ value: sql`1` })
+          .from(authorizedRepository)
+          .where(and(
+            eq(authorizedRepository.id, runs.repositoryId),
+            eq(authorizedRepository.tenantId, runs.tenantId),
+            inArray(authorizedRepository.fullName, context.repositoryAllowlist),
+          )),
+      )
     : undefined;
 }
 
@@ -161,7 +177,7 @@ function historyWhere(
 ): SQL[] {
   const conditions: SQL[] = [eq(runs.tenantId, context.tenantId)];
   const filtersUsage = Boolean(filters.model || filters.runtime || filters.provider || filters.lane);
-  const authorizedRepositories = repositoryScope(context);
+  const authorizedRepositories = runRepositoryScope(database, context);
   if (authorizedRepositories) conditions.push(authorizedRepositories);
   if (filters.from) conditions.push(gte(runs.completedAt, new Date(filters.from)));
   if (filters.to) conditions.push(lte(runs.completedAt, new Date(filters.to)));
@@ -171,12 +187,38 @@ function historyWhere(
   if (executionScope === 'usage') {
     if (filters.skill) conditions.push(eq(skillExecutions.skill, filters.skill));
     if (filters.errorCode) conditions.push(eq(skillExecutions.errorCode, filters.errorCode));
+    if (filters.model) conditions.push(eq(usageLineItems.model, filters.model));
+    if (filters.runtime) conditions.push(eq(usageLineItems.runtime, filters.runtime));
+    if (filters.provider) conditions.push(eq(usageLineItems.provider, filters.provider));
+    if (filters.lane) conditions.push(eq(usageLineItems.lane, filters.lane));
+    return conditions;
+  }
+  if (filtersUsage) {
+    const executionConditions: SQL[] = [
+      eq(filteredUsageLineItems.tenantId, runs.tenantId),
+      eq(filteredUsageLineItems.runId, runs.id),
+    ];
+    if (filters.model) executionConditions.push(eq(filteredUsageLineItems.model, filters.model));
+    if (filters.runtime) executionConditions.push(eq(filteredUsageLineItems.runtime, filters.runtime));
+    if (filters.provider) executionConditions.push(eq(filteredUsageLineItems.provider, filters.provider));
+    if (filters.lane) executionConditions.push(eq(filteredUsageLineItems.lane, filters.lane));
+    let usageQuery = database.select({ value: sql`1` })
+      .from(filteredUsageLineItems)
+      .$dynamic();
+    if (filters.skill || filters.errorCode) {
+      usageQuery = usageQuery.innerJoin(filteredSkillExecutions, and(
+        eq(filteredSkillExecutions.id, filteredUsageLineItems.skillExecutionId),
+        eq(filteredSkillExecutions.tenantId, filteredUsageLineItems.tenantId),
+      ));
+      if (filters.skill) executionConditions.push(eq(filteredSkillExecutions.skill, filters.skill));
+      if (filters.errorCode) executionConditions.push(eq(filteredSkillExecutions.errorCode, filters.errorCode));
+    }
+    conditions.push(exists(usageQuery.where(and(...executionConditions))));
   } else if (filters.skill || filters.errorCode) {
     const executionConditions: SQL[] = [
       eq(filteredSkillExecutions.tenantId, runs.tenantId),
       eq(filteredSkillExecutions.runId, runs.id),
     ];
-    if (filtersUsage) executionConditions.push(eq(filteredSkillExecutions.id, usageLineItems.skillExecutionId));
     if (filters.skill) executionConditions.push(eq(filteredSkillExecutions.skill, filters.skill));
     if (filters.errorCode) executionConditions.push(eq(filteredSkillExecutions.errorCode, filters.errorCode));
     conditions.push(exists(
@@ -185,10 +227,6 @@ function historyWhere(
         .where(and(...executionConditions)),
     ));
   }
-  if (filters.model) conditions.push(eq(usageLineItems.model, filters.model));
-  if (filters.runtime) conditions.push(eq(usageLineItems.runtime, filters.runtime));
-  if (filters.provider) conditions.push(eq(usageLineItems.provider, filters.provider));
-  if (filters.lane) conditions.push(eq(usageLineItems.lane, filters.lane));
   return conditions;
 }
 
@@ -430,7 +468,7 @@ export async function listRuns(database: WardenDatabase, contextInput: ServiceCo
     const [completedAt, id] = filters.cursor;
     conditions.push(sql`(${runs.completedAt}, ${runs.id}) < (${new Date(completedAt)}, ${id})`);
   }
-  const result = await read.selectDistinct({
+  const result = await read.select({
     id: runs.id,
     client_run_id: runs.clientRunId,
     source: runs.source,
@@ -450,12 +488,12 @@ export async function listRuns(database: WardenDatabase, contextInput: ServiceCo
     cost_usd: sql<string | null>`(
       SELECT SUM(${usageLineItems.costUsd})
       FROM ${usageLineItems}
-      WHERE ${usageLineItems.runId} = ${runs.id}
+      WHERE ${usageLineItems.tenantId} = ${runs.tenantId}
+        AND ${usageLineItems.runId} = ${runs.id}
     )`.as('cost_usd'),
   })
     .from(runs)
     .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
-    .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
     .where(and(...conditions))
     .orderBy(desc(runs.completedAt), desc(runs.id))
     .limit(limit + 1);
@@ -546,7 +584,8 @@ export async function getRunDetail(database: WardenDatabase, contextInput: Servi
     cost_usd: sql<string | null>`(
       SELECT SUM(${usageLineItems.costUsd})
       FROM ${usageLineItems}
-      WHERE ${usageLineItems.runId} = ${runs.id}
+      WHERE ${usageLineItems.tenantId} = ${runs.tenantId}
+        AND ${usageLineItems.runId} = ${runs.id}
     )`.as('cost_usd'),
   })
     .from(runs)
@@ -631,8 +670,6 @@ interface AggregateRow extends Record<string, unknown> {
   [key: `dimension_${number}`]: string;
 }
 
-type BreakdownRow = AggregateRow & Record<`grouping_${number}`, number>;
-
 function mapAggregateRow(row: AggregateRow): Omit<CostGroup, 'dimensions'> {
   return {
     runs: Number(row.runs),
@@ -645,12 +682,14 @@ function mapAggregateRow(row: AggregateRow): Omit<CostGroup, 'dimensions'> {
 async function aggregateRows(database: WardenDatabase, context: ServiceContext, filters: HistoryFilters, dimensions: readonly CostDimension[]) {
   const read = getReadDatabase(database);
   const conditions = historyWhere(read, context, filters, 'usage');
+  const needsRepositories = dimensions.includes('repository');
+  const needsSkills = dimensions.includes('skill') || Boolean(filters.skill || filters.errorCode);
   const groupDimensions = dimensions.map((dimension) => dimensionSql[dimension]);
   const selectDimensions = Object.fromEntries(dimensions.map((dimension, index) => [
     `dimension_${index}`,
     dimensionSql[dimension].as(`dimension_${index}`),
   ]));
-  const query = read.select({
+  let query = read.select({
     ...selectDimensions,
     runs: sql<number>`COUNT(DISTINCT ${runs.id})::integer`.as('runs'),
     input_tokens: sql<string | number>`COALESCE(SUM(${usageLineItems.inputTokens}), 0)`.as('input_tokens'),
@@ -658,49 +697,28 @@ async function aggregateRows(database: WardenDatabase, context: ServiceContext, 
     cost_usd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
   })
     .from(runs)
-    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
-    .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
-    .leftJoin(skillExecutions, and(eq(skillExecutions.id, usageLineItems.skillExecutionId), eq(skillExecutions.tenantId, runs.tenantId)))
-    .where(and(...conditions));
+    .$dynamic();
+  if (needsRepositories) {
+    query = query.innerJoin(repositories, and(
+      eq(repositories.id, runs.repositoryId),
+      eq(repositories.tenantId, runs.tenantId),
+    ));
+  }
+  query = query.leftJoin(usageLineItems, and(
+    eq(usageLineItems.runId, runs.id),
+    eq(usageLineItems.tenantId, runs.tenantId),
+  ));
+  if (needsSkills) {
+    query = query.leftJoin(skillExecutions, and(
+      eq(skillExecutions.id, usageLineItems.skillExecutionId),
+      eq(skillExecutions.tenantId, runs.tenantId),
+    ));
+  }
+  query = query.where(and(...conditions));
   const result = groupDimensions.length > 0
     ? await query.groupBy(...groupDimensions).orderBy(...groupDimensions)
     : await query;
   return result as unknown as AggregateRow[];
-}
-
-async function aggregateBreakdownRows(
-  database: WardenDatabase,
-  context: ServiceContext,
-  filters: HistoryFilters,
-  dimensions: readonly CostDimension[],
-): Promise<BreakdownRow[]> {
-  const read = getReadDatabase(database);
-  const conditions = historyWhere(read, context, filters, 'usage');
-  const groupDimensions = dimensions.map((dimension) => dimensionSql[dimension]);
-  const selectDimensions = Object.fromEntries(groupDimensions.map((dimension, index) => [
-    `dimension_${index}`,
-    dimension.as(`dimension_${index}`),
-  ]));
-  const selectGrouping = Object.fromEntries(groupDimensions.map((dimension, index) => [
-    `grouping_${index}`,
-    sql<number>`GROUPING(${dimension})`.as(`grouping_${index}`),
-  ]));
-  const groupingSets = groupDimensions.map((dimension) => sql`(${dimension})`);
-  const result = await read.select({
-    ...selectDimensions,
-    ...selectGrouping,
-    runs: sql<number>`COUNT(DISTINCT ${runs.id})::integer`.as('runs'),
-    input_tokens: sql<string | number>`COALESCE(SUM(${usageLineItems.inputTokens}), 0)`.as('input_tokens'),
-    output_tokens: sql<string | number>`COALESCE(SUM(${usageLineItems.outputTokens}), 0)`.as('output_tokens'),
-    cost_usd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
-  })
-    .from(runs)
-    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
-    .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
-    .leftJoin(skillExecutions, and(eq(skillExecutions.id, usageLineItems.skillExecutionId), eq(skillExecutions.tenantId, runs.tenantId)))
-    .where(and(...conditions))
-    .groupBy(sql`GROUPING SETS (${sql.join(groupingSets, sql`, `)})`);
-  return result as unknown as BreakdownRow[];
 }
 
 /** Aggregate additive usage and nullable cost over explicit, allowlisted dimensions. */
@@ -733,18 +751,18 @@ export async function aggregateCostBreakdowns(
   dimensions: readonly CostDimension[],
 ): Promise<CostBreakdownsResponse> {
   const context = requireServiceContext(contextInput);
-  const rows = await aggregateBreakdownRows(database, context, filters, dimensions);
-  const breakdowns = dimensions.map((dimension) => ({ dimension, groups: [] as CostGroup[] }));
-  for (const row of rows) {
-    const dimensionIndex = dimensions.findIndex((_, index) => Number(row[`grouping_${index}`]) === 0);
-    const breakdown = breakdowns[dimensionIndex];
-    if (!breakdown) continue;
-    breakdown.groups.push({
-      dimensions: { [breakdown.dimension]: String(row[`dimension_${dimensionIndex}`]) },
-      ...mapAggregateRow(row),
-    });
-  }
-  return { breakdowns };
+  const rowsByDimension = await Promise.all(
+    dimensions.map((dimension) => aggregateRows(database, context, filters, [dimension])),
+  );
+  return {
+    breakdowns: dimensions.map((dimension, index) => ({
+      dimension,
+      groups: (rowsByDimension[index] ?? []).map((row) => ({
+        dimensions: { [dimension]: String(row['dimension_0']) },
+        ...mapAggregateRow(row),
+      })),
+    })),
+  };
 }
 
 /** List lightweight repository and skill values used by history filters. */
@@ -801,91 +819,128 @@ export async function listHistoryDimensions(
 export async function listRepositories(database: WardenDatabase, contextInput: ServiceContext | undefined): Promise<RepositoryListResponse> {
   const context = requireServiceContext(contextInput);
   const read = getReadDatabase(database);
-  const costs = read.$with('run_costs').as(
+  const repositoryConditions: SQL[] = [eq(repositories.tenantId, context.tenantId)];
+  const authorizedRepositories = repositoryScope(context);
+  if (authorizedRepositories) repositoryConditions.push(authorizedRepositories);
+  const runConditions: SQL[] = [eq(runs.tenantId, context.tenantId)];
+  const authorizedRuns = runRepositoryScope(read, context);
+  if (authorizedRuns) runConditions.push(authorizedRuns);
+
+  const [repositoryRows, runRows, costRows] = await Promise.all([
     read.select({
-      runId: usageLineItems.runId,
+      id: repositories.id,
+      provider: repositories.provider,
+      owner: repositories.owner,
+      name: repositories.name,
+      fullName: repositories.fullName,
+    })
+      .from(repositories)
+      .where(and(...repositoryConditions)),
+    read.select({
+      repositoryId: runs.repositoryId,
+      runs: sql<number>`COUNT(*)::integer`.as('runs'),
+      findings: sql<number>`COALESCE(SUM(${runs.findingCount}), 0)::integer`.as('findings'),
+      lastRunAt: sql<Date | string | null>`MAX(${runs.completedAt})`.as('last_run_at'),
+    })
+      .from(runs)
+      .where(and(...runConditions))
+      .groupBy(runs.repositoryId),
+    read.select({
+      repositoryId: runs.repositoryId,
       costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
     })
       .from(usageLineItems)
-      .where(eq(usageLineItems.tenantId, context.tenantId))
-      .groupBy(usageLineItems.runId),
-  );
-  const conditions: SQL[] = [eq(repositories.tenantId, context.tenantId)];
-  const authorizedRepositories = repositoryScope(context);
-  if (authorizedRepositories) conditions.push(authorizedRepositories);
-  const result = await read.with(costs).select({
-    id: repositories.id,
-    provider: repositories.provider,
-    owner: repositories.owner,
-    name: repositories.name,
-    full_name: repositories.fullName,
-    runs: sql<number>`COUNT(DISTINCT ${runs.id})::integer`.as('runs'),
-    findings: sql<number>`COALESCE(SUM(${runs.findingCount}), 0)::integer`.as('findings'),
-    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
-    last_run_at: sql<Date | string | null>`MAX(${runs.completedAt})`.as('last_run_at'),
-  })
-    .from(repositories)
-    .leftJoin(runs, and(eq(runs.repositoryId, repositories.id), eq(runs.tenantId, repositories.tenantId)))
-    .leftJoin(costs, eq(costs.runId, runs.id))
-    .where(and(...conditions))
-    .groupBy(repositories.id)
-    .orderBy(sql`MAX(${runs.completedAt}) DESC NULLS LAST`, asc(repositories.fullName));
-  return { items: result.map((row) => ({
-    id: String(row['id']),
-    repository: {
-      provider: row['provider'] as 'github' | 'gitlab' | 'local',
-      owner: String(row['owner']),
-      name: String(row['name']),
-      fullName: String(row['full_name']),
-    },
-    runs: Number(row['runs']),
-    findings: Number(row['findings']),
-    costUsd: numberOrNull(row['cost_usd'] as string | number | null),
-    lastRunAt: row['last_run_at'] ? iso(row['last_run_at'] as Date | string) : null,
-  })) };
+      .innerJoin(runs, and(
+        eq(runs.id, usageLineItems.runId),
+        eq(runs.tenantId, usageLineItems.tenantId),
+      ))
+      .where(and(eq(usageLineItems.tenantId, context.tenantId), ...runConditions))
+      .groupBy(runs.repositoryId),
+  ]);
+  const runsByRepository = new Map(runRows.map((row) => [row.repositoryId, row]));
+  const costsByRepository = new Map(costRows.map((row) => [row.repositoryId, row.costUsd]));
+  const items = repositoryRows.map((row) => {
+    const aggregate = runsByRepository.get(row.id);
+    return {
+      id: row.id,
+      repository: {
+        provider: row.provider as 'github' | 'gitlab' | 'local',
+        owner: row.owner,
+        name: row.name,
+        fullName: row.fullName,
+      },
+      runs: Number(aggregate?.runs ?? 0),
+      findings: Number(aggregate?.findings ?? 0),
+      costUsd: numberOrNull(costsByRepository.get(row.id) ?? null),
+      lastRunAt: aggregate?.lastRunAt ? iso(aggregate.lastRunAt) : null,
+    };
+  });
+  items.sort((left, right) => {
+    if (left.lastRunAt && right.lastRunAt && left.lastRunAt !== right.lastRunAt) {
+      return right.lastRunAt.localeCompare(left.lastRunAt);
+    }
+    if (left.lastRunAt) return -1;
+    if (right.lastRunAt) return 1;
+    return left.repository.fullName.localeCompare(right.repository.fullName);
+  });
+  return { items };
 }
 
 /** Summarize skill execution quality with explicit success/failure denominators. */
 export async function listSkills(database: WardenDatabase, contextInput: ServiceContext | undefined): Promise<SkillListResponse> {
   const context = requireServiceContext(contextInput);
   const read = getReadDatabase(database);
-  const costs = read.$with('skill_costs').as(
-    read.select({
-      skillExecutionId: usageLineItems.skillExecutionId,
-      costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
-    })
-      .from(usageLineItems)
-      .where(and(
-        eq(usageLineItems.tenantId, context.tenantId),
-        sql`${usageLineItems.skillExecutionId} IS NOT NULL`,
-      ))
-      .groupBy(usageLineItems.skillExecutionId),
-  );
-  const conditions: SQL[] = [eq(skillExecutions.tenantId, context.tenantId)];
-  const authorizedRepositories = repositoryScope(context);
-  if (authorizedRepositories) conditions.push(authorizedRepositories);
-  const result = await read.with(costs).select({
+  const selectSummary = {
     skill: skillExecutions.skill,
     executions: sql<number>`COUNT(*)::integer`.as('executions'),
     successful: sql<number>`COUNT(*) FILTER (WHERE ${skillExecutions.status} = 'success')::integer`.as('successful'),
     failed: sql<number>`COUNT(*) FILTER (WHERE ${skillExecutions.status} = 'failure')::integer`.as('failed'),
     findings: sql<number>`COALESCE(SUM(${skillExecutions.findingCount}), 0)::integer`.as('findings'),
-    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
-  })
-    .from(skillExecutions)
-    .innerJoin(runs, and(eq(runs.id, skillExecutions.runId), eq(runs.tenantId, skillExecutions.tenantId)))
-    .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
-    .leftJoin(costs, eq(costs.skillExecutionId, skillExecutions.id))
-    .where(and(...conditions))
-    .groupBy(skillExecutions.skill)
-    .orderBy(desc(sql`COUNT(*)`), asc(skillExecutions.skill));
-  return { items: result.map((row) => ({
-    skill: String(row['skill']),
-    executions: Number(row['executions']),
-    successful: Number(row['successful']),
-    failed: Number(row['failed']),
-    findings: Number(row['findings']),
-    costUsd: numberOrNull(row['cost_usd'] as string | number | null),
+  };
+  const selectCosts = {
+    skill: skillExecutions.skill,
+    costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
+  };
+  const authorizedRuns = runRepositoryScope(read, context);
+  const summaryQuery = authorizedRuns
+    ? read.select(selectSummary)
+        .from(skillExecutions)
+        .innerJoin(runs, and(eq(runs.id, skillExecutions.runId), eq(runs.tenantId, skillExecutions.tenantId)))
+        .where(and(eq(skillExecutions.tenantId, context.tenantId), authorizedRuns))
+        .groupBy(skillExecutions.skill)
+        .orderBy(desc(sql`COUNT(*)`), asc(skillExecutions.skill))
+    : read.select(selectSummary)
+        .from(skillExecutions)
+        .where(eq(skillExecutions.tenantId, context.tenantId))
+        .groupBy(skillExecutions.skill)
+        .orderBy(desc(sql`COUNT(*)`), asc(skillExecutions.skill));
+  const costQuery = authorizedRuns
+    ? read.select(selectCosts)
+        .from(usageLineItems)
+        .innerJoin(skillExecutions, and(
+          eq(skillExecutions.id, usageLineItems.skillExecutionId),
+          eq(skillExecutions.tenantId, usageLineItems.tenantId),
+        ))
+        .innerJoin(runs, and(eq(runs.id, skillExecutions.runId), eq(runs.tenantId, skillExecutions.tenantId)))
+        .where(and(eq(usageLineItems.tenantId, context.tenantId), authorizedRuns))
+        .groupBy(skillExecutions.skill)
+    : read.select(selectCosts)
+        .from(usageLineItems)
+        .innerJoin(skillExecutions, and(
+          eq(skillExecutions.id, usageLineItems.skillExecutionId),
+          eq(skillExecutions.tenantId, usageLineItems.tenantId),
+        ))
+        .where(eq(usageLineItems.tenantId, context.tenantId))
+        .groupBy(skillExecutions.skill);
+  const [summaryRows, costRows] = await Promise.all([summaryQuery, costQuery]);
+  const costsBySkill = new Map(costRows.map((row) => [row.skill, row.costUsd]));
+  return { items: summaryRows.map((row) => ({
+    skill: row.skill,
+    executions: Number(row.executions),
+    successful: Number(row.successful),
+    failed: Number(row.failed),
+    findings: Number(row.findings),
+    costUsd: numberOrNull(costsBySkill.get(row.skill) ?? null),
   })) };
 }
 
@@ -894,38 +949,28 @@ export async function summarizeOutcomes(database: WardenDatabase, contextInput: 
   const context = requireServiceContext(contextInput);
   const read = getReadDatabase(database);
   const conditions = historyWhere(read, context, filters);
-  const filteredRuns = read.$with('filtered_runs').as(
-    read.selectDistinct({
-      id: runs.id,
-      outcome: runs.outcome,
-      findingCount: runs.findingCount,
+  const [totalRows, costRows] = await Promise.all([
+    read.select({
+      runs: sql<number>`COUNT(*)::integer`.as('runs'),
+      successful: sql<number>`COUNT(*) FILTER (WHERE ${runs.outcome} = 'success')::integer`.as('successful'),
+      failed: sql<number>`COUNT(*) FILTER (WHERE ${runs.outcome} = 'failure')::integer`.as('failed'),
+      cancelled: sql<number>`COUNT(*) FILTER (WHERE ${runs.outcome} = 'cancelled')::integer`.as('cancelled'),
+      skipped: sql<number>`COUNT(*) FILTER (WHERE ${runs.outcome} = 'skipped')::integer`.as('skipped'),
+      findings: sql<number>`COALESCE(SUM(${runs.findingCount}), 0)::integer`.as('findings'),
     })
       .from(runs)
-      .innerJoin(repositories, and(eq(repositories.id, runs.repositoryId), eq(repositories.tenantId, runs.tenantId)))
-      .leftJoin(usageLineItems, and(eq(usageLineItems.runId, runs.id), eq(usageLineItems.tenantId, runs.tenantId)))
       .where(and(...conditions)),
-  );
-  const costs = read.$with('run_costs').as(
     read.select({
-      runId: usageLineItems.runId,
       costUsd: sql<string | number | null>`SUM(${usageLineItems.costUsd})`.as('cost_usd'),
     })
       .from(usageLineItems)
-      .where(eq(usageLineItems.tenantId, context.tenantId))
-      .groupBy(usageLineItems.runId),
-  );
-  const result = await read.with(filteredRuns, costs).select({
-    runs: sql<number>`COUNT(*)::integer`.as('runs'),
-    successful: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'success')::integer`.as('successful'),
-    failed: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'failure')::integer`.as('failed'),
-    cancelled: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'cancelled')::integer`.as('cancelled'),
-    skipped: sql<number>`COUNT(*) FILTER (WHERE ${filteredRuns.outcome} = 'skipped')::integer`.as('skipped'),
-    findings: sql<number>`COALESCE(SUM(${filteredRuns.findingCount}), 0)::integer`.as('findings'),
-    cost_usd: sql<string | number | null>`SUM(${costs.costUsd})`.as('cost_usd'),
-  })
-    .from(filteredRuns)
-    .leftJoin(costs, eq(costs.runId, filteredRuns.id));
-  const row = result[0];
+      .innerJoin(runs, and(
+        eq(runs.id, usageLineItems.runId),
+        eq(runs.tenantId, usageLineItems.tenantId),
+      ))
+      .where(and(eq(usageLineItems.tenantId, context.tenantId), ...conditions)),
+  ]);
+  const row = totalRows[0];
   return { totals: {
     runs: Number(row?.runs ?? 0),
     successful: Number(row?.successful ?? 0),
@@ -933,6 +978,6 @@ export async function summarizeOutcomes(database: WardenDatabase, contextInput: 
     cancelled: Number(row?.cancelled ?? 0),
     skipped: Number(row?.skipped ?? 0),
     findings: Number(row?.findings ?? 0),
-    costUsd: numberOrNull(row?.cost_usd ?? null),
+    costUsd: numberOrNull(costRows[0]?.costUsd ?? null),
   } };
 }


### PR DESCRIPTION
Production traces show database work dominating the dashboard request path. Recent database-span p50s were approximately 1.77s for repositories, 1.75s for skills, 945ms for outcome summaries, 964ms for costs, and 818ms for cost breakdowns. The direct history dimension queries complete in 12-46ms and provide the target query shape.

This replaces tenant-wide cost CTEs, unconditional joins, SELECT DISTINCT deduplication, and GROUPING SETS with narrow tenant-scoped aggregates. Run filters now use correlated EXISTS checks, cost breakdowns execute one simple query per requested dimension, and queries only join repositories or skill executions when their dimensions require them.

Repository and skill summaries now merge independent indexed aggregates in application memory. An additive migration adds the missing (tenant_id, skill_execution_id) index used by skill cost lookups. The migration does not alter or remove existing schema.

Adding more indexes to the existing broad queries was considered, but it would preserve avoidable full-tenant grouping and join work. Simplifying the query plans first keeps each predicate aligned with the existing tenant-leading indexes.