### PR TITLE
feat(security-review): add Apple mobile specific skill references

### DIFF
--- a/packages/warden/src/builtin-skills/security-review/SKILL.md
+++ b/packages/warden/src/builtin-skills/security-review/SKILL.md
@@ -16,12 +16,13 @@ Load only matching references:
 | `references/javascript-typescript.md` | Reviewing JavaScript, TypeScript, Node, React, Next.js, or browser code |
 | `references/python.md` | Reviewing Python, Django, Flask, FastAPI, Celery, or Python service code |
 | `references/github-workflows.md` | Reviewing GitHub Actions workflows, local actions, reusable workflows, or workflow-loaded scripts/config |
+| `references/apple.md` | Reviewing Swift or Objective-C code on Apple Platforms |
 
 ## Finding Requirements
 
 - Report a finding only when you can show attacker-controlled input, the vulnerable sink or missing guard, the security boundary, and concrete impact.
-- Identify attacker-controlled input: request bodies, query strings, path params, cookies, headers, uploads, webhooks, OAuth callbacks, third-party callbacks, user-written database values, and caller-controlled service inputs.
-- Identify the security boundary: login state, session, tenant, org, team, account, project, role, webhook signature, internal network, filesystem root, cache namespace, or paid quota.
+- Identify attacker-controlled input: request bodies, query strings, path params, cookies, headers, uploads, webhooks, OAuth callbacks, third-party callbacks, user-written database values, caller-controlled service inputs, deep links, inter-app messages, same-device callers, untrusted embedded web content, extension payloads, and backup-restored secrets.
+- Identify the security boundary: login state, session, tenant, org, team, account, project, role, webhook signature, internal network, filesystem root, cache namespace, paid quota, platform secret-store access control, shared-container membership, embedded-web origin, or transport trust.
 - Follow imports, wrappers, middleware, validators, serializers, auth helpers, route definitions, shared utilities, sibling handlers, and framework conventions before reporting.
 - Verify mitigations in the effective path. Parameterized queries, exact allowlists, safe URL fetchers, escaping, signature checks, handler-level auth, ownership checks, realpath containment, and quota controls can close the path.
 - Treat pattern matches as leads. A dangerous API is not a vulnerability unless untrusted data can reach it without an effective mitigation.
@@ -31,7 +32,7 @@ Load only matching references:
 
 1. Read the changed hunk and target file enough to understand the effective execution path.
 2. Confirm the code is production-reachable. Return no findings for generated, vendored, test-only, fixture, example, migration, or build-output code unless it is actually shipped or invoked.
-3. Find security entry points: routes, server actions, RPC handlers, webhooks, service handlers, background jobs, serializers, clients, file operations, and network operations.
+3. Find security entry points: routes, server actions, RPC handlers, webhooks, service handlers, background jobs, serializers, clients, file operations, network operations, deep links, inter-app entry points, embedded-web bridges, and local secret or preference storage.
 4. Trace suspicious values from source to sink or missing guard.
 5. Read imported guards, validators, auth wrappers, schemas, middleware, shared utilities, and sibling handlers when they decide exploitability.
 6. Check whether mitigations block the real path, not just a nearby path.
@@ -56,8 +57,8 @@ Load only matching references:
 
 | Level | Use For |
 |-------|---------|
-| high | Broad auth bypass, privilege escalation, cross-tenant sensitive data access, RCE, SQL/NoSQL injection over sensitive data, SSRF to internal services or cloud metadata, unsafe deserialization, production credential exposure, privileged CI execution, or destructive unauthorized actions. |
-| medium | XSS with script execution, bounded path traversal, sensitive information disclosure, webhook side effects without verification, open redirects in auth/token flows, weak token validation, meaningful abuse of expensive or sensitive operations, or limited unauthorized data mutation. |
+| high | Broad auth bypass, privilege escalation, cross-tenant sensitive data access, RCE, SQL/NoSQL injection over sensitive data, SSRF to internal services or cloud metadata, unsafe deserialization, production credential exposure, privileged CI execution, destructive unauthorized actions, an inter-app or embedded-web entry point that applies a session or performs a privileged action, a TLS trust kill-switch on an auth or data API, or a refresh token or private key written to unencrypted storage, logs, or a shared clipboard. |
+| medium | XSS with script execution, bounded path traversal, sensitive information disclosure, webhook side effects without verification, open redirects in auth/token flows, weak token validation, meaningful abuse of expensive or sensitive operations, limited unauthorized data mutation, or a local biometric or passcode prompt as the only gate in front of an otherwise readable secret. |
 | low | Concrete defense-in-depth flaw with a plausible exploit path and limited impact. Do not use low for vague best-practice advice. |
 
 - Tie-breaker: choose the lower severity when impact depends on unproven preconditions.
@@ -72,6 +73,7 @@ Load only matching references:
 - Workflow style, actionlint issues, broad permissions, or mutable action refs without a traced path to execution, credential exposure, trusted artifacts, or privileged side effects.
 - Secret-looking placeholders such as `example`, `test`, `dummy`, documented fake keys, or values confined to tests.
 - Framework defaults that already escape, parameterize, validate, or authorize unless the code uses an unsafe escape hatch.
+- Missing certificate pinning, jailbreak or debugger detection, obfuscation, screenshot hiding, keyboard-cache flags, or other mobile hygiene without a proven exploit path.
 
 ## Finding Format
 

--- a/packages/warden/src/builtin-skills/security-review/SPEC.md
+++ b/packages/warden/src/builtin-skills/security-review/SPEC.md
@@ -13,13 +13,13 @@ In scope:
 - Authentication, authorization, tenant isolation, identity, and service-boundary bugs.
 - Injection, RCE, unsafe deserialization, XSS, SSRF, path traversal, unsafe redirects, webhook verification, secrets exposure, weak crypto, sensitive data exposure, and meaningful abuse-control gaps.
 - General guidance that applies across web services and application code.
-- Focused notes for JavaScript/TypeScript, Python, and GitHub Actions workflows.
+- Focused notes for JavaScript/TypeScript, Python, Swift/Objective-C and GitHub Actions workflows.
 
 Out of scope:
 
 - Full dependency CVE triage without reachable changed code.
 - Compliance checklists, infrastructure-only policy review, or exhaustive cloud IAM audits.
-- Style, maintainability, performance, or non-security correctness bugs.
+- Style, maintainability, performance, hygiene, or non-security correctness bugs.
 - Benchmark-specific prompt compatibility.
 - Large language-specific catalogs in `SKILL.md`.
 
@@ -55,6 +55,9 @@ Out of scope:
 - `references/javascript-typescript.md` contains JS/TS/Node/React/Next-specific examples and false-positive controls.
 - `references/python.md` contains Python/Django/Flask/FastAPI-specific examples and false-positive controls.
 - `references/github-workflows.md` contains GitHub Actions workflow examples and false-positive controls.
+- `references/apple.md` contains Apple native entry points, high-signal patterns, false-positive controls, and examples, plus mappings to topic files under `references/apple/`.
+- `references/apple/ipc.md`, `storage.md`, `auth.md`, `network.md`, `webview.md`, and `crypto.md` are lookup leaves loaded only through that mapping.
+- `references/apple/CONTEXT.md` and `references/apple/SOURCES.md` are authoring files, not runtime references.
 - `scripts/`, `assets/`, and `references/evidence/` are unused until repeated evidence warrants them.
 
 ## Evaluation
@@ -65,13 +68,19 @@ Out of scope:
   - Run init command tests that install bundled skills.
 - Deeper evaluation:
   - Add eval cases for SQL injection, XSS, SSRF, authz bypass, secrets, and safe counterexamples.
+  - Add Apple eval cases later for scheme-applied tokens, `UserDefaults` refresh tokens, `LAContext` gates, WebView bridges, and accept-any-cert handlers, plus safe counterexamples.
   - Compare false positives against sanitized real Warden runs.
 - Acceptance gates:
   - `SKILL.md` stays concise enough to scan.
   - Language-specific examples stay in references.
   - Findings require exploitability evidence, not keyword matches.
+  - Apple reviews load `references/apple.md`, then only the mapped topic files.
 
 ## Maintenance Notes
 
 - Add a new language reference only when recurring findings need language-specific calibration.
