### PR TITLE
fix(service): Explain findings skipped after PR changes

### DIFF
--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -57,7 +57,7 @@ function dateTime(value, fallback = 'Not reported') {
   return time;
 }
 
-function findingOutcomeLabel(finding, fallback = 'No posting record') {
+function findingOutcomeLabel(finding, fallback = 'Delivery not tracked') {
   if (finding.outcome === 'skipped' && finding.outcomeReason === 'pull_request_changed') {
     return 'Not posted: PR changed';
   }
@@ -73,7 +73,7 @@ function findingOutcomeDescription(finding) {
     return 'Skipped because Warden could not verify that the pull request was still current, so it did not add review feedback.';
   }
   if (!finding.outcome) {
-    return 'This older run retained the finding but did not record what happened during review posting.';
+    return 'Warden did not record how this finding was delivered. Scheduled scans and older runs may omit this data.';
   }
   return findingOutcomeLabel(finding);
 }
@@ -604,7 +604,7 @@ function findingRows(finding) {
   const location = element('td', locationText, 'finding-location');
   location.title = locationText;
 
-  const status = element('td', findingOutcomeLabel(finding, '—'), `finding-status ${finding.outcome ?? ''}`);
+  const status = element('td', findingOutcomeLabel(finding), `finding-status ${finding.outcome ?? ''}`);
   const firstObserved = document.createElement('td');
   firstObserved.append(dateTime(finding.firstObservedAt, '—'));
   const lastObserved = document.createElement('td');

--- a/apps/warden-service/public/assets/app.js
+++ b/apps/warden-service/public/assets/app.js
@@ -57,6 +57,27 @@ function dateTime(value, fallback = 'Not reported') {
   return time;
 }
 
+function findingOutcomeLabel(finding, fallback = 'No posting record') {
+  if (finding.outcome === 'skipped' && finding.outcomeReason === 'pull_request_changed') {
+    return 'Not posted: PR changed';
+  }
+  if (!finding.outcome) return fallback;
+  return finding.outcome.charAt(0).toUpperCase() + finding.outcome.slice(1);
+}
+
+function findingOutcomeDescription(finding) {
+  if (finding.outcome === 'skipped' && finding.outcomeReason === 'pull_request_changed') {
+    return 'Warden did not post this finding because the pull request changed before Warden finished. It refers to an older commit; the newer run reviews the updated code.';
+  }
+  if (finding.outcome === 'skipped' && finding.outcomeReason === 'review_not_posted') {
+    return 'Skipped because Warden could not verify that the pull request was still current, so it did not add review feedback.';
+  }
+  if (!finding.outcome) {
+    return 'This older run retained the finding but did not record what happened during review posting.';
+  }
+  return findingOutcomeLabel(finding);
+}
+
 function setPage(title, description) {
   pageTitle.textContent = title;
   pageDescription.textContent = description;
@@ -583,7 +604,7 @@ function findingRows(finding) {
   const location = element('td', locationText, 'finding-location');
   location.title = locationText;
 
-  const status = element('td', finding.outcome ?? '—', `finding-status ${finding.outcome ?? ''}`);
+  const status = element('td', findingOutcomeLabel(finding, '—'), `finding-status ${finding.outcome ?? ''}`);
   const firstObserved = document.createElement('td');
   firstObserved.append(dateTime(finding.firstObservedAt, '—'));
   const lastObserved = document.createElement('td');
@@ -611,7 +632,7 @@ function findingRows(finding) {
     findingDetail('Skill', finding.skill),
     findingDetail('Location', locationText),
     findingDetail('Confidence', finding.confidence ?? 'Not reported'),
-    findingDetail('Status', finding.outcome ?? 'Not reported'),
+    findingDetail('Reporting outcome', findingOutcomeDescription(finding)),
     findingDetail('First observed', dateTime(finding.firstObservedAt)),
     findingDetail('Last observed', dateTime(finding.lastObservedAt)),
   );
@@ -729,8 +750,13 @@ async function renderFinding(version, findingId) {
   const heading = element('div', undefined, 'finding-page-heading');
   heading.append(
     element('span', finding.severity, `severity ${finding.severity}`),
-    element('span', finding.outcome ?? 'Not reported', `finding-status ${finding.outcome ?? ''}`),
+    element('span', findingOutcomeLabel(finding), `finding-status ${finding.outcome ?? ''}`),
   );
+
+  const outcomeDescription = findingOutcomeDescription(finding);
+  const reportingNote = outcomeDescription !== findingOutcomeLabel(finding)
+    ? element('p', outcomeDescription, 'finding-reporting-note')
+    : undefined;
 
   const explanation = findingPageSection('Why Warden Flagged This');
   explanation.append(element('p', finding.description, 'finding-page-description'));
@@ -759,7 +785,7 @@ async function renderFinding(version, findingId) {
     findingDetail('Skill', finding.skill),
     findingDetail('Location', findingLocation(finding)),
     findingDetail('Confidence', finding.confidence ?? 'Not reported'),
-    findingDetail('Latest outcome', finding.outcome ?? 'Not reported'),
+    findingDetail('Latest outcome', findingOutcomeDescription(finding)),
     findingDetail('First observed', dateTime(finding.firstObservedAt)),
     findingDetail('Last observed', dateTime(finding.lastObservedAt)),
     findingDetail('Run completed', dateTime(finding.completedAt)),
@@ -767,7 +793,9 @@ async function renderFinding(version, findingId) {
     findingDetail('Commit', detail.headSha ? detail.headSha.slice(0, 12) : 'Not reported'),
   );
   details.append(metadata);
-  article.append(heading, explanation, codeContext, details);
+  article.append(heading);
+  if (reportingNote) article.append(reportingNote);
+  article.append(explanation, codeContext, details);
   section.append(article);
   content.replaceChildren(section);
 }

--- a/apps/warden-service/public/assets/styles.css
+++ b/apps/warden-service/public/assets/styles.css
@@ -187,7 +187,7 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-table th:nth-child(2) { width: 30%; }
 .finding-table th:nth-child(3) { width: 16%; }
 .finding-table th:nth-child(4) { width: 16%; }
-.finding-table th:nth-child(5) { width: 82px; }
+.finding-table th:nth-child(5) { width: 170px; }
 .finding-table th:nth-child(6),
 .finding-table th:nth-child(7) { width: 146px; }
 .finding-table td { padding: 10px 12px; border-top: 1px solid var(--border); vertical-align: top; font-size: 12px; }
@@ -209,7 +209,7 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-context, .finding-location { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .finding-skill { margin-top: 3px; color: var(--muted); }
 .finding-location { color: var(--muted-strong); font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.finding-status { color: var(--muted-strong); font-size: 11px; text-transform: capitalize; }
+.finding-status { color: var(--muted-strong); font-size: 11px; }
 .finding-status.posted, .finding-status.resolved, .finding-status.revised { color: var(--success); }
 .finding-table time { color: var(--muted); font-size: 11px; white-space: nowrap; }
 .finding-detail-row > td { border-top: 0; padding: 0 12px 14px 112px; background: var(--surface-raised); }
@@ -226,6 +226,7 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .finding-page > .text-link { width: fit-content; font-size: 12px; }
 .finding-page-card { min-width: 0; padding: 24px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
 .finding-page-heading { display: flex; align-items: center; gap: 16px; margin-bottom: 22px; }
+.finding-reporting-note { margin: -8px 0 22px; padding: 12px 14px; border-left: 2px solid var(--medium); background: #1b1714; color: var(--muted-strong); font-size: 13px; line-height: 1.5; }
 .finding-page-section { min-width: 0; padding-top: 22px; border-top: 1px solid var(--border); }
 .finding-page-heading + .finding-page-section { padding-top: 0; border-top: 0; }
 .finding-page-section + .finding-page-section { margin-top: 24px; }

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -104,6 +104,12 @@ describe('Vercel service app', () => {
     expect(script).toContain("element('h2', 'Code Context')");
     expect(script).toContain("findingPageSection('Finding Details')");
     expect(script).toContain("'No source snippet was retained for this finding.'");
+    expect(script).toContain("'Not posted: PR changed'");
+    expect(script).toContain(
+      "'Warden did not post this finding because the pull request changed before Warden finished. It refers to an older commit; the newer run reviews the updated code.'",
+    );
+    expect(script).toContain("'This older run retained the finding but did not record what happened during review posting.'");
+    expect(script).toContain("findingDetail('Reporting outcome', findingOutcomeDescription(finding))");
     expect(script).toContain("findingDetail('First observed'");
     expect(script).toContain("findingDetail('Last observed'");
     expect(script).not.toContain('protected-session');

--- a/apps/warden-service/src/create-app.test.ts
+++ b/apps/warden-service/src/create-app.test.ts
@@ -108,7 +108,12 @@ describe('Vercel service app', () => {
     expect(script).toContain(
       "'Warden did not post this finding because the pull request changed before Warden finished. It refers to an older commit; the newer run reviews the updated code.'",
     );
-    expect(script).toContain("'This older run retained the finding but did not record what happened during review posting.'");
+    expect(script).toContain("fallback = 'Delivery not tracked'");
+    expect(script).toContain(
+      "'Warden did not record how this finding was delivered. Scheduled scans and older runs may omit this data.'",
+    );
+    expect(script).not.toContain('This older run retained the finding');
+    expect(script).toContain("element('td', findingOutcomeLabel(finding), `finding-status");
     expect(script).toContain("findingDetail('Reporting outcome', findingOutcomeDescription(finding))");
     expect(script).toContain("findingDetail('First observed'");
     expect(script).toContain("findingDetail('Last observed'");

--- a/packages/warden-service-api/src/api.ts
+++ b/packages/warden-service-api/src/api.ts
@@ -76,6 +76,8 @@ export const FindingFeedItemSchema = z.object({
     endLine: z.number().int().positive().optional(),
   }).strict().optional(),
   outcome: FindingOutcomeSchema.nullable(),
+  /** Machine-readable reason attached to the latest finding observation. */
+  outcomeReason: z.string().trim().min(1).max(128).nullable(),
   /** Earliest observation timestamp for this finding row. */
   firstObservedAt: TimestampSchema.nullable(),
   /** Latest observation timestamp for this finding row. */

--- a/packages/warden-service/src/app.test.ts
+++ b/packages/warden-service/src/app.test.ts
@@ -334,7 +334,8 @@ describe('createWardenService', () => {
           skill: 'security', severity: 'high', confidence: 'high',
           title: 'Unsafe query', description: 'Use parameters.',
           path: 'src/query.ts', start_line: 12, end_line: 12,
-          observation_outcome: 'posted',
+          observation_outcome: 'skipped',
+          observation_reason: 'pull_request_changed',
           first_observed_at: '2026-08-12T10:00:00.000Z',
           last_observed_at: '2026-08-12T10:01:00.000Z',
           completed_at: '2026-08-12T10:01:00.000Z',
@@ -373,6 +374,8 @@ describe('createWardenService', () => {
       finding: {
         id: '00000000-0000-4000-8000-000000000010',
         displayId: '7MV-5V7',
+        outcome: 'skipped',
+        outcomeReason: 'pull_request_changed',
         firstObservedAt: '2026-08-12T10:00:00.000Z',
         lastObservedAt: '2026-08-12T10:01:00.000Z',
       },

--- a/packages/warden-service/src/history/store.test.ts
+++ b/packages/warden-service/src/history/store.test.ts
@@ -145,6 +145,7 @@ describe('history store', () => {
         start_line: 42,
         end_line: 48,
         observation_outcome: 'posted',
+        observation_reason: null,
         first_observed_at: '2026-08-12T10:00:00.000Z',
         last_observed_at: '2026-08-12T10:02:00.000Z',
         completed_at: '2026-08-12T10:01:00.000Z',
@@ -165,6 +166,7 @@ describe('history store', () => {
       repository: { fullName: 'acme/widgets' },
       location: { path: 'src/api.ts', startLine: 42 },
       outcome: 'posted',
+      outcomeReason: null,
       firstObservedAt: '2026-08-12T10:00:00.000Z',
       lastObservedAt: '2026-08-12T10:02:00.000Z',
     });
@@ -202,6 +204,7 @@ describe('history store', () => {
       42,
       48,
       'posted',
+      null,
       '2026-08-12T10:00:00.000Z',
       '2026-08-12T10:02:00.000Z',
       '2026-08-12T10:01:00.000Z',
@@ -213,10 +216,10 @@ describe('history store', () => {
         const timestamps = sql.includes('as "first_observed_at"')
           && sql.includes('as "last_observed_at"')
           ? {
-              first_observed_at: rowValues[18],
-              last_observed_at: rowValues[19],
+              first_observed_at: rowValues[19],
+              last_observed_at: rowValues[20],
             }
-          : { observed_at: rowValues[19] };
+          : { observed_at: rowValues[20] };
         return {
           rows: [{
             id: rowValues[0],
@@ -237,8 +240,9 @@ describe('history store', () => {
             start_line: rowValues[15],
             end_line: rowValues[16],
             observation_outcome: rowValues[17],
+            observation_reason: rowValues[18],
             ...timestamps,
-            completed_at: rowValues[20],
+            completed_at: rowValues[21],
           }],
           rowCount: 1,
         };
@@ -277,7 +281,8 @@ describe('history store', () => {
           skill: 'security-review', severity: 'high', confidence: 'high',
           title: 'Missing authorization check', description: 'The endpoint does not verify ownership.',
           path: 'src/api route.ts', start_line: 42, end_line: 48,
-          observation_outcome: 'posted',
+          observation_outcome: 'skipped',
+          observation_reason: 'pull_request_changed',
           first_observed_at: '2026-08-12T09:55:00.000Z',
           last_observed_at: '2026-08-12T10:02:00.000Z',
           completed_at: '2026-08-12T10:01:00.000Z',
@@ -296,6 +301,8 @@ describe('history store', () => {
       sourceEvidence: { targetStartLine: 42, content: 'authorize(request);' },
       verification: 'The route reads an account before checking the caller.',
       finding: {
+        outcome: 'skipped',
+        outcomeReason: 'pull_request_changed',
         firstObservedAt: '2026-08-12T09:55:00.000Z',
         lastObservedAt: '2026-08-12T10:02:00.000Z',
       },

--- a/packages/warden-service/src/history/store.ts
+++ b/packages/warden-service/src/history/store.ts
@@ -253,6 +253,7 @@ interface FindingFeedRow extends Record<string, unknown> {
   start_line: number | null;
   end_line: number | null;
   observation_outcome: FindingFeedItem['outcome'];
+  observation_reason: string | null;
   first_observed_at: Date | string | null;
   last_observed_at: Date | string | null;
   completed_at: Date | string;
@@ -289,6 +290,7 @@ function mapFinding(row: FindingFeedRow): FindingFeedItem {
       },
     } : {}),
     outcome: row.observation_outcome,
+    outcomeReason: row.observation_reason ?? null,
     firstObservedAt: row.first_observed_at ? iso(row.first_observed_at) : null,
     lastObservedAt: row.last_observed_at ? iso(row.last_observed_at) : null,
     completedAt: iso(row.completed_at),
@@ -319,6 +321,7 @@ function findingContextQueries(database: WardenReadDatabase) {
     .as('location');
   const observation = database.select({
     outcome: findingObservations.outcome,
+    reason: findingObservations.reason,
     last_observed_at: sql<Date>`${findingObservations.observedAt}`.as('last_observed_at'),
   })
     .from(findingObservations)
@@ -394,6 +397,7 @@ export async function listFindings(
     start_line: location.start_line,
     end_line: location.end_line,
     observation_outcome: observation.outcome,
+    observation_reason: observation.reason,
     first_observed_at: firstObservation.first_observed_at,
     last_observed_at: observation.last_observed_at,
     completed_at: runs.completedAt,
@@ -451,6 +455,7 @@ export async function getFindingDetail(
     start_line: location.start_line,
     end_line: location.end_line,
     observation_outcome: observation.outcome,
+    observation_reason: observation.reason,
     first_observed_at: firstObservation.first_observed_at,
     last_observed_at: observation.last_observed_at,
     completed_at: runs.completedAt,

--- a/packages/warden/src/action/reporting/outcomes.ts
+++ b/packages/warden/src/action/reporting/outcomes.ts
@@ -11,7 +11,12 @@ export type FindingOutcome =
 
 export type DedupeSource = 'warden' | 'external';
 export type DedupeMatchType = 'hash' | 'semantic';
-export type SkippedReason = 'max_findings' | 'duplicate_in_batch' | 'no_inline_location' | 'review_not_posted';
+export type SkippedReason =
+  | 'max_findings'
+  | 'duplicate_in_batch'
+  | 'no_inline_location'
+  | 'pull_request_changed'
+  | 'review_not_posted';
 export type ResolvedReason = 'fix_evaluation' | 'stale_check';
 
 export const DedupeDetailSchema = z.object({
@@ -84,7 +89,13 @@ export const FindingObservationSchema = z.discriminatedUnion('outcome', [
     finding: FindingSchema,
     skill: z.string().optional(),
     skillExecutionId: z.string().optional(),
-    skippedReason: z.enum(['max_findings', 'duplicate_in_batch', 'no_inline_location', 'review_not_posted']),
+    skippedReason: z.enum([
+      'max_findings',
+      'duplicate_in_batch',
+      'no_inline_location',
+      'pull_request_changed',
+      'review_not_posted',
+    ]),
   }),
   z.object({
     outcome: z.literal('resolved'),

--- a/packages/warden/src/action/review/poster.test.ts
+++ b/packages/warden/src/action/review/poster.test.ts
@@ -411,7 +411,7 @@ describe('postTriggerReview', () => {
     // Regression: these findings were about to post — the export must record
     // why they didn't, not silently drop them from findingObservations.
     expect(
-      postResult.findingObservations.filter((o) => o.outcome === 'skipped' && o.skippedReason === 'review_not_posted')
+      postResult.findingObservations.filter((o) => o.outcome === 'skipped' && o.skippedReason === 'pull_request_changed')
     ).toHaveLength(2);
   });
 
@@ -477,7 +477,7 @@ describe('postTriggerReview', () => {
       // Regression: the finding that would have posted must be recorded as
       // blocked, not vanish from the export.
       expect(
-        postResult.findingObservations.filter((o) => o.outcome === 'skipped' && o.skippedReason === 'review_not_posted')
+        postResult.findingObservations.filter((o) => o.outcome === 'skipped' && o.skippedReason === 'pull_request_changed')
       ).toEqual([expect.objectContaining({ finding: findings[0] })]);
     } finally {
       dateNowSpy.mockRestore();

--- a/packages/warden/src/action/review/poster.ts
+++ b/packages/warden/src/action/review/poster.ts
@@ -159,9 +159,15 @@ function remapFindingProcessingEvents(
  * - `posted`: the review was created on the PR
  * - `checks_only`: findings could not be attached inline; they stay in Checks
  * - `no_review`: nothing to post (no PR context or no rendered review)
- * - `blocked`: the run may no longer write feedback for the current PR head
+ * - `pull_request_changed`: the run targets an older PR head
+ * - `review_not_posted`: the current PR head could not be verified
  */
-type PostReviewOutcome = 'posted' | 'checks_only' | 'no_review' | 'blocked';
+type PostReviewOutcome =
+  | 'posted'
+  | 'checks_only'
+  | 'no_review'
+  | 'pull_request_changed'
+  | 'review_not_posted';
 
 /**
  * Post a PR review to GitHub.
@@ -203,9 +209,9 @@ async function postReviewToGitHub(
 
   // Duplicate-action comment updates between the poster's gate check and this
   // write can outlive the gate's cache window; verify once more.
-  if (!(await feedbackGate.canWrite())) {
-    return 'blocked';
-  }
+  const writability = await feedbackGate.check();
+  if (writability === 'blocked') return 'pull_request_changed';
+  if (writability === 'unknown') return 'review_not_posted';
 
   await octokit.pulls.createReview({
     owner,
@@ -393,14 +399,18 @@ export async function postTriggerReview(
     // Consolidation and dedup above can spend minutes in LLM calls. Re-verify
     // head freshness before the first GitHub write (duplicate-action comment
     // updates below, then the review itself).
-    if (!(await deps.feedbackGate.canWrite())) {
+    const writability = await deps.feedbackGate.check();
+    if (writability !== 'writable') {
+      const skippedReason = writability === 'blocked'
+        ? 'pull_request_changed' as const
+        : 'review_not_posted' as const;
       for (const finding of findingsToPost) {
         findingObservations.push({
           outcome: 'skipped',
           finding,
           skill,
           skillExecutionId: result.skillExecutionId,
-          skippedReason: 'review_not_posted',
+          skippedReason,
         });
       }
       return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
@@ -506,14 +516,14 @@ export async function postTriggerReview(
         return emptyReviewPostResult(newComments, activeWardenCommentIds, findingObservations);
       }
       if (postOutcome !== 'posted') {
-        if (postOutcome === 'blocked') {
+        if (postOutcome === 'pull_request_changed' || postOutcome === 'review_not_posted') {
           for (const finding of postedFindings) {
             findingObservations.push({
               outcome: 'skipped',
               finding,
               skill,
               skillExecutionId: result.skillExecutionId,
-              skippedReason: 'review_not_posted',
+              skippedReason: postOutcome,
             });
           }
         }

--- a/packages/warden/src/action/service.test.ts
+++ b/packages/warden/src/action/service.test.ts
@@ -176,7 +176,13 @@ describe('Action service integration', () => {
       serviceToken: 'service-token',
       serviceData: 'findings',
     }));
-    const buildOutput = vi.fn(() => buildFindingsOutput([report], context, [], {
+    const buildOutput = vi.fn(() => buildFindingsOutput([report], context, [{
+      outcome: 'skipped',
+      finding: report.findings[0]!,
+      skill: report.skill,
+      skillExecutionId: 'execution-1',
+      skippedReason: 'pull_request_changed',
+    }], {
       runId: 'action-run-123',
       timestamp: '2026-08-12T12:00:01.000Z',
       skillExecutions: [{
@@ -214,6 +220,12 @@ describe('Action service integration', () => {
         ],
       }],
       findings: [{ id: 'finding-1', skillExecutionId: 'execution-1' }],
+      observations: [{
+        findingId: 'finding-1',
+        skillExecutionId: 'execution-1',
+        outcome: 'skipped',
+        reason: 'pull_request_changed',
+      }],
     });
   });
 

--- a/packages/warden/src/action/workflow/pr-workflow.test.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.test.ts
@@ -1410,6 +1410,15 @@ describe('runPRWorkflow', () => {
         expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
         expect(mockEvaluateFixAttempts).not.toHaveBeenCalled();
         expect(mockOctokit.pulls.dismissReview).not.toHaveBeenCalled();
+        const [, , observations] = mockWriteFindingsOutput.mock.calls[0]!;
+        expect(observations).toEqual([
+          expect.objectContaining({
+            outcome: 'skipped',
+            finding,
+            skill: 'test-skill',
+            skippedReason: 'pull_request_changed',
+          }),
+        ]);
       } finally {
         dateNowSpy.mockRestore();
       }

--- a/packages/warden/src/action/workflow/pr-workflow.ts
+++ b/packages/warden/src/action/workflow/pr-workflow.ts
@@ -751,6 +751,23 @@ async function postReviewsAndTrackFailures(
         postResult.activeWardenCommentIds.forEach((id) => activeWardenCommentIds.add(id));
         findingObservations.push(...postResult.findingObservations);
         reviewPosted = postResult.posted;
+      } else {
+        const skippedReason = writability === 'blocked'
+          ? 'pull_request_changed' as const
+          : 'review_not_posted' as const;
+        const reportableFindings = filterFindings(
+          result.report.findings,
+          result.reportOn,
+          result.minConfidence,
+        );
+        const skill = result.report.skill;
+        findingObservations.push(...reportableFindings.map((finding): FindingObservation => ({
+          outcome: 'skipped',
+          finding,
+          skill,
+          skillExecutionId: result.skillExecutionId,
+          skippedReason,
+        })));
       }
       // A stale head skips silently (the newer run owns feedback), but an
       // unverifiable head must not silently swallow a blocking review.


### PR DESCRIPTION
Findings skipped because a pull request changed during analysis now retain a
`pull_request_changed` observation and expose it as `outcomeReason` through the
finding API. The dashboard presents these as `Not posted: PR changed` and
explains that the finding belongs to an older commit. Historical findings that
lack an observation instead show `No posting record` with separate explanatory
copy.

This distinguishes the expected PR freshness safeguard from incomplete
historical reporting. Review should start with the freshness paths in the PR
workflow and review poster, then follow the reason through the service query
and dashboard presentation.
