### PR TITLE
feat(pi): configure provider headers

### DIFF
--- a/packages/docs/src/content/docs/config/models.mdx
+++ b/packages/docs/src/content/docs/config/models.mdx
@@ -86,14 +86,21 @@ and use a LiteLLM virtual key:
 env:
   WARDEN_ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
   WARDEN_ANTHROPIC_BASE_URL: https://litellm.example.com
+  WARDEN_ANTHROPIC_HEADERS: '{"x-litellm-tags":"repo:acme/api,component:review"}'
   WARDEN_OPENAI_API_KEY: ${{ secrets.LITELLM_API_KEY }}
   WARDEN_OPENAI_BASE_URL: https://litellm.example.com/v1
+  WARDEN_OPENAI_HEADERS: '{"x-litellm-tags":"repo:acme/api,component:review"}'
 ```
 
 Use the LiteLLM root URL for Anthropic models because Pi appends
 `/v1/messages`. Use the `/v1` URL for OpenAI models because Pi appends its
 OpenAI API path. Do not set both a native provider key and a LiteLLM virtual key
 for the same provider.
+
+Set `WARDEN_{PROVIDER}_HEADERS` to a JSON object when the gateway requires
+additional request headers. Warden merges them with the selected Pi model's
+headers, with configured values taking precedence. Every header value must be a
+string.
 
 ## Claude Runtime Models
 

--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -17,7 +17,13 @@ import { startTraceRecorder, withTraceRecorder } from '../../sentry-trace.js';
 import type { TraceSpan } from '../../types/index.js';
 
 const piMocks = vi.hoisted(() => {
-  const model = {
+  const model: {
+    id: string;
+    provider: string;
+    model: string;
+    baseUrl?: string;
+    headers?: Record<string, string>;
+  } = {
     id: 'gpt-test',
     provider: 'openai',
     model: 'gpt-test',

--- a/packages/warden/src/sdk/runtimes/pi.test.ts
+++ b/packages/warden/src/sdk/runtimes/pi.test.ts
@@ -229,6 +229,44 @@ describe('piRuntime.runSkill', () => {
     }
   });
 
+  it('merges WARDEN_<PROVIDER>_HEADERS into the resolved model', async () => {
+    process.env['WARDEN_OPENAI_HEADERS'] = JSON.stringify({
+      'x-existing': 'overridden',
+      'x-litellm-tags': 'repo:acme/api,component:review',
+    });
+    piMocks.modelRuntime.getModel.mockReturnValue({
+      ...piMocks.model,
+      headers: { 'x-existing': 'original' },
+    });
+    try {
+      await piRuntime.runSkill(baseSkillRequest());
+
+      expect(createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({
+            headers: {
+              'x-existing': 'overridden',
+              'x-litellm-tags': 'repo:acme/api,component:review',
+            },
+          }),
+        })
+      );
+    } finally {
+      delete process.env['WARDEN_OPENAI_HEADERS'];
+    }
+  });
+
+  it('rejects invalid WARDEN_<PROVIDER>_HEADERS', async () => {
+    process.env['WARDEN_OPENAI_HEADERS'] = '{"x-litellm-tags":42}';
+    try {
+      await expect(piRuntime.runSkill(baseSkillRequest())).rejects.toThrow(
+        'WARDEN_OPENAI_HEADERS must be a JSON object with string values'
+      );
+    } finally {
+      delete process.env['WARDEN_OPENAI_HEADERS'];
+    }
+  });
+
   it('passes read-only Pi tools and normalizes the result', async () => {
     const result = await piRuntime.runSkill(baseSkillRequest());
 

--- a/packages/warden/src/sdk/runtimes/pi.ts
+++ b/packages/warden/src/sdk/runtimes/pi.ts
@@ -344,6 +344,20 @@ function providerBaseUrlOverride(provider: string): string | undefined {
   return value && value.length > 0 ? value : undefined;
 }
 
+function providerHeadersOverride(provider: string): Record<string, string> | undefined {
+  const envName = `WARDEN_${provider.toUpperCase()}_HEADERS`;
+  const value = process.env[envName];
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return z.record(z.string(), z.string()).parse(JSON.parse(value));
+  } catch {
+    throw new Error(`${envName} must be a JSON object with string values`);
+  }
+}
+
 function resolvePiModel(
   model: string | undefined,
   modelRuntime: ModelRuntime,
@@ -361,7 +375,16 @@ function resolvePiModel(
   }
 
   const baseUrl = providerBaseUrlOverride(provider);
-  return baseUrl ? { ...resolved, baseUrl } : resolved;
+  const headers = providerHeadersOverride(provider);
+  if (!baseUrl && !headers) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(headers ? { headers: { ...resolved.headers, ...headers } } : {}),
+  };
 }
 
 function resolvePiSkillTools(


### PR DESCRIPTION
This is a follow-up to #512, which added provider base URL overrides. It adds `WARDEN_<PROVIDER>_HEADERS` so gateways such as LiteLLM can receive per-request metadata.