+- Keep Apple platforms as one system. Carve out a finding only when the API cannot run on that OS.
+- Do not add pinning, resilience, or cross-platform framework catalogs to the Apple folder.
+- Update `references/apple.md` when a new Apple topic is added. Do not add Apple topic rows to `SKILL.md`.
+- Update `references/apple/CONTEXT.md` and `references/apple/SOURCES.md` when the Apple contract or source map changes. Do not route those files from `SKILL.md`.
 - Keep examples minimal and transformed; do not store proprietary code.

--- a/packages/warden/src/builtin-skills/security-review/references/apple.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple.md
@@ -1,6 +1,6 @@
 # Apple Native Security Notes
 
-Use this when reviewing Swift or Objective-C on iOS, iPadOS, visionOS, watchOS, or tvOS. This reference adapts the dedicated workflow-security prior art for the broad `security-review` skill; keep findings exploit-oriented, not style-oriented.
+Use this when reviewing Swift or Objective-C on Apple platforms, including iOS, iPadOS, macOS, visionOS, watchOS, and tvOS. These examples refine the core skill; they do not add new reporting scope.
 
 Load a topic file only when the change needs more depth than this page.
 

--- a/packages/warden/src/builtin-skills/security-review/references/apple.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple.md
@@ -1,0 +1,76 @@
+# Apple Native Security Notes
+
+Use this when reviewing Swift or Objective-C on iOS, iPadOS, visionOS, watchOS, or tvOS. This reference adapts the dedicated workflow-security prior art for the broad `security-review` skill; keep findings exploit-oriented, not style-oriented.
+
+Load a topic file only when the change needs more depth than this page.
+
+## Platform Entry Points
+
+- Custom URL scheme handlers, Universal Links, App Intents, Siri/Shortcuts, share sheet, and app extensions are potentially caller-controlled entry points. Another app or webpage can invoke them.
+- `WKWebView` script handlers and `evaluateJavaScript` run in the loaded page's trust. Treat page JS as untrusted unless the URL and navigation are proven first-party.
+- `UserDefaults`, sandbox files, logs, and the general pasteboard are not secret stores. Backups can read defaults and most files.
+- `LAContext.evaluatePolicy` proves user presence. It does not bind that proof to a secret. Keychain access control does.
+- ATS already encrypts `URLSession`. Report trust kill-switches and cleartext secrets, not missing pinning.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Deep-link session | `onOpenURL` / `application(_:open:)` applies `token` or `code` from the URL | One-time server-validated code. Do not persist the raw URL. |
+| Privileged deep link | Scheme or Universal Link transfers funds, changes email, or deletes data from query items | Allowlisted actions. Re-auth on the server for irreversible work. |
+| Unencrypted secret | Refresh token or private key in `UserDefaults`, a file, logs, or `UIPasteboard.general`, including after propagating through other variables or encoding | Keychain with a tight accessibility class. Do not log or paste secrets. |
+| Boolean local auth | `evaluatePolicy` then read an ACL-less Keychain item or defaults token | Store the secret with `SecAccessControl` and read it with `SecItemCopyMatching`. |
+| Accept-any-cert | `URLSession` / `WKNavigationDelegate` challenge handler calls `.useCredential` without `SecTrustEvaluateWithError` | Omit the callback, or evaluate `serverTrust` and cancel on failure. |
+| WebView bridge | `WKScriptMessageHandler` returns a token or starts a payment; reply via `evaluateJavaScript("cb('\(secret)')")` | Origin-check `frameInfo.securityOrigin`. Reply with `WKScriptMessageHandlerWithReply`. |
+| Unsafe unarchive | `NSKeyedUnarchiver.unarchiveObject(with:)` on scheme, pasteboard, or extension data | `JSONDecoder` or `unarchivedObject(ofClass:from:)`. |
+
+## False-Positive Controls
+
+- Missing certificate pinning, jailbreak detection, obfuscation, screenshot hiding, and keyboard-cache flags are not findings.
+- `UserDefaults`, logs, and pasteboard matter only when the value is a session token, refresh token, password, private key, or some secret.
+- `LAContext.evaluatePolicy` used only to show UI is fine when the secret fetch goes through Keychain access control.
+- `WKWebView` loading a hard-coded first-party URL with no bridge and no attacker-controlled navigation is not a finding.
+- `crypto` / `SecureEnclave` / `SecRandomCopyBytes` are suitable for security randomness; `Int.random` and `arc4random` are not when they mint a token.
+- React Native, Flutter, KMP, and Capacitor are out of scope for this reference.
+
+## Deeper Notes
+
+| Open when the change is about... | Read |
+|----------------------------------|------|
+| Schemes, Universal Links, App Intents, pasteboard, App Groups, extensions | `references/apple/ipc.md` |
+| `UserDefaults`, files, logs, backups, Keychain accessibility | `references/apple/storage.md` |
+| `LAContext` or biometric UI used as a gate | `references/apple/auth.md` |
+| Trust challenges or cleartext secret traffic | `references/apple/network.md` |
+| `WKWebView` bridges, `evaluateJavaScript`, `UIWebView` | `references/apple/webview.md` |
+| CryptoKit, CommonCrypto, hardcoded keys | `references/apple/crypto.md` |
+
+## Minimal Examples
+
+**Report: refresh token in unencrypted storage**
+
+```swift
+UserDefaults.standard.set(response.refreshToken, forKey: "refreshToken")
+```
+
+Encoding first (`base64`, JSON) does not make this safe.
+
+**Report: biometric UI, unprotected secret**
+
+```swift
+let ok = try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Unlock")
+if ok {
+    API.setSession(UserDefaults.standard.string(forKey: "refreshToken")!)
+}
+```
+
+Require: Keychain item with `SecAccessControl`. The prompt must be the system Keychain prompt.
+
+**Do not report: Keychain-bound secret**
+
+```swift
+let access = SecAccessControlCreateWithFlags(
+    nil, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, .biometryCurrentSet, nil
+)!
+// SecItemAdd with kSecAttrAccessControl: access
+// Later SecItemCopyMatching triggers the system prompt. No LAContext.
+```

--- a/packages/warden/src/builtin-skills/security-review/references/apple.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple.md
@@ -6,23 +6,25 @@ Load a topic file only when the change needs more depth than this page.
 
 ## Platform Entry Points
 
+- main, @main, @UIApplicationMain, AppDelegate functions
+
 - Custom URL scheme handlers, Universal Links, App Intents, Siri/Shortcuts, share sheet, and app extensions are potentially caller-controlled entry points. Another app or webpage can invoke them.
