### PR TITLE
feat(pi): configure provider base URLs

### DIFF
--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -73,6 +73,28 @@ Warden mirrors these to the native `{PROVIDER}_API_KEY` expected by each SDK at 
 If you already have a native provider key set (e.g. `OPENAI_API_KEY`), Warden will use it
 directly and the `WARDEN_`-prefixed form is not required.
 
+### Provider base URLs
+
+Set `WARDEN_{PROVIDER}_BASE_URL` to route a Pi provider through a gateway such
+as LiteLLM or a corporate proxy. Warden applies the value to the selected Pi
+model without changing its provider or model ID.
+
+For example, a LiteLLM-managed router can keep the normal Warden model selector
+and use a LiteLLM virtual key:
+
+```yaml title="GitHub Actions"
+env:
+  WARDEN_ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+  WARDEN_ANTHROPIC_BASE_URL: https://litellm.example.com
+  WARDEN_OPENAI_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+  WARDEN_OPENAI_BASE_URL: https://litellm.example.com/v1
+```
+
+Use the LiteLLM root URL for Anthropic models because Pi appends
+`/v1/messages`. Use the `/v1` URL for OpenAI models because Pi appends its
+OpenAI API path. Do not set both a native provider key and a LiteLLM virtual key
+for the same provider.
+
 ## Claude Runtime Models
 
 When `runtime = "claude"`, use the model IDs accepted by Claude Code:

--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -172,6 +172,63 @@ describe('piRuntime.runSkill', () => {
     piMocks.modelRuntime.getModels.mockReturnValue([piMocks.model]);
   });
 
+  it('leaves the model untouched when no base URL override is set', async () => {
+    await piRuntime.runSkill(baseSkillRequest());
+
+    expect(createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: piMocks.model })
+    );
+  });
+
+  it('applies WARDEN_<PROVIDER>_BASE_URL to the resolved model', async () => {
+    process.env['WARDEN_OPENAI_BASE_URL'] = 'https://gateway.internal/v1';
+    try {
+      await piRuntime.runSkill(baseSkillRequest());
+
+      expect(createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({ baseUrl: 'https://gateway.internal/v1' }),
+        })
+      );
+    } finally {
+      delete process.env['WARDEN_OPENAI_BASE_URL'];
+    }
+  });
+
+  it('uses the provider-specific base URL override', async () => {
+    process.env['WARDEN_ANTHROPIC_BASE_URL'] = 'https://gateway.internal';
+    try {
+      await piRuntime.runSkill({
+        ...baseSkillRequest(),
+        options: {
+          ...baseSkillRequest().options,
+          model: 'anthropic/claude-test',
+        },
+      });
+
+      expect(createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({ baseUrl: 'https://gateway.internal' }),
+        })
+      );
+    } finally {
+      delete process.env['WARDEN_ANTHROPIC_BASE_URL'];
+    }
+  });
+
+  it('ignores an empty WARDEN_<PROVIDER>_BASE_URL', async () => {
+    process.env['WARDEN_OPENAI_BASE_URL'] = '';
+    try {
+      await piRuntime.runSkill(baseSkillRequest());
+
+      expect(createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: piMocks.model })
+      );
+    } finally {
+      delete process.env['WARDEN_OPENAI_BASE_URL'];
+    }
+  });
+
   it('passes read-only Pi tools and normalizes the result', async () => {
     const result = await piRuntime.runSkill(baseSkillRequest());
 

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -330,6 +330,19 @@ async function createModelRuntime(
   return modelRuntime;
 }
 
+/**
+ * Optional base-URL override for a provider, from `WARDEN_<PROVIDER>_BASE_URL`.
+ *
+ * Mirrors the existing `WARDEN_<PROVIDER>_API_KEY` convention, so pointing a provider at
+ * an OpenAI-compatible gateway (LiteLLM, a corporate proxy, a self-hosted endpoint) is the
+ * same shape of configuration as giving it a key. Unset means the provider's own default,
+ * exactly as today.
+ */
+function providerBaseUrlOverride(provider: string): string | undefined {
+  const value = process.env[`WARDEN_${provider.toUpperCase()}_BASE_URL`];
+  return value && value.length > 0 ? value : undefined;
+}
+
 function resolvePiModel(
   model: string | undefined,
   modelRuntime: ModelRuntime,
@@ -345,7 +358,9 @@ function resolvePiModel(
       `Pi model not found: ${model}. Use provider/model, for example openai/gpt-5.5.`
     );
   }
-  return resolved;
+
+  const baseUrl = providerBaseUrlOverride(provider);
+  return baseUrl ? { ...resolved, baseUrl } : resolved;
 }
 
 function resolvePiSkillTools(


### PR DESCRIPTION
I’d love to use Warden with Pi through gateways such as LiteLLM. This adds `WARDEN_<PROVIDER>_BASE_URL`, so a configured provider can target a gateway without changing its model selector.