### PR TITLE
fix(warden): Avoid nested Pi provider retries

### DIFF
--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -203,7 +203,7 @@ describe('piRuntime.runSkill', () => {
       compaction: { enabled: false },
       retry: expect.objectContaining({
         enabled: true,
-        provider: expect.objectContaining({ maxRetries: 2 }),
+        provider: expect.objectContaining({ maxRetries: 0 }),
       }),
     }));
     expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -70,6 +70,7 @@ const READ_ONLY_TOOLS: ToolName[] = ['Read', 'Grep', 'Glob'];
 const MUTATING_TOOLS: ToolName[] = ['Write', 'Edit', 'Bash'];
 const UNSUPPORTED_TOOLS: ToolName[] = ['WebFetch', 'WebSearch'];
 const DEFAULT_PI_PROVIDER_MAX_RETRIES = 2;
+const PI_SKILL_PROVIDER_MAX_RETRIES = 0;
 const PI_MODEL_REFRESH_TIMEOUT_MS = 15_000;
 /**
  * Share one network catalog refresh per provider across concurrent Pi prompts.
@@ -468,7 +469,8 @@ function buildSettingsManager(timeout: number | undefined, maxRetries: number | 
   return SettingsManager.inMemory({
     compaction: { enabled: false },
     retry: {
-      enabled: providerMaxRetries > 0,
+      // Provider retries are independent from Pi's agent-level transient retry loop.
+      enabled: true,
       provider: {
         ...(timeout !== undefined ? { timeoutMs: timeout } : {}),
         maxRetries: providerMaxRetries,
@@ -975,6 +977,7 @@ export const piRuntime: Runtime = {
             toolNames: skillTools.toolNames,
             maxTurns,
             effort,
+            maxRetries: PI_SKILL_PROVIDER_MAX_RETRIES,
             abortController,
             parentSpan: span,
             traceRecorder: request.traceRecorder,


### PR DESCRIPTION
Disable provider SDK retries for Pi skill runs while retaining Pi's automatic agent-level retries.

Warden currently enables two retry layers. The provider SDK can make up to three request attempts for one turn, then Pi can make up to four attempts at that failed turn. In the worst case, that multiplies into 12 provider attempts and makes transient failures take much longer to surface.

Pi's retry loop remains enabled and automatically resubmits failed turns with backoff. This change sets only `retry.provider.maxRetries` to `0` for skill runs, matching Pi's recommended configuration. It does not add a total runtime limit or interrupt productive long-running sessions.