-- `WKWebView` script handlers and `evaluateJavaScript` run in the loaded page's trust. Treat page JS as untrusted unless the URL and navigation are proven first-party.
-- `UserDefaults`, sandbox files, logs, and the general pasteboard are not secret stores. Backups can read defaults and most files.
-- `LAContext.evaluatePolicy` proves user presence. It does not bind that proof to a secret. Keychain access control does.
-- ATS already encrypts `URLSession`. Report trust kill-switches and cleartext secrets, not missing pinning.
 
 ## High-Signal Patterns
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Deep-link session | `onOpenURL` / `application(_:open:)` applies `token` or `code` from the URL | One-time server-validated code. Do not persist the raw URL. |
-| Privileged deep link | Scheme or Universal Link transfers funds, changes email, or deletes data from query items | Allowlisted actions. Re-auth on the server for irreversible work. |
-| Unencrypted secret | Refresh token or private key in `UserDefaults`, a file, logs, or `UIPasteboard.general`, including after propagating through other variables or encoding | Keychain with a tight accessibility class. Do not log or paste secrets. |
-| Boolean local auth | `evaluatePolicy` then read an ACL-less Keychain item or defaults token | Store the secret with `SecAccessControl` and read it with `SecItemCopyMatching`. |
-| Accept-any-cert | `URLSession` / `WKNavigationDelegate` challenge handler calls `.useCredential` without `SecTrustEvaluateWithError` | Omit the callback, or evaluate `serverTrust` and cancel on failure. |
-| WebView bridge | `WKScriptMessageHandler` returns a token or starts a payment; reply via `evaluateJavaScript("cb('\(secret)')")` | Origin-check `frameInfo.securityOrigin`. Reply with `WKScriptMessageHandlerWithReply`. |
-| Unsafe unarchive | `NSKeyedUnarchiver.unarchiveObject(with:)` on scheme, pasteboard, or extension data | `JSONDecoder` or `unarchivedObject(ofClass:from:)`. |
+
+| Pattern              | Vulnerable                                                                                                                                               | Safer                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Deep-link session    | `onOpenURL` / `application(_:open:)` applies `token` or `code` from the URL                                                                              | One-time server-validated code. Do not persist the raw URL.                            |
+| Privileged deep link | Scheme or Universal Link transfers funds, changes email, or deletes data from query items                                                                | Allowlisted actions. Re-auth on the server for irreversible work.                      |
+| Unencrypted secret   | Refresh token or private key in `UserDefaults`, a file, logs, or `UIPasteboard.general`, including after propagating through other variables or encoding | Keychain with a tight accessibility class. Do not log or paste secrets.                |
+| Boolean local auth   | `evaluatePolicy` then read an ACL-less Keychain item or defaults token                                                                                   | Store the secret with `SecAccessControl` and read it with `SecItemCopyMatching`.       |
+| Accept-any-cert      | `URLSession` / `WKNavigationDelegate` challenge handler calls `.useCredential` without `SecTrustEvaluateWithError`                                       | Omit the callback, or evaluate `serverTrust` and cancel on failure.                    |
+| WebView bridge       | `WKScriptMessageHandler` returns a token or starts a payment; reply via `evaluateJavaScript("cb('\(secret)')")`                                          | Origin-check `frameInfo.securityOrigin`. Reply with `WKScriptMessageHandlerWithReply`. |
+| Unsafe unarchive     | `NSKeyedUnarchiver.unarchiveObject(with:)` on scheme, pasteboard, or extension data                                                                      | `JSONDecoder` or `unarchivedObject(ofClass:from:)`.                                    |
+
+
+
 
 ## False-Positive Controls
 
@@ -35,14 +37,18 @@ Load a topic file only when the change needs more depth than this page.
 
 ## Deeper Notes
 
-| Open when the change is about... | Read |
-|----------------------------------|------|
-| Schemes, Universal Links, App Intents, pasteboard, App Groups, extensions | `references/apple/ipc.md` |
-| `UserDefaults`, files, logs, backups, Keychain accessibility | `references/apple/storage.md` |
-| `LAContext` or biometric UI used as a gate | `references/apple/auth.md` |
-| Trust challenges or cleartext secret traffic | `references/apple/network.md` |
-| `WKWebView` bridges, `evaluateJavaScript`, `UIWebView` | `references/apple/webview.md` |
-| CryptoKit, CommonCrypto, hardcoded keys | `references/apple/crypto.md` |
+
+| Open when the change is about...                                          | Read                          |
+| ------------------------------------------------------------------------- | ----------------------------- |
+| Schemes, Universal Links, App Intents, pasteboard, App Groups, extensions | `references/apple/ipc.md`     |
+| `UserDefaults`, files, logs, backups, Keychain accessibility              | `references/apple/storage.md` |
+| `LAContext` or biometric UI used as a gate                                | `references/apple/auth.md`    |
+| Trust challenges or cleartext secret traffic                              | `references/apple/network.md` |
+| `WKWebView` bridges, `evaluateJavaScript`, `UIWebView`                    | `references/apple/webview.md` |
+| CryptoKit, CommonCrypto, hardcoded keys                                   | `references/apple/crypto.md`  |
+
+
+
 
 ## Minimal Examples
 
