### PR TITLE
docs(benchmarks): Publish Gemini 3.8 Flash result

### DIFF
--- a/packages/docs/scripts/validate-benchmark-results.mjs
+++ b/packages/docs/scripts/validate-benchmark-results.mjs
@@ -85,6 +85,19 @@ for (const filename of readdirSync(resultsDir).filter((file) => file.endsWith(".
     }
   }
 
+  if (result.comparison?.include && !isStableComparison(result)) {
+    for (const field of ["label", "caveat"]) {
+      if (
+        typeof result.comparison[field] !== "string" ||
+        result.comparison[field].trim() === ""
+      ) {
+        errors.push(
+          `${label}: caveated comparison rows require comparison.${field}`,
+        );
+      }
+    }
+  }
+
   if (result.shards?.length && result.summary && !result.supersededBy) {
     const checks = [
       ["chunksTotal", "chunksTotal"],

--- a/packages/docs/src/components/BenchmarkRuns.astro
+++ b/packages/docs/src/components/BenchmarkRuns.astro
@@ -20,6 +20,11 @@ type TimingDistribution = {
 };
 
 type BenchmarkResult = {
+  comparison?: {
+    caveat: string;
+    include: boolean;
+    label: string;
+  };
   corpusId: string;
   model: string;
   reasoningLevel?: string;
@@ -154,6 +159,7 @@ const runMeta = (result: BenchmarkResult) =>
   [
     hidesReasoningLabel(result) ? undefined : reasoningLabel(result.reasoningLevel),
     productionLabel(result),
+    result.comparison?.include ? result.comparison.label : undefined,
   ]
     .filter(Boolean)
     .join(" · ");
@@ -187,17 +193,26 @@ const compareResults = (a: BenchmarkResult, b: BenchmarkResult) => {
   return sortLabel(a).localeCompare(sortLabel(b));
 };
 
-const stableResults = Object.values(resultModules)
-  .filter(
-    (result) =>
-      result.corpusId === "sentry-vulnerability-corpus" &&
-      result.targetMode === "all-corpus-files-by-sha" &&
-      !result.supersededBy &&
-      result.summary.chunksFailed === 0 &&
-      (result.summary.skippedFileCount ?? 0) === 0 &&
-      result.summary.chunksAnalyzed === result.summary.chunksTotal &&
-      result.timing?.analysisChunkMs,
-  );
+const isStableComparison = (result: BenchmarkResult) =>
+  result.corpusId === "sentry-vulnerability-corpus" &&
+  result.targetMode === "all-corpus-files-by-sha" &&
+  !result.supersededBy &&
+  result.summary.chunksFailed === 0 &&
+  (result.summary.skippedFileCount ?? 0) === 0 &&
+  result.summary.chunksAnalyzed === result.summary.chunksTotal &&
+  Boolean(result.timing?.analysisChunkMs);
+
+const comparisonResults = Object.values(resultModules).filter(
+  (result) =>
+    result.corpusId === "sentry-vulnerability-corpus" &&
+    result.targetMode === "all-corpus-files-by-sha" &&
+    !result.supersededBy &&
+    (isStableComparison(result) || result.comparison?.include === true),
+);
+
+const caveatedResults = comparisonResults.filter(
+  (result) => !isStableComparison(result),
+);
 
 const compareCostResults = (a: BenchmarkResult, b: BenchmarkResult) => {
   const costPerKnownDiff =
@@ -215,15 +230,15 @@ const compareCostResults = (a: BenchmarkResult, b: BenchmarkResult) => {
   return compareResults(a, b);
 };
 
-const scoreResults = [...stableResults].sort(compareResults);
-const costResults = [...stableResults].sort(compareCostResults);
+const scoreResults = [...comparisonResults].sort(compareResults);
+const costResults = [...comparisonResults].sort(compareCostResults);
 ---
 
-<section class="benchmark-runs" aria-label="Stable benchmark comparison matrix">
-  {stableResults.length === 0 ? (
-    <p>No stable benchmark comparisons recorded yet.</p>
+<section class="benchmark-runs" aria-label="Benchmark comparison matrix">
+  {comparisonResults.length === 0 ? (
+    <p>No benchmark comparisons recorded yet.</p>
   ) : (
-    <div class="run-table score-table" role="table" aria-label="Stable benchmark comparison scores">
+    <div class="run-table score-table" role="table" aria-label="Benchmark comparison scores">
       <div class="run-header" role="row">
         <span role="columnheader">Run</span>
         <span role="columnheader">Known</span>
@@ -273,7 +288,17 @@ const costResults = [...stableResults].sort(compareCostResults);
     </div>
   )}
 
-  {stableResults.length > 0 && (
+  {caveatedResults.length > 0 && (
+    <aside class="comparison-caveats" aria-label="Comparison caveats">
+      {caveatedResults.map((result) => (
+        <p>
+          <strong>{runLabel(result)}:</strong> {result.comparison?.caveat}
+        </p>
+      ))}
+    </aside>
+  )}
+
+  {comparisonResults.length > 0 && (
     <div class="detail-tables">
       <section class="detail-section" aria-labelledby="benchmark-cost-breakdown">
         <h3 id="benchmark-cost-breakdown">Cost</h3>
@@ -343,7 +368,8 @@ const costResults = [...stableResults].sort(compareCostResults);
   .benchmark-runs .metric-detail,
   .benchmark-runs .cell-label,
   .benchmark-runs .detail-section h3,
-  .benchmark-runs .sort-note {
+  .benchmark-runs .sort-note,
+  .benchmark-runs .comparison-caveats p {
     margin: 0;
   }
 
@@ -447,6 +473,23 @@ const costResults = [...stableResults].sort(compareCostResults);
 
   .cell-label {
     display: none;
+  }
+
+  .comparison-caveats {
+    background: color-mix(in srgb, var(--sl-color-gray-6) 35%, transparent);
+    border-left: 3px solid var(--sl-color-orange);
+    margin-top: 0.75rem;
+    padding: 0.7rem 0.8rem;
+  }
+
+  .comparison-caveats p {
+    color: var(--sl-color-gray-2);
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
+
+  .comparison-caveats p + p {
+    margin-top: 0.5rem;
   }
 
   .detail-tables {

--- a/packages/docs/src/components/BenchmarkRuns.astro
+++ b/packages/docs/src/components/BenchmarkRuns.astro
@@ -69,6 +69,7 @@ const MODEL_LABELS: Record<string, string> = {
   "openai/gpt-5.6-luna": "GPT 5.6 Luna",
   "openrouter/deepseek/deepseek-v4-flash": "DeepSeek V4 Flash",
   "openrouter/deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
+  "openrouter/google/gemini-3.8-flash": "Gemini 3.8 Flash",
   "openrouter/x-ai/grok-4.5": "Grok 4.5",
   "openrouter/x-ai/grok-4.6": "Grok 4.6",
   "openrouter/z-ai/glm-5.2": "GLM 5.2",

--- a/packages/docs/src/components/BenchmarkRuns.astro
+++ b/packages/docs/src/components/BenchmarkRuns.astro
@@ -476,16 +476,13 @@ const costResults = [...comparisonResults].sort(compareCostResults);
   }
 
   .comparison-caveats {
-    background: color-mix(in srgb, var(--sl-color-gray-6) 35%, transparent);
-    border-left: 3px solid var(--sl-color-orange);
-    margin-top: 0.75rem;
-    padding: 0.7rem 0.8rem;
+    margin-top: 0.55rem;
   }
 
   .comparison-caveats p {
-    color: var(--sl-color-gray-2);
-    font-size: 0.8rem;
-    line-height: 1.5;
+    color: var(--sl-color-gray-3);
+    font-size: 0.78rem;
+    line-height: 1.4;
   }
 
   .comparison-caveats p + p {

--- a/packages/docs/src/content/docs/benchmarking.mdx
+++ b/packages/docs/src/content/docs/benchmarking.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Stable Sentry benchmark comparisons for Warden.
+description: Sentry benchmark comparisons for Warden.
 editUrl: false
 ---
 
@@ -27,8 +27,9 @@ Sentry repository.
 ## Comparison Matrix
 
 The score table is the headline and sorts by known-corpus recall. The cost table
-ranks runs by recorded provider cost per known corpus finding. This matrix only
-includes complete runs with no failed chunks and per-chunk trace data.
+ranks runs by recorded provider cost per known corpus finding. Complete runs
+with no failed chunks and per-chunk trace data enter automatically. Explicit
+exceptions are labeled in the table and explained directly beneath it.
 
 Timing remains in result metadata for diagnostics, but the overview does not
 rank it. Provider load, network conditions, retries, queueing, and the benchmark
@@ -145,17 +146,17 @@ findings. Eighteen findings matched 19 unique corpus entries. The other seven
 described different issues and received no corpus credit. Recorded spend was
 $78.17, or at least $4.11 per known entry.
 
-This is an incomplete operational result, not a stable comparison row. Two of
-156 chunks reached the 100-turn limit in the initial run and in all three
-serial repair passes. The failures cover the organization pipeline endpoint
-and one of four MS Teams webhook chunks. Exact-tuple repairs recovered the
-other 11 initial failures. Retrying these two again would turn the result into
-a best-of-N sample, so the run stopped after four attempts. The comparison
-matrix excludes every run with a failed chunk.
+This is an incomplete operational result, not a stable comparison row. It is
+included in the matrix as an explicitly labeled exception. Two of 156 chunks
+reached the 100-turn limit in the initial run and in all three serial repair
+passes. The failures cover the organization pipeline endpoint and one of four
+MS Teams webhook chunks. Exact-tuple repairs recovered the other 11 initial
+failures. Retrying these two again would turn the result into a best-of-N
+sample, so the run stopped after four attempts.
 
-For context only, 19 known entries would rank 16th among 22 rows if this result
-were treated as complete. It sits below Opus 4.8 high at 21 and above the two
-18-entry rows. Grok 4.6 high is the nearest recent configuration: it used Pi,
+The incomplete 19-entry result ranks 16th among the 22 displayed rows. It sits
+below Opus 4.8 high at 21 and above the two 18-entry rows. Grok 4.6 high is the
+nearest recent configuration: it used Pi,
 high effort, and GPT 5.6 Luna high for auxiliary calls on Warden 0.47.0. Grok
 4.6 completed all chunks, found 25 known entries, and cost $78.47. Gemini used
 Warden 0.48.0, cost nearly the same recorded amount, and found six fewer known

--- a/packages/docs/src/content/docs/benchmarking.mdx
+++ b/packages/docs/src/content/docs/benchmarking.mdx
@@ -142,21 +142,29 @@ not support moving the benchmark or production model lane to Grok 4.6.
 
 ### Gemini 3.8 Flash High
 
-Gemini 3.8 Flash found 19 of 86 known corpus entries and emitted 25 final
-findings. Eighteen findings matched 19 unique corpus entries; the other seven
-described different issues and received no corpus credit. Its matched set spans
-organization, project, and team authorization boundaries, OAuth and JWT flaws,
-weak webhook and transport controls, command injection, and HTML injection.
+Gemini 3.8 Flash high uses Pi through OpenRouter as
+`openrouter/google/gemini-3.8-flash`. It found 19 of 86 known entries and
+emitted 25 findings. This puts it behind Claude Opus 4.8 high on Pi and ahead
+of Claude Opus 4.8 medium and DeepSeek V4 Flash on known-corpus recall. Eighteen
+emitted findings matched 19 unique corpus entries because one Atlassian JWT
+finding covered two entries. The other seven findings described different
+issues and did not count.
 
-The result ranks 16th of 22 rows for recall and 20th for cost efficiency. Grok
-4.6 high found 25 entries for nearly the same recorded cost, $78.47 compared
-with $78.17. The runs shared 13 entries; Gemini found six that Grok missed, and
-Grok found 12 that Gemini missed. DeepSeek V4 Flash found 18 entries for $10.11,
-so Gemini added one known match for at least 7.7 times the provider cost.
+The matched findings cover a broad range of security boundaries. Gemini found
+cross-organization, cross-project, and cross-team authorization gaps, OAuth
+client-secret exposure, untrusted JWT algorithm selection, weak webhook and
+transport controls, and two client-side injection issues. It also caught
+narrower logic errors, including the accept-invite deletion fallthrough,
+pinned-search ownership bypass, and arbitrary GCS transfer-job trigger.
 
-Gemini completed 154 of 156 chunks, or 98.7%; the two unfinished chunks contain
-one known corpus entry each, so full completion could raise recall only to
-21/86. Recorded cost is a lower bound.
+Gemini cost $78.17, or $4.11 per known corpus finding. That is nearly the same
+as Grok 4.6 high at $78.47, while Gemini found six fewer known entries.
+DeepSeek V4 Flash found one fewer for $10.11. Gemini recorded 311 million input
+tokens, the highest total in the matrix.
+
+The run completed 154 of 156 chunks. The two remaining chunks each cover one
+corpus entry, so a complete run could score at most 21/86. Recorded cost is a
+lower bound.
 
 ### Kimi K3 Effort Levels and K2.6
 

--- a/packages/docs/src/content/docs/benchmarking.mdx
+++ b/packages/docs/src/content/docs/benchmarking.mdx
@@ -28,8 +28,9 @@ Sentry repository.
 
 The score table is the headline and sorts by known-corpus recall. The cost table
 ranks runs by recorded provider cost per known corpus finding. Complete runs
-with no failed chunks and per-chunk trace data enter automatically. Explicit
-exceptions are labeled in the table and explained directly beneath it.
+with no failed chunks and per-chunk trace data enter automatically. Rows based
+on partial run data show their chunk coverage and an accounting note below the
+table.
 
 Timing remains in result metadata for diagnostics, but the overview does not
 rank it. Provider load, network conditions, retries, queueing, and the benchmark
@@ -142,33 +143,21 @@ not support moving the benchmark or production model lane to Grok 4.6.
 ### Gemini 3.8 Flash High
 
 Gemini 3.8 Flash found 19 of 86 known corpus entries and emitted 25 final
-findings. Eighteen findings matched 19 unique corpus entries. The other seven
-described different issues and received no corpus credit. Recorded spend was
-$78.17, or at least $4.11 per known entry.
+findings. Eighteen findings matched 19 unique corpus entries; the other seven
+described different issues and received no corpus credit. Its matched set spans
+organization, project, and team authorization boundaries, OAuth and JWT flaws,
+weak webhook and transport controls, command injection, and HTML injection.
 
-This is an incomplete operational result, not a stable comparison row. It is
-included in the matrix as an explicitly labeled exception. Two of 156 chunks
-reached the 100-turn limit in the initial run and in all three serial repair
-passes. The failures cover the organization pipeline endpoint and one of four
-MS Teams webhook chunks. Exact-tuple repairs recovered the other 11 initial
-failures. Retrying these two again would turn the result into a best-of-N
-sample, so the run stopped after four attempts.
+The result ranks 16th of 22 rows for recall and 20th for cost efficiency. Grok
+4.6 high found 25 entries for nearly the same recorded cost, $78.47 compared
+with $78.17. The runs shared 13 entries; Gemini found six that Grok missed, and
+Grok found 12 that Gemini missed. DeepSeek V4 Flash found 18 entries for $10.11,
+so Gemini added one known match for at least 7.7 times the provider cost.
 
-The incomplete 19-entry result ranks 16th among the 22 displayed rows. It sits
-below Opus 4.8 high at 21 and above the two 18-entry rows. Grok 4.6 high is the
-nearest recent configuration: it used Pi,
-high effort, and GPT 5.6 Luna high for auxiliary calls on Warden 0.47.0. Grok
-4.6 completed all chunks, found 25 known entries, and cost $78.47. Gemini used
-Warden 0.48.0, cost nearly the same recorded amount, and found six fewer known
-entries.
-
-The cost comparison is less favorable. Gemini's lower-bound $4.11 per known
-entry would rank 20th of 22, ahead of only the two Claude SDK rows. DeepSeek V4
-Flash found 18 known entries for $10.11. Gemini found one more for at least
-7.7 times the provider cost. The 622 MB shard for the largest corpus commit
-also exceeded V8's string limit during finalization. Its streamed chunk records
-survived, but the verifier tail did not, so the published cost and 6 hour 49
-minute wall time are lower bounds.
+Gemini completed 154 of 156 chunks, or 98.7%; the two unfinished chunks contain
+one known corpus entry each, so full completion could raise recall only to
+21/86. The recorded cost and 6 hour 49 minute wall time are lower bounds because
+one oversized shard did not persist its final verifier accounting.
 
 ### Kimi K3 Effort Levels and K2.6
 

--- a/packages/docs/src/content/docs/benchmarking.mdx
+++ b/packages/docs/src/content/docs/benchmarking.mdx
@@ -138,6 +138,37 @@ replicated under the controlled rerun. The primary outputs still favor Grok
 These remain single runs, not a deterministic model ranking. The result does
 not support moving the benchmark or production model lane to Grok 4.6.
 
+### Gemini 3.8 Flash High
+
+Gemini 3.8 Flash found 19 of 86 known corpus entries and emitted 25 final
+findings. Eighteen findings matched 19 unique corpus entries. The other seven
+described different issues and received no corpus credit. Recorded spend was
+$78.17, or at least $4.11 per known entry.
+
+This is an incomplete operational result, not a stable comparison row. Two of
+156 chunks reached the 100-turn limit in the initial run and in all three
+serial repair passes. The failures cover the organization pipeline endpoint
+and one of four MS Teams webhook chunks. Exact-tuple repairs recovered the
+other 11 initial failures. Retrying these two again would turn the result into
+a best-of-N sample, so the run stopped after four attempts. The comparison
+matrix excludes every run with a failed chunk.
+
+For context only, 19 known entries would rank 16th among 22 rows if this result
+were treated as complete. It sits below Opus 4.8 high at 21 and above the two
+18-entry rows. Grok 4.6 high is the nearest recent configuration: it used Pi,
+high effort, and GPT 5.6 Luna high for auxiliary calls on Warden 0.47.0. Grok
+4.6 completed all chunks, found 25 known entries, and cost $78.47. Gemini used
+Warden 0.48.0, cost nearly the same recorded amount, and found six fewer known
+entries.
+
+The cost comparison is less favorable. Gemini's lower-bound $4.11 per known
+entry would rank 20th of 22, ahead of only the two Claude SDK rows. DeepSeek V4
+Flash found 18 known entries for $10.11. Gemini found one more for at least
+7.7 times the provider cost. The 622 MB shard for the largest corpus commit
+also exceeded V8's string limit during finalization. Its streamed chunk records
+survived, but the verifier tail did not, so the published cost and 6 hour 49
+minute wall time are lower bounds.
+
 ### Kimi K3 Effort Levels and K2.6
 
 The historical K3 max run remains the strongest Kimi result on this corpus. It

--- a/packages/docs/src/content/docs/benchmarking.mdx
+++ b/packages/docs/src/content/docs/benchmarking.mdx
@@ -156,8 +156,7 @@ so Gemini added one known match for at least 7.7 times the provider cost.
 
 Gemini completed 154 of 156 chunks, or 98.7%; the two unfinished chunks contain
 one known corpus entry each, so full completion could raise recall only to
-21/86. The recorded cost and 6 hour 49 minute wall time are lower bounds because
-one oversized shard did not persist its final verifier accounting.
+21/86. Recorded cost is a lower bound.
 
 ### Kimi K3 Effort Levels and K2.6
 

--- a/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
+++ b/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
@@ -4,8 +4,8 @@
   "stableComparisonEligible": false,
   "comparison": {
     "include": true,
-    "label": "Incomplete: 154/156 chunks",
-    "caveat": "Two chunks reached the 100-turn limit in the baseline and all three exact-tuple repair passes. Treat 19/86 as an incomplete-run result. Recorded cost and duration are lower bounds because one oversized shard did not persist its verifier tail."
+    "label": "154/156 chunks",
+    "caveat": "The two unfinished chunks contain one known entry each, limiting the score's possible increase to 21/86; cost and duration are lower bounds because one shard omitted final verifier accounting."
   },
   "corpusId": "sentry-vulnerability-corpus",
   "repository": "getsentry/sentry",

--- a/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
+++ b/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
@@ -2,6 +2,11 @@
   "runId": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001",
   "status": "completed-with-two-unresolved-chunks",
   "stableComparisonEligible": false,
+  "comparison": {
+    "include": true,
+    "label": "Incomplete: 154/156 chunks",
+    "caveat": "Two chunks reached the 100-turn limit in the baseline and all three exact-tuple repair passes. Treat 19/86 as an incomplete-run result. Recorded cost and duration are lower bounds because one oversized shard did not persist its verifier tail."
+  },
   "corpusId": "sentry-vulnerability-corpus",
   "repository": "getsentry/sentry",
   "wardenVersion": "0.48.0",

--- a/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
+++ b/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
@@ -1,0 +1,456 @@
+{
+  "runId": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001",
+  "status": "completed-with-two-unresolved-chunks",
+  "stableComparisonEligible": false,
+  "corpusId": "sentry-vulnerability-corpus",
+  "repository": "getsentry/sentry",
+  "wardenVersion": "0.48.0",
+  "wardenSourceCommit": "cac76087f80e3a99ae1313846b64b7078f25be25",
+  "skill": "security-review",
+  "model": "openrouter/google/gemini-3.8-flash",
+  "runtime": "pi",
+  "piVersion": "0.84.4",
+  "reasoningLevel": "high",
+  "targetMode": "all-corpus-files-by-sha",
+  "shardCount": 6,
+  "runOptions": {
+    "runtime": "pi",
+    "model": "openrouter/google/gemini-3.8-flash",
+    "effort": "high",
+    "auxiliaryModel": "openrouter/openai/gpt-5.6-luna",
+    "auxiliaryEffort": "high",
+    "traces": true,
+    "parallel": 4,
+    "repairParallel": 1,
+    "reportOn": "low",
+    "minConfidence": "low",
+    "maxTurns": 100
+  },
+  "providerRouting": {
+    "only": [
+      "Google"
+    ],
+    "allowFallbacks": false,
+    "requireParameters": true
+  },
+  "findingVerification": {
+    "enabled": true,
+    "source": "benchmark-config",
+    "notes": "The benchmark warden.toml explicitly enables finding verification. One oversized shard did not persist its final verifier usage."
+  },
+  "traceCapture": {
+    "enabled": true,
+    "coverage": "withheld",
+    "tracedShardCount": 6,
+    "tracedChunkCount": 156,
+    "notes": "All 156 final chunk records have local traces. Per-trace metadata and raw JSONL are withheld pending sensitive-data review."
+  },
+  "reportOn": "low",
+  "minConfidence": "low",
+  "summary": {
+    "corpusFindingCount": 86,
+    "targetFileCount": 79,
+    "filesAttempted": 79,
+    "filesAnalyzed": 78,
+    "skippedFileCount": 0,
+    "chunksTotal": 156,
+    "chunksAnalyzed": 154,
+    "chunksFailed": 2,
+    "findingsTotal": 25,
+    "findingsBySeverity": {
+      "low": 1,
+      "medium": 14,
+      "high": 10
+    },
+    "findingsByConfidence": {
+      "low": 0,
+      "medium": 2,
+      "high": 23
+    },
+    "analysisCostUSD": 77.140005525,
+    "auxiliaryCostUSD": 1.02737475,
+    "costUSD": 78.167380275,
+    "costIsLowerBound": true,
+    "inputTokens": 310996804,
+    "outputTokens": 3972753,
+    "cacheReadInputTokens": 248425592,
+    "cacheCreationInputTokens": 2229065,
+    "durationMs": 24587400,
+    "durationIsLowerBound": true
+  },
+  "timing": {
+    "contaminated": true,
+    "notes": "Total wall time includes the baseline and three serial exact-tuple repair passes. The oversized baseline shard did not persist its verifier tail, so duration and cost are lower bounds.",
+    "analysisChunkMs": {
+      "count": 156,
+      "total": 38162069,
+      "max": 1188988,
+      "p50": 214934,
+      "p75": 310832,
+      "p90": 432464,
+      "p95": 545782,
+      "source": "Selected baseline or exact failed-chunk repair record durationMs, including two terminal failed records"
+    }
+  },
+  "reliability": {
+    "firstPassSuccessRate": 0.9167,
+    "finalSuccessRate": 0.9872,
+    "repairPolicy": "Only originally failed file, chunk index, and chunk total tuples replace baseline records. Findings recentered onto originally successful tuples are excluded.",
+    "unresolved": [
+      {
+        "sha": "7f41cc502faa1088108e896565409be72d92bc38",
+        "file": "src/sentry/api/endpoints/organization_pipeline.py",
+        "index": 1,
+        "total": 1,
+        "error": "max_turns",
+        "totalAttempts": 4,
+        "corpusIds": [
+          "sentry-vuln-049"
+        ]
+      },
+      {
+        "sha": "9fc06de579fbbee810565304efcc982e5dea1d1a",
+        "file": "src/sentry/integrations/msteams/webhook.py",
+        "index": 3,
+        "total": 4,
+        "error": "max_turns",
+        "totalAttempts": 4,
+        "corpusIds": [
+          "sentry-vuln-012"
+        ]
+      }
+    ]
+  },
+  "scoring": {
+    "reviewer": "agent-semantic-match-pass",
+    "scoredAt": "2026-09-02",
+    "knownFindingCount": 86,
+    "knownFound": 19,
+    "knownMissed": 67,
+    "knownPartial": 0,
+    "knownFoundRate": 0.2209,
+    "matchedFindingCount": 18,
+    "notKnownFindingCount": 7,
+    "costPerKnownFoundUSD": 4.114072646052631,
+    "notes": "Final emitted findings only. Same-commit semantic matching is required. Same-file adjacent issues and unsupported merged locations do not count."
+  },
+  "scores": [
+    {
+      "findingId": "DHL-47E",
+      "matchedCorpusIds": [
+        "sentry-vuln-007"
+      ],
+      "verdict": "known-found",
+      "notes": "Same cross-tenant release-threshold empty-project scope bug."
+    },
+    {
+      "findingId": "WYM-TUG",
+      "matchedCorpusIds": [
+        "sentry-vuln-003"
+      ],
+      "verdict": "known-found",
+      "notes": "Same InternalEAFeaturesEndpoint admin authorization gap."
+    },
+    {
+      "findingId": "6MV-U8A",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "System-options GET secret redaction gap, not the allowlist tuple bug for this commit."
+    },
+    {
+      "findingId": "BNN-FKD",
+      "matchedCorpusIds": [
+        "sentry-vuln-001"
+      ],
+      "verdict": "known-found",
+      "notes": "Same accept-invite token-validation and member-deletion fallthrough."
+    },
+    {
+      "findingId": "LQK-HZ3",
+      "matchedCorpusIds": [
+        "sentry-vuln-056"
+      ],
+      "verdict": "known-found",
+      "notes": "Same OAuth application client-secret exposure to non-owners."
+    },
+    {
+      "findingId": "WQC-XWR",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "Timing-unsafe comparisons, not the Statsig timestamp-freshness bug."
+    },
+    {
+      "findingId": "HJ4-4LU",
+      "matchedCorpusIds": [
+        "sentry-vuln-047"
+      ],
+      "verdict": "known-found",
+      "notes": "Same workflow-backed rule cross-project authorization bug."
+    },
+    {
+      "findingId": "RA6-LUV",
+      "matchedCorpusIds": [
+        "sentry-vuln-069",
+        "sentry-vuln-071"
+      ],
+      "verdict": "known-found",
+      "notes": "Same untrusted Atlassian JWT algorithm selection represented by two corpus entries."
+    },
+    {
+      "findingId": "UVM-LTL",
+      "matchedCorpusIds": [
+        "sentry-vuln-073"
+      ],
+      "verdict": "known-found",
+      "notes": "Same UUIDv1 release webhook token weakness."
+    },
+    {
+      "findingId": "ZU6-NK9",
+      "matchedCorpusIds": [
+        "sentry-vuln-058"
+      ],
+      "verdict": "known-found",
+      "notes": "Same detector anomaly-data project-access bypass."
+    },
+    {
+      "findingId": "4W7-RNP",
+      "matchedCorpusIds": [
+        "sentry-vuln-078"
+      ],
+      "verdict": "known-found",
+      "notes": "Same legacy Jira TLS verification disablement."
+    },
+    {
+      "findingId": "4TK-C3H",
+      "matchedCorpusIds": [
+        "sentry-vuln-082"
+      ],
+      "verdict": "known-found",
+      "notes": "Same ECharts feature-flag tooltip HTML injection."
+    },
+    {
+      "findingId": "DZ3-X6F",
+      "matchedCorpusIds": [
+        "sentry-vuln-055"
+      ],
+      "verdict": "known-found",
+      "notes": "Same public organization Seer RPC project-access bypass."
+    },
+    {
+      "findingId": "5UT-RHE",
+      "matchedCorpusIds": [
+        "sentry-vuln-081"
+      ],
+      "verdict": "known-found",
+      "notes": "Same copy-as-cURL method and header-name command injection."
+    },
+    {
+      "findingId": "5ZM-B2S",
+      "matchedCorpusIds": [
+        "sentry-vuln-018"
+      ],
+      "verdict": "known-found",
+      "notes": "Same pinned-search ownership bypass."
+    },
+    {
+      "findingId": "VNV-Y8F",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "Accept-invite deletion bug represented at another corpus commit, not the commit-specific corpus summary."
+    },
+    {
+      "findingId": "BA6-PPW",
+      "matchedCorpusIds": [
+        "sentry-vuln-025"
+      ],
+      "verdict": "known-found",
+      "notes": "Same cross-team external actor modification gap."
+    },
+    {
+      "findingId": "4RY-AA7",
+      "matchedCorpusIds": [
+        "sentry-vuln-021"
+      ],
+      "verdict": "known-found",
+      "notes": "Same org:read destructive repository-token rotation."
+    },
+    {
+      "findingId": "CSK-KSE",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "Perforce rsh command execution, not the corpus credential-disclosure bug."
+    },
+    {
+      "findingId": "9XG-CRT",
+      "matchedCorpusIds": [
+        "sentry-vuln-014"
+      ],
+      "verdict": "known-found",
+      "notes": "Same cross-tenant Slack options-load team and member disclosure."
+    },
+    {
+      "findingId": "JRQ-8RS",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "Slack autofix membership gap, not either same-file corpus bug."
+    },
+    {
+      "findingId": "K5Y-KRM",
+      "matchedCorpusIds": [
+        "sentry-vuln-015"
+      ],
+      "verdict": "known-found",
+      "notes": "Same unauthenticated arbitrary GCP transfer-job trigger."
+    },
+    {
+      "findingId": "AUE-ZW2",
+      "matchedCorpusIds": [
+        "sentry-vuln-034"
+      ],
+      "verdict": "known-found",
+      "notes": "Same Seer autofix run-to-group ownership gap."
+    },
+    {
+      "findingId": "VLZ-WUQ",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "Workflow attachment authorization gap, not the corpus disconnect bug; the merged open-periods location is not semantically supported by the final finding."
+    },
+    {
+      "findingId": "UKU-FKG",
+      "matchedCorpusIds": [],
+      "verdict": "not-known",
+      "notes": "System-options GET secret redaction gap, not the cleartext option-value logging bug for this commit."
+    }
+  ],
+  "shards": [
+    {
+      "sha": "2d929588e20b931d2631ade31405f6ddbd34603a",
+      "wardenRunId": "92ea9272-6edb-4d35-810e-818a899d6444",
+      "corpusFindingCount": 7,
+      "targetFileCount": 6,
+      "filesAnalyzed": 6,
+      "chunksTotal": 6,
+      "chunksAnalyzed": 6,
+      "chunksFailed": 0,
+      "findingsTotal": 3,
+      "skippedFileCount": 0,
+      "durationMs": 565673,
+      "costUSD": 2.98837641,
+      "attemptCount": 1,
+      "traceCount": 6,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2d929588.jsonl",
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-2d929588e20b931d2631ade31405f6ddbd34603a.txt"
+    },
+    {
+      "sha": "6993246259d0193a6a6aac49aa3763959b1126df",
+      "wardenRunId": "6c2aa596-c6e6-48ab-9b5e-31f2332007ef",
+      "corpusFindingCount": 1,
+      "targetFileCount": 1,
+      "filesAnalyzed": 1,
+      "chunksTotal": 2,
+      "chunksAnalyzed": 2,
+      "chunksFailed": 0,
+      "findingsTotal": 0,
+      "skippedFileCount": 0,
+      "durationMs": 266047,
+      "costUSD": 0.599717175,
+      "attemptCount": 1,
+      "traceCount": 2,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-69932462.jsonl",
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-6993246259d0193a6a6aac49aa3763959b1126df.txt"
+    },
+    {
+      "sha": "788ba30f1aa42b00c02d64ed4b8b2515ff8ab8da",
+      "wardenRunId": "a2ce6b1b-2873-487b-b75f-8f91f9abba5c",
+      "corpusFindingCount": 1,
+      "targetFileCount": 1,
+      "filesAnalyzed": 1,
+      "chunksTotal": 2,
+      "chunksAnalyzed": 2,
+      "chunksFailed": 0,
+      "findingsTotal": 1,
+      "skippedFileCount": 0,
+      "durationMs": 494277,
+      "costUSD": 0.850085695,
+      "attemptCount": 1,
+      "traceCount": 2,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-788ba30f.jsonl",
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-788ba30f1aa42b00c02d64ed4b8b2515ff8ab8da.txt"
+    },
+    {
+      "sha": "7f41cc502faa1088108e896565409be72d92bc38",
+      "wardenRunId": "20d968d7-2455-4231-8654-f7d6f70d6c44",
+      "corpusFindingCount": 43,
+      "targetFileCount": 38,
+      "filesAnalyzed": 37,
+      "chunksTotal": 80,
+      "chunksAnalyzed": 79,
+      "chunksFailed": 1,
+      "findingsTotal": 10,
+      "skippedFileCount": 0,
+      "durationMs": 8011819,
+      "costUSD": 28.507293885,
+      "attemptCount": 4,
+      "traceCount": 80,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-7f41cc50.jsonl",
+      "repairJsonl": [
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-7f41cc50-repair-1.jsonl",
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-7f41cc50-repair-2.jsonl",
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-7f41cc50-repair-3.jsonl"
+      ],
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-7f41cc502faa1088108e896565409be72d92bc38.txt"
+    },
+    {
+      "sha": "9fc06de579fbbee810565304efcc982e5dea1d1a",
+      "wardenRunId": "21c8962a-3c38-43a1-b729-94dc6209cd58",
+      "corpusFindingCount": 32,
+      "targetFileCount": 31,
+      "filesAnalyzed": 31,
+      "chunksTotal": 64,
+      "chunksAnalyzed": 63,
+      "chunksFailed": 1,
+      "findingsTotal": 10,
+      "skippedFileCount": 0,
+      "durationMs": 14334281,
+      "costUSD": 43.53245788,
+      "attemptCount": 4,
+      "traceCount": 64,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-9fc06de5.jsonl",
+      "repairJsonl": [
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-9fc06de5-repair-1.jsonl",
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-9fc06de5-repair-2.jsonl",
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-9fc06de5-repair-3.jsonl"
+      ],
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-9fc06de579fbbee810565304efcc982e5dea1d1a.txt"
+    },
+    {
+      "sha": "fbecd17d210c2eacfad4bf17872be62320b8a110",
+      "wardenRunId": "313ccd24-923e-4c80-a0bc-53ddb1655340",
+      "corpusFindingCount": 2,
+      "targetFileCount": 2,
+      "filesAnalyzed": 2,
+      "chunksTotal": 2,
+      "chunksAnalyzed": 2,
+      "chunksFailed": 0,
+      "findingsTotal": 1,
+      "skippedFileCount": 0,
+      "durationMs": 915303,
+      "costUSD": 1.68944923,
+      "attemptCount": 2,
+      "traceCount": 2,
+      "rawJsonl": "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-fbecd17d.jsonl",
+      "repairJsonl": [
+        "sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-fbecd17d-repair-1.jsonl"
+      ],
+      "rawArtifactStatus": "withheld-pending-sensitive-review",
+      "targetList": "targets-fbecd17d210c2eacfad4bf17872be62320b8a110.txt"
+    }
+  ],
+  "notes": "Incomplete Warden 0.48.0 benchmark using Pi with openrouter/google/gemini-3.8-flash at high effort and openrouter/openai/gpt-5.6-luna at high effort for auxiliary calls. Google-only routing disabled provider fallbacks. The initial run completed 143 of 156 chunks. Three serial repair passes recovered 11 exact failed tuples; two reached maxTurns in all four attempts and remain failed. Further retries were stopped to avoid best-of-N cherry-picking. The 622 MB 9fc06de5 artifact exceeded V8's string limit during finalization. Its streamed chunks survived, but final verifier usage and latency were not persisted, so cost and wall time are lower bounds. Raw JSONL artifacts are withheld pending sensitive-data review."
+}

--- a/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
+++ b/packages/docs/src/data/benchmarking/results/sentry-security-review-pi-openrouter-gemini-3-8-flash-high-corpus-2026-09-02-001.json
@@ -5,7 +5,7 @@
   "comparison": {
     "include": true,
     "label": "154/156 chunks",
-    "caveat": "The two unfinished chunks contain one known entry each, limiting the score's possible increase to 21/86; cost and duration are lower bounds because one shard omitted final verifier accounting."
+    "caveat": "The two unfinished chunks contain one known entry each, limiting the score's possible increase to 21/86. Recorded cost is a lower bound."
   },
   "corpusId": "sentry-vulnerability-corpus",
   "repository": "getsentry/sentry",


### PR DESCRIPTION
Publish the scored Gemini 3.8 Flash high run against the 86-vulnerability Sentry corpus and include it in the standard score and cost tables.

Gemini uses Pi through OpenRouter at high effort. It found 19 known entries and emitted 25 findings. Eighteen findings matched 19 corpus entries, covering authorization boundaries, OAuth and JWT flaws, weak webhook and transport controls, and client-side injection.

The run cost $78.17, or $4.11 per known entry, and recorded 311 million input tokens. Grok 4.6 high found six more entries for nearly the same cost. DeepSeek V4 Flash found one fewer for $10.11.

The run completed 154 of 156 chunks. The two remaining chunks cover one corpus entry each, so a complete run could score at most 21/86. Recorded cost is a lower bound.

Complete runs still enter the matrix automatically. This adds a validated opt-in path for publishing partial rows with visible coverage and a concise caveat.

The committed result contains sanitized aggregate metrics, semantic score mappings, and shard totals. Raw traces and per-trace metadata remain withheld pending sensitive-data review.