### PR TITLE
fix(service): Preserve finding timestamps in database reads

### DIFF
--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -336,7 +336,7 @@ describe('createWardenService', () => {
           path: 'src/query.ts', start_line: 12, end_line: 12,
           observation_outcome: 'posted',
           first_observed_at: '2026-08-12T10:00:00.000Z',
-          observed_at: '2026-08-12T10:01:00.000Z',
+          last_observed_at: '2026-08-12T10:01:00.000Z',
           completed_at: '2026-08-12T10:01:00.000Z',
           };
           return { rows: [finding] as unknown as TRow[], rowCount: 1 };

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -146,7 +146,7 @@ describe('history store', () => {
         end_line: 48,
         observation_outcome: 'posted',
         first_observed_at: '2026-08-12T10:00:00.000Z',
-        observed_at: '2026-08-12T10:02:00.000Z',
+        last_observed_at: '2026-08-12T10:02:00.000Z',
         completed_at: '2026-08-12T10:01:00.000Z',
       }], rowCount: 1 };
     });
@@ -182,6 +182,80 @@ describe('history store', () => {
     ]));
   });
 
+  it('preserves duplicate observation timestamp columns returned by PostgreSQL', async () => {
+    const rowValues = [
+      '00000000-0000-0000-0000-000000000020',
+      '7MV-5V7',
+      null,
+      '00000000-0000-0000-0000-000000000021',
+      'run-21',
+      'github',
+      'acme',
+      'widgets',
+      'acme/widgets',
+      'security-review',
+      'high',
+      'high',
+      'Missing authorization check',
+      'The endpoint does not verify ownership.',
+      'src/api.ts',
+      42,
+      48,
+      'posted',
+      '2026-08-12T10:00:00.000Z',
+      '2026-08-12T10:02:00.000Z',
+      '2026-08-12T10:01:00.000Z',
+    ];
+    let capturedSql = '';
+    const database = {
+      async query(sql: string) {
+        capturedSql = sql;
+        const timestamps = sql.includes('as "first_observed_at"')
+          && sql.includes('as "last_observed_at"')
+          ? {
+              first_observed_at: rowValues[18],
+              last_observed_at: rowValues[19],
+            }
+          : { observed_at: rowValues[19] };
+        return {
+          rows: [{
+            id: rowValues[0],
+            client_finding_id: rowValues[1],
+            reported_id: rowValues[2],
+            run_id: rowValues[3],
+            client_run_id: rowValues[4],
+            provider: rowValues[5],
+            owner: rowValues[6],
+            name: rowValues[7],
+            full_name: rowValues[8],
+            skill: rowValues[9],
+            severity: rowValues[10],
+            confidence: rowValues[11],
+            title: rowValues[12],
+            description: rowValues[13],
+            path: rowValues[14],
+            start_line: rowValues[15],
+            end_line: rowValues[16],
+            observation_outcome: rowValues[17],
+            ...timestamps,
+            completed_at: rowValues[20],
+          }],
+          rowCount: 1,
+        };
+      },
+    } as unknown as WardenDatabase;
+
+    const page = await listFindings(database, context, {});
+
+    expect(page.items[0]).toMatchObject({
+      firstObservedAt: '2026-08-12T10:00:00.000Z',
+      lastObservedAt: '2026-08-12T10:02:00.000Z',
+      completedAt: '2026-08-12T10:01:00.000Z',
+    });
+    expect(capturedSql).toContain('as "first_observed_at"');
+    expect(capturedSql).toContain('as "last_observed_at"');
+  });
+
   it('returns source and verification context with the latest finding observation', async () => {
     let detailSql = '';
     const database = databaseFor((sql) => {
@@ -205,7 +279,7 @@ describe('history store', () => {
           path: 'src/api route.ts', start_line: 42, end_line: 48,
           observation_outcome: 'posted',
           first_observed_at: '2026-08-12T09:55:00.000Z',
-          observed_at: '2026-08-12T10:02:00.000Z',
+          last_observed_at: '2026-08-12T10:02:00.000Z',
           completed_at: '2026-08-12T10:01:00.000Z',
         }],
         rowCount: 1,

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -254,7 +254,7 @@ interface FindingFeedRow extends Record<string, unknown> {
   end_line: number | null;
   observation_outcome: FindingFeedItem['outcome'];
   first_observed_at: Date | string | null;
-  observed_at: Date | string | null;
+  last_observed_at: Date | string | null;
   completed_at: Date | string;
 }
 
@@ -290,7 +290,7 @@ function mapFinding(row: FindingFeedRow): FindingFeedItem {
     } : {}),
     outcome: row.observation_outcome,
     firstObservedAt: row.first_observed_at ? iso(row.first_observed_at) : null,
-    lastObservedAt: row.observed_at ? iso(row.observed_at) : null,
+    lastObservedAt: row.last_observed_at ? iso(row.last_observed_at) : null,
     completedAt: iso(row.completed_at),
   };
 }
@@ -319,7 +319,7 @@ function findingContextQueries(database: WardenReadDatabase) {
     .as('location');
   const observation = database.select({
     outcome: findingObservations.outcome,
-    observed_at: findingObservations.observedAt,
+    last_observed_at: sql<Date>`${findingObservations.observedAt}`.as('last_observed_at'),
   })
     .from(findingObservations)
     .where(and(
@@ -331,7 +331,7 @@ function findingContextQueries(database: WardenReadDatabase) {
     .as('observation');
   // Earliest observation is first seen for this finding row (per-run identity today).
   const firstObservation = database.select({
-    observed_at: findingObservations.observedAt,
+    first_observed_at: sql<Date>`${findingObservations.observedAt}`.as('first_observed_at'),
   })
     .from(findingObservations)
     .where(and(
@@ -394,8 +394,8 @@ export async function listFindings(
     start_line: location.start_line,
     end_line: location.end_line,
     observation_outcome: observation.outcome,
-    first_observed_at: firstObservation.observed_at,
-    observed_at: observation.observed_at,
+    first_observed_at: firstObservation.first_observed_at,
+    last_observed_at: observation.last_observed_at,
     completed_at: runs.completedAt,
   })
     .from(runs)
@@ -451,8 +451,8 @@ export async function getFindingDetail(
     start_line: location.start_line,
     end_line: location.end_line,
     observation_outcome: observation.outcome,
-    first_observed_at: firstObservation.observed_at,
-    observed_at: observation.observed_at,
+    first_observed_at: firstObservation.first_observed_at,
+    last_observed_at: observation.last_observed_at,
     completed_at: runs.completedAt,
   })
     .from(findings)


### PR DESCRIPTION
Keep finding timestamps aligned when reading PostgreSQL rows.

The first-observed change selected the earliest and latest timestamps under the same SQL column name. PostgreSQL object rows collapsed that duplicate key, shifting the Drizzle result mapping and causing `/api/v1/findings` to throw `RangeError: Invalid time value`.

Alias both timestamps explicitly and preserve those names through the findings feed and detail mappings. Regression coverage models the duplicate-column behavior that caused the production failure.

Fixes [WARDEN-2H](https://sentry.sentry.io/issues/7674643660/)