@@ -74,3 +80,4 @@ let access = SecAccessControlCreateWithFlags(
 // SecItemAdd with kSecAttrAccessControl: access
 // Later SecItemCopyMatching triggers the system prompt. No LAContext.
 ```
+

--- a/packages/warden/src/builtin-skills/security-review/references/apple/auth.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/auth.md
@@ -8,17 +8,19 @@ A hook that flips the `evaluatePolicy` reply to `true` therefore unlocks any pat
 
 ## High-Signal Patterns
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Boolean gate | `evaluatePolicy` then reveal a secret, set a session, or call a privileged API | Store the secret with `SecAccessControl`. Read it with `SecItemCopyMatching`. No separate `evaluatePolicy`. |
-| ACL-less Keychain | `evaluatePolicy` then `SecItemCopyMatching` without `kSecAttrAccessControl` | Add the item with `SecAccessControlCreateWithFlags` and `.biometryCurrentSet` or `.userPresence`. |
-| UI lock only | Lock screen dismissed on LA success; token stays in `UserDefaults` or memory | Drop in-memory secrets on lock. Next use is a Keychain read that triggers the system prompt. |
+
+| Pattern           | Vulnerable                                                                               | Safer                                                                                                                 |
+| ----------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Boolean gate      | `LAContext.evaluatePolicy` then reveal a secret, set a session, or call a privileged API | Store the secret with `SecAccessControl`. Read it with `SecItemCopyMatching`. No separate `LAContext.evaluatePolicy`. |
+| ACL-less Keychain | `LAContext.evaluatePolicy` then `SecItemCopyMatching` without `kSecAttrAccessControl`    | Add the item with `SecAccessControlCreateWithFlags` and `.biometryCurrentSet` or `.userPresence`.                     |
+| UI lock only      | Lock screen dismissed on LA success; token stays in `UserDefaults` or memory             | Drop in-memory secrets on lock. Next use is a Keychain read that triggers the system prompt.                          |
+
 
 Optional: pass an `LAContext` as `kSecUseAuthenticationContext` to customize the Keychain prompt. That is still Keychain-gated, not a boolean gate.
 
 ## Report When
 
-- `evaluatePolicy` is the only check before a privileged action or before reading a token that is already in memory, `UserDefaults`, or an ACL-less Keychain item.
+- `LAContext.evaluatePolicy` is the only check before a privileged action or before reading a token that is already in memory, `UserDefaults`, or an ACL-less Keychain item.
 
 ## Do Not Report
 
@@ -29,7 +31,7 @@ Optional: pass an `LAContext` as `kSecUseAuthenticationContext` to customize the
 
 ## Trace
 
-1. Find `evaluatePolicy`.
+1. Find `LAContext.evaluatePolicy`.
 2. On success, name the secret or privileged call.
 3. If the secret is in Keychain, check the add/update query for `kSecAttrAccessControl`.
 4. Report only if that ACL is missing and the secret or action is already available to the process.
@@ -69,6 +71,3 @@ let access = SecAccessControlCreateWithFlags(
 // SecItemCopyMatching presents the system prompt and returns the item only on success.
 ```
 
-## ObjC Leads
-
-`-[LAContext evaluatePolicy:localizedReason:reply:]`, `SecAccessControlCreateWithFlags`, `kSecAttrAccessControl`, `kSecUseAuthenticationContext`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/auth.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/auth.md
@@ -1,0 +1,74 @@
+# Apple Local Authentication
+
+Open when reviewing `LocalAuthentication`, `LAContext`, or biometric UI used as a gate.
+
+`LAContext.evaluatePolicy` asks the system whether Face ID / Touch ID / passcode succeeded and returns a bool to a developer-controlled reply block. That is not authorization. The Secure Enclave only gates a secret when the item is stored with `SecAccessControl` and read via `SecItemCopyMatching`.
+
+A hook that flips the `evaluatePolicy` reply to `true` therefore unlocks any path that only checks that bool. It does not unlock Keychain items protected with `biometryCurrentSet`, `biometryAny`, or `userPresence`.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Boolean gate | `evaluatePolicy` then reveal a secret, set a session, or call a privileged API | Store the secret with `SecAccessControl`. Read it with `SecItemCopyMatching`. No separate `evaluatePolicy`. |
+| ACL-less Keychain | `evaluatePolicy` then `SecItemCopyMatching` without `kSecAttrAccessControl` | Add the item with `SecAccessControlCreateWithFlags` and `.biometryCurrentSet` or `.userPresence`. |
+| UI lock only | Lock screen dismissed on LA success; token stays in `UserDefaults` or memory | Drop in-memory secrets on lock. Next use is a Keychain read that triggers the system prompt. |
+
+Optional: pass an `LAContext` as `kSecUseAuthenticationContext` to customize the Keychain prompt. That is still Keychain-gated, not a boolean gate.
+
+## Report When
+
+- `evaluatePolicy` is the only check before a privileged action or before reading a token that is already in memory, `UserDefaults`, or an ACL-less Keychain item.
+
+## Do Not Report
+
+- `evaluatePolicy` used only to show UI, with the secret fetch going through `SecItemCopyMatching` + access control.
+- Passcode fallback (`.deviceOwnerAuthentication` / `.userPresence`) when the Keychain item is access-controlled.
+- Missing Face ID usage strings.
+- `touchIDAuthenticationAllowableReuseDuration` on a context used with Keychain.
+
+## Trace
+
+1. Find `evaluatePolicy`.
+2. On success, name the secret or privileged call.
+3. If the secret is in Keychain, check the add/update query for `kSecAttrAccessControl`.
+4. Report only if that ACL is missing and the secret or action is already available to the process.
+
+## Minimal Examples
+
+**Report: boolean unlocks a stored token**
+
+```swift
+let ok = try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Unlock")
+if ok {
+    API.setSession(UserDefaults.standard.string(forKey: "refreshToken")!)
+}
+```
+
+**Report: Keychain read after a separate LAContext check**
+
+```swift
+if try await context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Unlock") {
+    SecItemCopyMatching([
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrAccount: "refresh",
+        kSecReturnData: true,
+    ] as CFDictionary, &item)
+}
+```
+
+No `kSecAttrAccessControl`. The prompt is optional.
+
+**Do not report: Keychain-bound secret**
+
+```swift
+let access = SecAccessControlCreateWithFlags(
+    nil, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, .biometryCurrentSet, nil
+)!
+// SecItemAdd with kSecAttrAccessControl: access
+// SecItemCopyMatching presents the system prompt and returns the item only on success.
+```
+
+## ObjC Leads
+
+`-[LAContext evaluatePolicy:localizedReason:reply:]`, `SecAccessControlCreateWithFlags`, `kSecAttrAccessControl`, `kSecUseAuthenticationContext`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/crypto.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/crypto.md
@@ -6,17 +6,19 @@ Open when reviewing CryptoKit, CommonCrypto, `SecKey`, hardcoded keys, or random
 
 ## Attackers
 
-Remote and same-device attackers who can read the app binary, a backup, or a ciphertext they were given. They cannot be assumed to have a debugger.
+Remote and same-device attackers who can read the app binary, a backup, or a ciphertext they were given.
 
 ## High-Signal Patterns
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Hardcoded private key / AES key / HMAC secret | `SymmetricKey(data: Data(base64Encoded: "…")!)`, PEM in source, `SecKeyCreateWithData` on a bundled private key used for auth | Keychain / Secure Enclave generated keys. No long-lived private material in the repo. |
-| Hardcoded bearer token | `let apiKey = "sk_live_…"` sent as auth | Server-side secret. Public client IDs are fine. |
-| Broken cipher for a secret | `kCCAlgorithmDES`, `kCCAlgorithmAES` + `kCCOptionECBMode`, RC4, XOR "encryption" of a token | CryptoKit `AES.GCM` or `ChaChaPoly` with a Keychain key |
-| Broken hash for a password / token | `Insecure.MD5` / `Insecure.SHA1` / `CC_MD5` of a password | System Keychain, or a real KDF (`CryptoKit` / `SecKey`) on the server |
-| Predictable secret | `Int.random`, `drand48`, `arc4random` used as a session token or reset code | `SecureEnclave` / `SymmetricKey` / `SecRandomCopyBytes` |
+
+| Pattern                                       | Vulnerable                                                                                                                                              | Safer                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Hardcoded private key / AES key / HMAC secret | `SymmetricKey(data: Data(base64Encoded: "…")!)`, PEM in source or bundled on file system, `SecKeyCreateWithData` on a bundled private key used for auth | Keychain / Secure Enclave generated keys. No long-lived private material in the repo. |
+| Hardcoded bearer token                        | `let apiKey = "sk_live_…"` sent as auth                                                                                                                 | Server-side secret. Public client IDs are fine.                                       |
+| Broken cipher for a secret                    | `kCCAlgorithmDES`, `kCCAlgorithmAES` + `kCCOptionECBMode`, RC4, XOR "encryption" of a token                                                             | CryptoKit `AES.GCM` or `ChaChaPoly` with a Keychain key                               |
+| Broken hash for a password / token            | `Insecure.MD5` / `Insecure.SHA1` / `CC_MD5` of a password                                                                                               | System Keychain, or a real KDF (`CryptoKit` / `SecKey`) on the server                 |
+| Predictable secret                            | `Int.random`, `drand48`, `arc4random` used as a session token or reset code                                                                             | `SecureEnclave` / `SymmetricKey` / `SecRandomCopyBytes`                               |
+
 
 ## Report When
 
@@ -30,7 +32,7 @@ Remote and same-device attackers who can read the app binary, a backup, or a cip
 - `arc4random` for UI, jitter, or analytics.
 - CommonCrypto AES-GCM/CBC with a Keychain key and a random IV, even if CryptoKit would be nicer.
 - Missing Secure Enclave.
-- Public client IDs, example keys, test fixtures, `sk_test_` confined to tests.
+- Public client IDs, example keys, test fixtures, keys confined to tests.
 - Certificate pinning helpers.
 
 ## Trace
@@ -72,6 +74,3 @@ let key = SymmetricKey(size: .bits256)
 let digest = Insecure.MD5.hash(data: fileData)
 ```
 
-## ObjC Leads
-
-`CCCrypt`, `CC_MD5`, `SecKeyCreateWithData`, literal `NSString` keys, `arc4random` / `rand` used as tokens.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/crypto.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/crypto.md
@@ -1,0 +1,77 @@
+# Apple Crypto And Hardcoded Secrets
+
+Open when reviewing CryptoKit, CommonCrypto, `SecKey`, hardcoded keys, or randomness used to protect secrets.
+
+"Use CryptoKit" is not a finding. Report broken algorithms, hardcoded key material, or non-crypto RNG only when they protect a secret or auth decision.
+
+## Attackers
+
+Remote and same-device attackers who can read the app binary, a backup, or a ciphertext they were given. They cannot be assumed to have a debugger.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Hardcoded private key / AES key / HMAC secret | `SymmetricKey(data: Data(base64Encoded: "…")!)`, PEM in source, `SecKeyCreateWithData` on a bundled private key used for auth | Keychain / Secure Enclave generated keys. No long-lived private material in the repo. |
+| Hardcoded bearer token | `let apiKey = "sk_live_…"` sent as auth | Server-side secret. Public client IDs are fine. |
+| Broken cipher for a secret | `kCCAlgorithmDES`, `kCCAlgorithmAES` + `kCCOptionECBMode`, RC4, XOR "encryption" of a token | CryptoKit `AES.GCM` or `ChaChaPoly` with a Keychain key |
+| Broken hash for a password / token | `Insecure.MD5` / `Insecure.SHA1` / `CC_MD5` of a password | System Keychain, or a real KDF (`CryptoKit` / `SecKey`) on the server |
+| Predictable secret | `Int.random`, `drand48`, `arc4random` used as a session token or reset code | `SecureEnclave` / `SymmetricKey` / `SecRandomCopyBytes` |
+
+## Report When
+
+- Real private key, AES/HMAC key, or live API secret is in source and used for security.
+- A token or password is "encrypted" with ECB, DES, RC4, XOR, or a hardcoded key, then stored or sent.
+- A session identifier or reset code is generated with a non-crypto RNG and accepted as auth.
+
+## Do Not Report
+
+- `Insecure.MD5` / SHA1 for a non-security checksum or etag.
+- `arc4random` for UI, jitter, or analytics.
+- CommonCrypto AES-GCM/CBC with a Keychain key and a random IV, even if CryptoKit would be nicer.
+- Missing Secure Enclave.
+- Public client IDs, example keys, test fixtures, `sk_test_` confined to tests.
+- Certificate pinning helpers.
+
+## Trace
+
+1. Is the output used as auth, a wrapping key, or stored next to a secret? If not, stop.
+2. Where does the key material come from? Literal, bundled file, Keychain, server.
+3. Name the algorithm and mode. ECB and DES on a secret are enough. CBC needs a fixed IV or hardcoded key to be worth reporting.
+4. For RNG, show the value is later compared as a capability (token, code), not a display nonce.
+
+## Minimal Examples
+
+**Report: hardcoded AES key wrapping a token**
+
+```swift
+let key = SymmetricKey(data: Data(base64Encoded: "YWFhYWFhYWFhYWFhYWFhYQ==")!)
+let box = try AES.GCM.seal(Data(refreshToken.utf8), using: key)
+UserDefaults.standard.set(box.combined, forKey: "tok")
+```
+
+The key is in the binary. This is still an unencrypted secret for anyone who reads the app. Pair with `storage.md`.
+
+**Report: ECB of a session blob**
+
+```swift
+CCCrypt(CCOperation(kCCEncrypt), CCAlgorithm(kCCAlgorithmAES), CCOptions(kCCOptionECBMode),
+        keyBytes, kCCKeySizeAES128, nil, input, inputLen, out, outLen, &moved)
+```
+
+**Do not report: CryptoKit with a generated key**
+
+```swift
+let key = SymmetricKey(size: .bits256)
+// persist via Keychain, then AES.GCM.seal
+```
+
+**Do not report: MD5 of a file for cache busting**
+
+```swift
+let digest = Insecure.MD5.hash(data: fileData)
+```
+
+## ObjC Leads
+
+`CCCrypt`, `CC_MD5`, `SecKeyCreateWithData`, literal `NSString` keys, `arc4random` / `rand` used as tokens.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/ipc.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/ipc.md
@@ -6,27 +6,25 @@ Any other app or webpage can invoke a registered custom scheme. Universal Links 
 
 ## Attackers
 
-| Source | Trust |
-|--------|--------|
-| `myapp://…` from Safari, Notes, another app, QR, push | Untrusted. Scheme is not an identity. |
-| `https://app.example.com/…` Universal Link | Host is associated, path/query are attacker-controlled. |
-| App Intent / Siri / Shortcuts / Spotlight | Untrusted caller. Same checks as the in-app action. |
-| `UIPasteboard.general` | Other apps can plant or, on older iOS, read. |
-| App Group container / `UserDefaults(suiteName:)` | Every app and extension in the group. |
-| App extension (`NSExtension`) | Host app may be hostile. Validate every payload. |
+| Source                                                | Trust                                                     |
+| ----------------------------------------------------- | --------------------------------------------------------- |
+| `myapp://…` from Safari, Notes, another app, QR, push | Untrusted. Path/query/parameters are attacker-controlled. |
+| `https://app.example.com/…` Universal Link            | Host is associated, path/query are attacker-controlled.   |
+| App Intent / Siri / Shortcuts / Spotlight             | Untrusted caller. Same checks as the in-app action.       |
+| `UIPasteboard.general`                                | Other apps can plant or, on older iOS, read.              |
+| App extension (`NSExtension`)                         | Host app may be hostile. Validate every payload.          |
 
 ## High-Signal Patterns
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Privileged scheme action | `onOpenURL` / `application(_:open:options:)` transfers money, changes email, applies a token, or deletes data from query items | Allowlisted actions. Server re-auth for irreversible work. Ignore unknown hosts/paths. |
-| Token in a scheme | `myapp://auth?token=` or `myapp://reset?code=` consumed as a session | One-time server-validated code. Prefer Universal Links for auth redirects. Never persist the raw URL. |
-| Unvalidated file/url param | Scheme/link path opens `WKWebView`, `Data(contentsOf:)`, or a filesystem path | Exact allowlist of hosts or resource IDs. No `..`. No `file:` unless you built it. |
-| Missing source check on an internal scheme | Internal-only action accepted from any caller | Same-team `sourceApplication` allowlist, or do not use a custom scheme for internal IPC |
-| App Intent side effect | `@AppIntent` performs the same privileged mutation as an in-app button with no auth re-check | Re-run the same authorization as the UI path. Do not put secrets in intent parameters or results. |
-| General pasteboard secret | `UIPasteboard.general.string = refreshToken` | Do not write secrets. If the user copies, that is their action, not a finding. |
-| App Group secret | Token in `UserDefaults(suiteName:)` or a file under `containerURL(forSecurityApplicationGroupIdentifier:)` | Keychain with an explicit access group, or do not share the secret. |
-| Unsafe unarchive of IPC | `NSKeyedUnarchiver.unarchiveObject(with: urlPayload)` / `decodeObject(forKey:)` on scheme, pasteboard, or extension data | `JSONDecoder` or `unarchivedObject(ofClass:from:)`. Never decode arbitrary classes. |
+| Pattern                                    | Vulnerable                                                                                                                     | Safer                                                                                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Privileged scheme action                   | `onOpenURL` / `application(_:open:options:)` transfers money, changes email, applies a token, or deletes data from query items | Allowlisted actions. Server re-auth for irreversible work. Ignore unknown hosts/paths.                |
+| Token in a scheme                          | `myapp://auth?token=` or `myapp://reset?code=` consumed as a session                                                           | One-time server-validated code. Prefer Universal Links for auth redirects. Never persist the raw URL. |
+| Unvalidated file/url param                 | Scheme/link path opens `WKWebView`, `Data(contentsOf:)`, or a filesystem path                                                  | Exact allowlist of hosts or resource IDs. No `..`. No `file:` unless you built it.                    |
+| Missing source check on an internal scheme | Internal-only action accepted from any caller                                                                                  | Same-team `sourceApplication` allowlist, or do not use a custom scheme for internal IPC               |
+| App Intent side effect                     | `@AppIntent` performs the same privileged mutation as an in-app button with no auth re-check                                   | Re-run the same authorization as the UI path. Do not put secrets in intent parameters or results.     |
+| General pasteboard secret                  | `UIPasteboard.general.string = refreshToken`                                                                                   | Do not write secrets. If the user copies, that is their action, not a finding.                        |
+| Unsafe unarchive of IPC                    | `NSKeyedUnarchiver.unarchiveObject(with: urlPayload)` / `decodeObject(forKey:)` on scheme, pasteboard, or extension data       | `JSONDecoder` or `unarchivedObject(ofClass:from:)`. Never decode arbitrary classes.                   |
 
 ## Report When
 
@@ -34,7 +32,6 @@ Any other app or webpage can invoke a registered custom scheme. Universal Links 
 - Auth tokens or codes arrive in a scheme/link and are stored or used as a session without single-use server validation.
 - An App Intent / extension entry point mutates sensitive state or returns a secret, and the in-app path would have required a stronger check.
 - A secret is written to `UIPasteboard.general` by app code.
-- A secret is written to an App Group container that another target in the repo can read.
 - Attacker-controlled bytes are deserialized with an open `NSKeyedUnarchiver`.
 
 ## Do Not Report
@@ -43,7 +40,6 @@ Any other app or webpage can invoke a registered custom scheme. Universal Links 
 - Universal Links that open a product page after parsing an ID, with the server enforcing authz.
 - Missing `sourceApplication` on a documented public deep link that cannot do harm.
 - User-initiated copy of a password field.
-- App Groups used for non-secrets (widgets, shared theme).
 - `NSKeyedUnarchiver` of bundled or otherwise trusted constants.
 
 ## Trace
@@ -96,6 +92,3 @@ Any app or page can set the user's session.
 UIPasteboard.general.string = session.refreshToken
 ```
 
-## ObjC Leads
-
-`application:openURL:options:`, `application:continueUserActivity:restorationHandler:`, `UIPasteboard.generalPasteboard`, `NSUserDefaults` with a suite name, `NSKeyedUnarchiver`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/ipc.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/ipc.md
@@ -1,0 +1,101 @@
+# Apple IPC And Entry Points
+
+Open when reviewing custom URL schemes, Universal Links, App Intents, pasteboard, App Groups, extensions, or share/Handoff entry points.
+
+Any other app or webpage can invoke a registered custom scheme. Universal Links are origin-bound to an associated domain, but the URL parameters are still attacker-controlled. Treat both as untrusted input.
+
+## Attackers
+
+| Source | Trust |
+|--------|--------|
+| `myapp://…` from Safari, Notes, another app, QR, push | Untrusted. Scheme is not an identity. |
+| `https://app.example.com/…` Universal Link | Host is associated, path/query are attacker-controlled. |
+| App Intent / Siri / Shortcuts / Spotlight | Untrusted caller. Same checks as the in-app action. |
+| `UIPasteboard.general` | Other apps can plant or, on older iOS, read. |
+| App Group container / `UserDefaults(suiteName:)` | Every app and extension in the group. |
+| App extension (`NSExtension`) | Host app may be hostile. Validate every payload. |
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Privileged scheme action | `onOpenURL` / `application(_:open:options:)` transfers money, changes email, applies a token, or deletes data from query items | Allowlisted actions. Server re-auth for irreversible work. Ignore unknown hosts/paths. |
+| Token in a scheme | `myapp://auth?token=` or `myapp://reset?code=` consumed as a session | One-time server-validated code. Prefer Universal Links for auth redirects. Never persist the raw URL. |
+| Unvalidated file/url param | Scheme/link path opens `WKWebView`, `Data(contentsOf:)`, or a filesystem path | Exact allowlist of hosts or resource IDs. No `..`. No `file:` unless you built it. |
+| Missing source check on an internal scheme | Internal-only action accepted from any caller | Same-team `sourceApplication` allowlist, or do not use a custom scheme for internal IPC |
+| App Intent side effect | `@AppIntent` performs the same privileged mutation as an in-app button with no auth re-check | Re-run the same authorization as the UI path. Do not put secrets in intent parameters or results. |
+| General pasteboard secret | `UIPasteboard.general.string = refreshToken` | Do not write secrets. If the user copies, that is their action, not a finding. |
+| App Group secret | Token in `UserDefaults(suiteName:)` or a file under `containerURL(forSecurityApplicationGroupIdentifier:)` | Keychain with an explicit access group, or do not share the secret. |
+| Unsafe unarchive of IPC | `NSKeyedUnarchiver.unarchiveObject(with: urlPayload)` / `decodeObject(forKey:)` on scheme, pasteboard, or extension data | `JSONDecoder` or `unarchivedObject(ofClass:from:)`. Never decode arbitrary classes. |
+
+## Report When
+
+- A custom scheme or Universal Link handler performs a privileged or irreversible action, or consumes auth material, without validating path/query against an allowlist.
+- Auth tokens or codes arrive in a scheme/link and are stored or used as a session without single-use server validation.
+- An App Intent / extension entry point mutates sensitive state or returns a secret, and the in-app path would have required a stronger check.
+- A secret is written to `UIPasteboard.general` by app code.
+- A secret is written to an App Group container that another target in the repo can read.
+- Attacker-controlled bytes are deserialized with an open `NSKeyedUnarchiver`.
+
+## Do Not Report
+
+- A scheme that only navigates to a public screen (`myapp://settings`) with no sensitive side effect.
+- Universal Links that open a product page after parsing an ID, with the server enforcing authz.
+- Missing `sourceApplication` on a documented public deep link that cannot do harm.
+- User-initiated copy of a password field.
+- App Groups used for non-secrets (widgets, shared theme).
+- `NSKeyedUnarchiver` of bundled or otherwise trusted constants.
+
+## Trace
+
+1. Find the handler: `application(_:open:options:)`, `scene(_:openURLContexts:)`, `.onOpenURL`, `continue userActivity`, `AppIntent.perform()`.
+2. List every query/path value that reaches a sink.
+3. Name the sink: WebView load, token store, payment call, file I/O, unarchive, privileged API.
+4. Confirm there is no allowlist, server check, or same-team source check on that path.
+5. State who can invoke it (any app, any webpage, Shortcuts).
+
+## Minimal Examples
+
+**Report: scheme applies a session token**
+
+```swift
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?.first(where: { $0.name == "token" })?.value
+    Keychain.save(token: token!)
+    return true
+}
+```
+
+Any app or page can set the user's session.
+
+**Report: scheme drives a privileged action**
+
+```swift
+.onOpenURL { url in
+    if url.host == "transfer" {
+        let amount = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "amount" })?.value
+        Payments.send(amount: Decimal(string: amount!)!)
+    }
+}
+```
+
+**Do not report: navigation only**
+
+```swift
+.onOpenURL { url in
+    guard url.host == "product", let id = url.pathItems.first, id.allSatisfy(\.isNumber) else { return }
+    router.openProduct(id: id)
+}
+```
+
+**Report: secret on the general pasteboard**
+
+```swift
+UIPasteboard.general.string = session.refreshToken
+```
+
+## ObjC Leads
+
+`application:openURL:options:`, `application:continueUserActivity:restorationHandler:`, `UIPasteboard.generalPasteboard`, `NSUserDefaults` with a suite name, `NSKeyedUnarchiver`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/network.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/network.md
@@ -1,0 +1,83 @@
+# Apple Network Trust
+
+Open when reviewing `URLSession` trust challenges, `WKNavigationDelegate` auth challenges, cleartext HTTP of secrets, or code that disables ATS / server trust.
+
+ATS already encrypts `URLSession` traffic. Missing pinning is not a finding. Report only when the app turns off system trust or sends secrets in cleartext.
+
+## Attackers
+
+Remote MITM on the local network, hostile Wi-Fi, or a compromised captive portal. Same-device apps are not the primary network attacker.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Accept any cert | `urlSession(_:didReceive:)` / `webView(_:didReceive:)` calls `completionHandler(.useCredential, …)` without `SecTrustEvaluateWithError` | Do not implement the callback. Or evaluate `serverTrust` and cancel on failure. |
+| Trust always true | `completionHandler(.useCredential, URLCredential(trust: challenge.protectionSpace.serverTrust!))` for every challenge | Same as above. |
+| ATS kill-switch used by secret traffic | Code builds `http://` URLs for login/API, or uses `Network.framework` / BSD sockets to skip ATS, and the body or headers carry tokens | `https://` via `URLSession`. No custom trust. |
+| TLS version forced down | `tlsMinimumSupportedProtocolVersion = .TLSv10` on a session that carries secrets | Leave the system default. |
+
+## Report When
+
+- A `URLSessionDelegate` or `WKNavigationDelegate` authentication-challenge handler accepts server trust without a successful `SecTrustEvaluateWithError`.
+- Login, token refresh, or other secret-bearing requests are sent over `http://`, or over a socket API that bypasses ATS.
+- Production code installs a custom trust that always succeeds (including `#if DEBUG` blocks that still compile into the reviewed production target).
+
+## Do Not Report
+
+- Missing certificate pinning, missing `NSPinnedDomains`, or "ATS pinning not configured".
+- Presence of `urlSession(_:didReceive:)` that correctly calls `SecTrustEvaluateWithError` and cancels on failure.
+- ATS exceptions for unrelated hosts with no secrets (analytics, images) unless trust evaluation is also disabled.
+- `NSAllowsArbitraryLoads` in a plist with no secret-bearing cleartext path in the changed Swift/ObjC.
+- Third-party SDK traffic you cannot trace to a secret.
+- Development-only trust overrides that cannot ship in the reviewed target.
+
+## Trace
+
+1. Find challenge handlers and `http://` URL builders.
+2. For challenges: does every path either cancel or call `SecTrustEvaluateWithError` and check the result?
+3. For cleartext: does this request include a token, password, or PII that enables account takeover?
+4. Confirm ATS cannot save the path (`NWConnection`, `CFStream`, raw sockets ignore ATS).
+
+## Minimal Examples
+
+**Report: accept any server certificate**
+
+```swift
+func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
+                completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    completionHandler(.useCredential, URLCredential(trust: challenge.protectionSpace.serverTrust!))
+}
+```
+
+**Report: login over HTTP**
+
+```swift
+var request = URLRequest(url: URL(string: "http://api.example.com/login")!)
+request.httpBody = try JSONEncoder().encode(creds)
+```
+
+**Do not report: default URLSession HTTPS**
+
+```swift
+let (data, _) = try await URLSession.shared.data(from: URL(string: "https://api.example.com/me")!)
+```
+
+**Do not report: evaluate then cancel**
+
+```swift
+func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
+                completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+          let trust = challenge.protectionSpace.serverTrust,
+          SecTrustEvaluateWithError(trust, nil) else {
+        completionHandler(.cancelAuthenticationChallenge, nil)
+        return
+    }
+    completionHandler(.useCredential, URLCredential(trust: trust))
+}
+```
+
+## ObjC Leads
+
+`URLSession:didReceiveChallenge:completionHandler:`, `webView:didReceiveAuthenticationChallenge:completionHandler:`, `SecTrustEvaluate`, `NSAllowsArbitraryLoads` only as a lead for a cleartext secret path.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/network.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/network.md
@@ -6,7 +6,7 @@ ATS already encrypts `URLSession` traffic. Missing pinning is not a finding. Rep
 
 ## Attackers
 
-Remote MITM on the local network, hostile Wi-Fi, or a compromised captive portal. Same-device apps are not the primary network attacker.
+Remote MITM on the local network, hostile Wi-Fi, or a compromised captive portal.
 
 ## High-Signal Patterns
 
@@ -21,7 +21,7 @@ Remote MITM on the local network, hostile Wi-Fi, or a compromised captive portal
 
 - A `URLSessionDelegate` or `WKNavigationDelegate` authentication-challenge handler accepts server trust without a successful `SecTrustEvaluateWithError`.
 - Login, token refresh, or other secret-bearing requests are sent over `http://`, or over a socket API that bypasses ATS.
-- Production code installs a custom trust that always succeeds (including `#if DEBUG` blocks that still compile into the reviewed production target).
+- Production code installs a custom trust that always succeeds
 
 ## Do Not Report
 
@@ -77,7 +77,3 @@ func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationCh
     completionHandler(.useCredential, URLCredential(trust: trust))
 }
 ```
-
-## ObjC Leads
-
-`URLSession:didReceiveChallenge:completionHandler:`, `webView:didReceiveAuthenticationChallenge:completionHandler:`, `SecTrustEvaluate`, `NSAllowsArbitraryLoads` only as a lead for a cleartext secret path.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/storage.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/storage.md
@@ -1,0 +1,95 @@
+# Apple Storage And Secrets
+
+Open when reviewing `UserDefaults`, files, Core Data, Realm, logs, backup flags, or Keychain accessibility.
+
+The sandbox is not a secrecy boundary against backups. `UserDefaults` is a plist in the sandbox and is included in iTunes / Finder / iCloud backups. Encoding is not encryption.
+
+## Attackers
+
+| Sink | Who can read it |
+|------|-----------------|
+| `UserDefaults.standard` | Backup. Any code in the app. Not other apps. |
+| Files in Documents / Library | Backup unless `isExcludedFromBackup` is actually set on that file. |
+| Logs (`print`, `NSLog`, `os.Logger`, Crashlytics) | Device logs, attached Mac, some MDM, crash reporters. |
+| Keychain item without `ThisDeviceOnly` | Migrates in encrypted backups. |
+| App Group defaults/files | Every app/extension in the group, plus backup. |
+
+Physical theft of an unlocked phone is out of scope. Backup of a secret is in scope.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Token in defaults | `defaults.set(refreshToken, forKey:)` | Keychain, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` or stricter |
+| Encoded secret | `defaults.set(token.data(using: .utf8)!.base64EncodedString(), forKey:)` | Same as plaintext. Encoding is not a control. |
+| Secret in a file | `try token.write(to: documents/"session.json")` | Keychain, or file protection + exclude from backup **and** still prefer Keychain for tokens |
+| Secret in logs | `logger.info("auth \(response)")` where response contains a token | Log a request ID, never the token |
+| Weak Keychain ACL | `kSecAttrAccessibleAlways`, `kSecAttrAccessibleAlwaysThisDeviceOnly` | `WhenUnlockedThisDeviceOnly` / `AfterFirstUnlockThisDeviceOnly` plus access control if the item is a long-lived secret |
+| Shared suite | `UserDefaults(suiteName: appGroup)` stores a token | Keychain access group, or do not share |
+
+## Report When
+
+- A session token, refresh token, password, private key, or API secret is written to `UserDefaults`, a sandbox file, Core Data, or a log sink.
+- The same secret is written after `base64`, hex, JSON, or plist encoding.
+- A Keychain item holding a secret uses `kSecAttrAccessibleAlways` / `AlwaysThisDeviceOnly`.
+- A secret is written to an App Group container. Pair with `ipc.md` if another target can read it.
+
+## Do Not Report
+
+- `UserDefaults` for names, themes, non-secret IDs, public client IDs, feature flags.
+- `print` / `os.log` of non-secrets, view lifecycle, or redacted placeholders.
+- Missing `isExcludedFromBackup` on non-secret files.
+- Missing Data Protection class on non-secret files.
+- Keychain use without biometrics. That is `auth.md` only if `LAContext` is the real gate.
+- "Should have used Keychain" for data that is not a secret.
+
+## Trace
+
+1. Identify the value. Prove it is a secret (name, type, where it is later sent as `Authorization`, used as a key, or unlocks an account).
+2. Follow assignments, wrappers, Codable models, and "secure storage" helpers. A helper named `SecureStore` that writes defaults still counts.
+3. Name the sink API and whether the value is encoded first.
+4. For files, check backup exclusion only as extra impact, not as the bug. The bug is storing the secret outside Keychain.
+5. For logs, show the interpolated value includes the secret, not just an object description that might.
+
+## Minimal Examples
+
+**Report: refresh token in UserDefaults**
+
+```swift
+UserDefaults.standard.set(response.refreshToken, forKey: "refreshToken")
+```
+
+**Report: encoded secret is still a secret**
+
+```swift
+let blob = try JSONEncoder().encode(tokens) // includes refreshToken
+UserDefaults.standard.set(blob.base64EncodedString(), forKey: "session")
+```
+
+**Report: token logged**
+
+```swift
+os_log("login %{public}@", log: .default, type: .info, response.accessToken)
+```
+
+**Do not report: non-secret defaults**
+
+```swift
+UserDefaults.standard.set(user.displayName, forKey: "displayName")
+```
+
+**Do not report: Keychain store of a token**
+
+```swift
+let query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "refresh",
+    kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    kSecValueData as String: Data(token.utf8),
+]
+SecItemAdd(query as CFDictionary, nil)
+```
+
+## ObjC Leads
+
+`NSUserDefaults`, `writeToFile:`, `NSFileManager`, `NSLog`, `os_log`, `SecItemAdd` with `kSecAttrAccessibleAlways`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/webview.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/webview.md
@@ -6,25 +6,29 @@ Not applicable on watchOS. JavaScript in the page can call every `WKScriptMessag
 
 ## Attackers
 
-| Source | Trust |
-|--------|--------|
-| Remote URL, or a URL taken from a scheme/link | Untrusted page + JS |
-| HTML string built from user / scheme / network input | Injection → JS |
-| Trusted first-party page, but handler also exposed to iframes / navigations | Origin confusion |
-| `UIWebView` + `JSExport` / `JSContext` | Always-on JS, weaker isolation |
+
+| Source                                                                      | Trust                          |
+| --------------------------------------------------------------------------- | ------------------------------ |
+| Remote URL, or a URL taken from a scheme/link                               | Untrusted page + JS            |
+| HTML string built from user / scheme / network input                        | Injection → JS                 |
+| Trusted first-party page, but handler also exposed to iframes / navigations | Origin confusion               |
+| `UIWebView` + `JSExport` / `JSContext`                                      | Always-on JS, weaker isolation |
+
 
 Need a path for attacker JS: injected HTML, attacker URL, or a bridge that is still attached after navigation to an untrusted origin.
 
 ## High-Signal Patterns
 
-| Pattern | Vulnerable | Safer |
-|---------|------------|-------|
-| Privileged bridge | `WKScriptMessageHandler` returns tokens, starts payments, or opens `file://` without origin checks | Minimize methods. Validate `message.frameInfo.securityOrigin`. Refuse unexpected hosts. |
-| Reply via `evaluateJavaScript` | Handler does `evaluateJavaScript("cb('\(token)')")` | `WKScriptMessageHandlerWithReply`. Never interpolate secrets into JS. |
-| Untrusted load | `webView.load(URLRequest(url: userURL))` or `loadHTMLString(userHTML, …)` with JS on | Allowlisted https hosts, or disable JS (`WKPreferences.isJavaScriptEnabled = false` where possible) and no bridge. |
-| Local file + JS | `loadFileURL` / `allowFileAccessFromFileURLs` with attacker-influenced HTML | Do not combine file access and untrusted HTML. Prefer `QLPreviewController` for files. |
-| `UIWebView` bridge | `JSContext` / `JSExport` on `UIWebView` | `WKWebView` + restricted handlers. Report `UIWebView` only with a bridge or untrusted content. |
-| Sensitive write into DOM | `evaluateJavaScript("document.body.innerHTML = '\(secret)'")` in `.page` | Native UI overlay, or a non-page `WKContentWorld` that still must not share the secret with page JS. |
+
+| Pattern                        | Vulnerable                                                                                         | Safer                                                                                                              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Privileged bridge              | `WKScriptMessageHandler` returns tokens, starts payments, or opens `file://` without origin checks | Minimize methods. Validate `message.frameInfo.securityOrigin`. Refuse unexpected hosts.                            |
+| Reply via `evaluateJavaScript` | Handler does `evaluateJavaScript("cb('\(token)')")`                                                | `WKScriptMessageHandlerWithReply`. Never interpolate secrets into JS.                                              |
+| Untrusted load                 | `webView.load(URLRequest(url: userURL))` or `loadHTMLString(userHTML, …)` with JS on               | Allowlisted https hosts, or disable JS (`WKPreferences.isJavaScriptEnabled = false` where possible) and no bridge. |
+| Local file + JS                | `loadFileURL` / `allowFileAccessFromFileURLs` with attacker-influenced HTML                        | Do not combine file access and untrusted HTML. Prefer `QLPreviewController` for files.                             |
+| `UIWebView` bridge             | `JSContext` / `JSExport` on `UIWebView`                                                            | `WKWebView` + restricted handlers. Report `UIWebView` only with a bridge or untrusted content.                     |
+| Sensitive write into DOM       | `evaluateJavaScript("document.body.innerHTML = '\(secret)'")` in `.page`                           | Native UI overlay, or a non-page `WKContentWorld` that still must not share the secret with page JS.               |
+
 
 ## Report When
 
