### PR TITLE
fix(config): Inherit org execution defaults for repo skills

### DIFF
--- a/packages/warden/src/config/loader.test.ts
+++ b/packages/warden/src/config/loader.test.ts
@@ -984,14 +984,21 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved[1]?.runtime).toBe('pi');
   });
 
-  it('lets repo-defined skills inherit base verification defaults when omitted', () => {
+  it('inherits base execution defaults without inheriting base policy defaults', () => {
     const baseConfig: WardenConfig = {
       version: 1,
       defaults: {
         failOn: 'high',
-        model: 'base-model',
+        model: 'openrouter/moonshotai/kimi-k3',
+        agent: { maxTurns: 30, effort: 'max' },
+        auxiliary: {
+          model: 'openrouter/openai/gpt-5.6-luna',
+          effort: 'high',
+          maxRetries: 5,
+        },
+        synthesis: { model: 'openrouter/anthropic/claude-sonnet-4.6' },
         ignorePaths: ['base/**'],
-        runtime: 'claude',
+        runtime: 'pi',
         verification: { enabled: false },
         chunking: { maxContextFiles: 25 },
       },
@@ -1018,11 +1025,67 @@ describe('resolveLayeredSkillConfigs', () => {
     expect(resolved).toHaveLength(2);
     expect(resolved[0]?.verifyFindings).toBe(false);
     expect(resolved[1]?.verifyFindings).toBe(false);
-    expect(resolved[1]?.runtime).toBe('claude');
+    expect(resolved[1]?.runtime).toBe('pi');
     expect(resolved[1]?.failOn).toBeUndefined();
-    expect(resolved[1]?.model).toBeUndefined();
+    expect(resolved[1]?.model).toBe('openrouter/moonshotai/kimi-k3');
+    expect(resolved[1]?.maxTurns).toBe(30);
+    expect(resolved[1]?.effort).toBe('max');
+    expect(resolved[1]?.auxiliaryModel).toBe('openrouter/openai/gpt-5.6-luna');
+    expect(resolved[1]?.auxiliaryEffort).toBe('high');
+    expect(resolved[1]?.auxiliaryMaxRetries).toBe(5);
+    expect(resolved[1]?.synthesisModel).toBe('openrouter/anthropic/claude-sonnet-4.6');
     expect(resolved[1]?.filters.ignorePaths).toBeUndefined();
     expect(resolved[1]?.maxContextFiles).toBeUndefined();
+  });
+
+  it('lets repo execution defaults override inherited base defaults', () => {
+    const baseConfig: WardenConfig = {
+      version: 1,
+      defaults: {
+        agent: {
+          model: 'openrouter/moonshotai/kimi-k3',
+          maxTurns: 30,
+          effort: 'max',
+        },
+        auxiliary: {
+          model: 'openrouter/openai/gpt-5.6-luna',
+          effort: 'high',
+          maxRetries: 5,
+        },
+        synthesis: { model: 'openrouter/anthropic/claude-sonnet-4.6' },
+      },
+      skills: [{ name: 'org-skill' }],
+    };
+
+    const repoConfig: WardenConfig = {
+      version: 1,
+      defaults: {
+        model: 'openrouter/x-ai/grok-4.5',
+        maxTurns: 12,
+        agent: { effort: 'low' },
+        auxiliary: { model: 'openrouter/google/gemini-3.1-pro-preview' },
+        auxiliaryMaxRetries: 2,
+        synthesis: { model: 'openrouter/openai/gpt-5.5' },
+      },
+      skills: [{ name: 'repo-skill' }],
+    };
+
+    const resolved = resolveLayeredSkillConfigs({
+      config: mergeWardenConfigs(baseConfig, repoConfig),
+      baseConfig,
+      repoConfig,
+    });
+
+    expect(resolved[1]).toMatchObject({
+      name: 'repo-skill',
+      model: 'openrouter/x-ai/grok-4.5',
+      maxTurns: 12,
+      effort: 'low',
+      auxiliaryModel: 'openrouter/google/gemini-3.1-pro-preview',
+      auxiliaryEffort: 'high',
+      auxiliaryMaxRetries: 2,
+      synthesisModel: 'openrouter/openai/gpt-5.5',
+    });
   });
 
   it('lets a repo-layer skill override inherited base verification defaults', () => {

--- a/packages/warden/src/config/loader.ts
+++ b/packages/warden/src/config/loader.ts
@@ -185,8 +185,62 @@ function mergeServiceConfig(base?: ServiceConfig, overlay?: ServiceConfig): Serv
   return merged;
 }
 
+function effectiveAgentDefaults(defaults?: Defaults): AgentRuntimeConfig | undefined {
+  const model = emptyToUndefined(defaults?.agent?.model) ?? emptyToUndefined(defaults?.model);
+  const maxTurns = defaults?.agent?.maxTurns ?? defaults?.maxTurns;
+  const effort = defaults?.agent?.effort;
+  const effective: AgentRuntimeConfig = {};
+
+  if (model !== undefined) effective.model = model;
+  if (maxTurns !== undefined) effective.maxTurns = maxTurns;
+  if (effort !== undefined) effective.effort = effort;
+
+  return Object.keys(effective).length > 0 ? effective : undefined;
+}
+
+function effectiveAuxiliaryDefaults(defaults?: Defaults): AuxiliaryRuntimeConfig | undefined {
+  const model = emptyToUndefined(defaults?.auxiliary?.model);
+  const effort = defaults?.auxiliary?.effort;
+  const maxRetries = defaults?.auxiliary?.maxRetries ?? defaults?.auxiliaryMaxRetries;
+  const effective: AuxiliaryRuntimeConfig = {};
+
+  if (model !== undefined) effective.model = model;
+  if (effort !== undefined) effective.effort = effort;
+  if (maxRetries !== undefined) effective.maxRetries = maxRetries;
+
+  return Object.keys(effective).length > 0 ? effective : undefined;
+}
+
+function effectiveSynthesisDefaults(defaults?: Defaults): Defaults['synthesis'] {
+  const model = emptyToUndefined(defaults?.synthesis?.model);
+  return model === undefined ? undefined : { model };
+}
+
 function inheritRepoLayerDefaults(base?: Defaults, repo?: Defaults): Defaults | undefined {
   const inherited: Defaults = { ...(repo ?? {}) };
+
+  // Normalize legacy and nested fields before merging so either repo syntax
+  // overrides the corresponding base execution default.
+  const agent = mergeNestedConfig(effectiveAgentDefaults(base), effectiveAgentDefaults(repo));
+  if (agent) {
+    inherited.agent = agent;
+  }
+
+  const auxiliary = mergeNestedConfig(
+    effectiveAuxiliaryDefaults(base),
+    effectiveAuxiliaryDefaults(repo)
+  );
+  if (auxiliary) {
+    inherited.auxiliary = auxiliary;
+  }
+
+  const synthesis = mergeNestedConfig(
+    effectiveSynthesisDefaults(base),
+    effectiveSynthesisDefaults(repo)
+  );
+  if (synthesis) {
+    inherited.synthesis = synthesis;
+  }
 
   if (base?.runtime !== undefined && inherited.runtime === undefined) {
     inherited.runtime = base.runtime;


### PR DESCRIPTION
Let repo-local skills inherit agent, auxiliary, and synthesis execution defaults from the org base config when they omit them. This covers both the nested configuration and the legacy model, turn-limit, and auxiliary-retry fields.

Layered resolution currently isolates repo-local skills from these defaults. An omitted model can therefore fall through to the environment or SDK default even when the org base config selects a model. In production this allowed repo-local skills to run on K2.6 while the org security review ran on Grok.

Explicit repo settings retain precedence. Reporting thresholds, path filters, and other policy defaults remain layer-local, preserving the separation between org-enforced and repo-owned skills.

The alternative in https://github.com/getsentry/.github/pull/211 sets a global model fallback. That covers an omitted primary model, but it cannot carry effort, turn limits, auxiliary settings, or synthesis settings and leaves the layered configuration behavior surprising.