@@ -92,6 +96,3 @@ func userContentController(_ ucc: WKUserContentController, didReceive message: W
 }
 ```
 
-## ObjC Leads
-
-`WKWebView`, `addScriptMessageHandler:name:`, `evaluateJavaScript:completionHandler:`, `UIWebView`, `JSContext`, `JSExport`.

--- a/packages/warden/src/builtin-skills/security-review/references/apple/webview.md
+++ b/packages/warden/src/builtin-skills/security-review/references/apple/webview.md
@@ -1,0 +1,97 @@
+# Apple WebViews
+
+Open when reviewing `WKWebView`, `WKScriptMessageHandler`, `evaluateJavaScript`, `WKUserScript`, or `UIWebView`.
+
+Not applicable on watchOS. JavaScript in the page can call every `WKScriptMessageHandler` registered on that WebView. Default `evaluateJavaScript` runs in the page world and can leak values to page JS.
+
+## Attackers
+
+| Source | Trust |
+|--------|--------|
+| Remote URL, or a URL taken from a scheme/link | Untrusted page + JS |
+| HTML string built from user / scheme / network input | Injection → JS |
+| Trusted first-party page, but handler also exposed to iframes / navigations | Origin confusion |
+| `UIWebView` + `JSExport` / `JSContext` | Always-on JS, weaker isolation |
+
+Need a path for attacker JS: injected HTML, attacker URL, or a bridge that is still attached after navigation to an untrusted origin.
+
+## High-Signal Patterns
+
+| Pattern | Vulnerable | Safer |
+|---------|------------|-------|
+| Privileged bridge | `WKScriptMessageHandler` returns tokens, starts payments, or opens `file://` without origin checks | Minimize methods. Validate `message.frameInfo.securityOrigin`. Refuse unexpected hosts. |
+| Reply via `evaluateJavaScript` | Handler does `evaluateJavaScript("cb('\(token)')")` | `WKScriptMessageHandlerWithReply`. Never interpolate secrets into JS. |
+| Untrusted load | `webView.load(URLRequest(url: userURL))` or `loadHTMLString(userHTML, …)` with JS on | Allowlisted https hosts, or disable JS (`WKPreferences.isJavaScriptEnabled = false` where possible) and no bridge. |
+| Local file + JS | `loadFileURL` / `allowFileAccessFromFileURLs` with attacker-influenced HTML | Do not combine file access and untrusted HTML. Prefer `QLPreviewController` for files. |
+| `UIWebView` bridge | `JSContext` / `JSExport` on `UIWebView` | `WKWebView` + restricted handlers. Report `UIWebView` only with a bridge or untrusted content. |
+| Sensitive write into DOM | `evaluateJavaScript("document.body.innerHTML = '\(secret)'")` in `.page` | Native UI overlay, or a non-page `WKContentWorld` that still must not share the secret with page JS. |
+
+## Report When
+
+- A script message handler performs a privileged action or returns a secret, and attacker JS can reach that WebView.
+- The handler replies by injecting JS that contains a secret.
+- Attacker-controlled HTML or URL is loaded into a WebView that has a privileged bridge or file access.
+- `UIWebView` loads untrusted content or exposes native objects.
+
+## Do Not Report
+
+- `WKWebView` loading a hard-coded first-party URL with no bridge and no attacker-controlled navigation.
+- JavaScript enabled on a trusted page with no sensitive native API.
+- Missing `WKContentWorld` isolation for a non-secret DOM read.
+- `UIWebView` with no untrusted input and no bridge (deprecation only).
+- `hasOnlySecureContent` not checked (informational API).
+
+## Trace
+
+1. How does content get into the WebView? Hard-coded URL, scheme param, HTML string, file.
+2. Which handlers are registered, and on which content world?
+3. What does each handler do with `message.body`? What does it return?
+4. Can the WebView navigate away from the trusted origin while the handler stays registered?
+5. Pair with `ipc.md` if a scheme/link chooses the loaded URL.
+
+## Minimal Examples
+
+**Report: bridge returns a session token**
+
+```swift
+func userContentController(_ ucc: WKUserContentController, didReceive message: WKScriptMessage) {
+    let token = Keychain.refreshToken
+    message.webView?.evaluateJavaScript("window.onToken('\(token)')")
+}
+```
+
+Any script in the page can `postMessage` and then exfiltrate `onToken`.
+
+**Report: untrusted URL + privileged handler**
+
+```swift
+ucc.add(self, name: "native")
+webView.load(URLRequest(url: incomingDeepLink)) // attacker URL
+
+func userContentController(_ ucc: WKUserContentController, didReceive message: WKScriptMessage) {
+    Payments.send(amount: message.body as! String)
+}
+```
+
+**Do not report: first-party page, no secrets**
+
+```swift
+webView.load(URLRequest(url: URL(string: "https://help.example.com/faq")!))
+```
+
+**Safer reply shape (still require origin + no secret unless needed)**
+
+```swift
+func userContentController(_ ucc: WKUserContentController, didReceive message: WKScriptMessage,
+                           replyHandler: @escaping (Any?, String?) -> Void) {
+    guard message.frameInfo.securityOrigin.host == "app.example.com" else {
+        replyHandler(nil, "denied")
+        return
+    }
+    replyHandler(["ok": true], nil)
+}
+```
+
+## ObjC Leads
+
+`WKWebView`, `addScriptMessageHandler:name:`, `evaluateJavaScript:completionHandler:`, `UIWebView`, `JSContext`, `JSExport`.


### PR DESCRIPTION
This change adds some Apple specific references to the security-review tooling. In some small tests, I saw a 80-120% increase in valid findings against some fairly obvious targets (DVIA-v2, iGoat-Swift, etc). I tried to follow established patterns were possible. 

Let me know what you think :D 